### PR TITLE
dist/fedora: Include file magic headers

### DIFF
--- a/dist/get_deps_fedora.sh
+++ b/dist/get_deps_fedora.sh
@@ -4,6 +4,7 @@ dnf install \
   cmake \
   gcc-c++ \
   capstone-devel \
+  file-devel \
   glfw-devel \
   glm-devel \
   json-devel \


### PR DESCRIPTION
Due to differences in package names between Deb based systems, Arch
Linux, and RPM based systems the package containing the development
headers for file were missing from the Fedora dependencies script.

This includes the package `file-devel`, which is the package which
resolves the issue.

In Fedora, one can identify the package providing a specific file using
the verb "whatprovides" with the command dnf, e.g.:

    [~]$ dnf whatprovides /usr/include/magic.h
    Last metadata expiration check: 4 days, 0:23:05 ago on Fri 04 Dec 2020 09:06:53 AM PST.
    file-devel-5.39-3.fc33.i686 : Libraries and header files for file development
    Repo        : fedora
    Matched from:
    Filename    : /usr/include/magic.h

    file-devel-5.39-3.fc33.x86_64 : Libraries and header files for file development
    Repo        : @System
    Matched from:
    Filename    : /usr/include/magic.h

    file-devel-5.39-3.fc33.x86_64 : Libraries and header files for file development
    Repo        : fedora
    Matched from:
    Filename    : /usr/include/magic.h

If one is unsure of the specific path, globbing may be used (but must be
quoted):

    dnf whatprovides "*/magic.h"

Resolves #48