### PR TITLE
cmake: add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,3 +97,5 @@ endif (WIN32)
 if (UNIX)
     target_link_libraries(ImHex libglfw.so libmagic.so libcrypto.so libdl.so libcapstone.so ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
 endif (UNIX)
+
+install(TARGETS ImHex DESTINATION bin)


### PR DESCRIPTION
Ref #31.

This PR adds an install target so that `make install` works.