### PR TITLE
add glm to arch deps

### DIFF
--- a/dist/get_deps_archlinux.sh
+++ b/dist/get_deps_archlinux.sh
@@ -8,4 +8,5 @@ pacman -S \
   llvm \
   llvm-libs \
   nlohmann-json \
+  glm \
   python3


### PR DESCRIPTION
After running `sh get_deps_archlinux.sh` then `cmake ..` in the build folder, got `None of the required 'glm' found`. This fixes that