### PR TITLE
a few bugfixes

### DIFF
--- a/source/views/view_data_inspector.cpp
+++ b/source/views/view_data_inspector.cpp
@@ -92,7 +92,7 @@ namespace hex {
                 auto endianAdjustedTime = hex::changeEndianess(this->m_previewData.time, this->m_endianess);
                 std::tm * ptm = localtime(&endianAdjustedTime);
                 char buffer[64];
-                if (std::strftime(buffer, 64, "%a, %d.%m.%Y %H:%M:%S", ptm) != 0)
+                if (ptm != nullptr && std::strftime(buffer, 64, "%a, %d.%m.%Y %H:%M:%S", ptm) != 0)
                     this->m_cachedData.emplace_back("time_t", buffer);
                 else
                     this->m_cachedData.emplace_back("time_t", "Invalid");

--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -137,7 +137,7 @@ namespace hex {
 
         size_t copySize = (end - start) + 1;
 
-        std::string buffer;
+        std::string buffer(copySize, 0x00);
         buffer.reserve(copySize + 1);
         this->m_dataProvider->read(start, buffer.data(), copySize);
 


### PR DESCRIPTION
The `time_t` decoding fix only actually affected the windows codepaths. The copy hex bytes bug manifested for me by sometimes copying too many bytes because the vector did not place its null terminator correctly.