### PR TITLE
Fix segmentation fault when searching for an empty hex string

### DIFF
--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -775,7 +775,8 @@ R"(
             string = "0" + string;
 
         std::vector<u8> hex;
-        hex.reserve(string.size() / 2);
+        hex.reserve(string.size() / 2 + 1);
+        hex[hex.size()-1] = '\0';
 
         for (u32 i = 0; i < string.size(); i += 2) {
             char byte[3] = { string[i], string[i + 1], 0 };


### PR DESCRIPTION
Close #56.

This PR fixes the crash caused by a segfault when searching for an empty hex string. The crash gets fixed by appending a null byte to the bytes to search for. When searching for an empty hex string, the currently highlighted sequences get deselected, similar to how string searching behaves.