### PR TITLE
Add support for macOS and cxxabi demangler to decouple from LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ pkg_search_module(GLFW REQUIRED glfw3)
 pkg_search_module(GLM REQUIRED glm)
 pkg_search_module(CRYPTO REQUIRED libcrypto)
 pkg_search_module(CAPSTONE REQUIRED capstone)
+if (APPLE)
+    pkg_search_module(OPENSSL REQUIRED OpenSSL)
+endif (APPLE)
+
 if (NOT LLVM_DEMANGLE)
     include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(abi::__cxa_demangle "cxxabi.h" HAVE_CXXABI)
@@ -23,6 +27,14 @@ if (LLVM_DEMANGLE OR NOT HAVE_CXXABI)
 endif (LLVM_DEMANGLE OR NOT HAVE_CXXABI)
 find_package(nlohmann_json REQUIRED)
 find_package(Python COMPONENTS Interpreter Development)
+if (APPLE)
+    find_package(Python3 REQUIRED)
+    find_package(glfw3 REQUIRED)
+    find_package(OpenSSL REQUIRED)
+    find_library(CAPSTONE_LIBRARY capstone)
+    find_library(MAGIC_LIBRARY magic)
+endif (APPLE)
+
 
 if(Python_VERSION LESS 3)
     message(STATUS ${PYTHON_VERSION_MAJOR_MINOR})
@@ -37,6 +49,10 @@ if (LLVM_FOUND)
 endif (LLVM_FOUND)
 
 include_directories(include ${GLFW_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS} libs/ImGui/include libs/glad/include ${Python_INCLUDE_DIRS})
+if (APPLE)
+    include_directories(include ${OPENSSL_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS})
+endif (APPLE)
+
 
 # Get Python major and minor
 string(REPLACE "." ";" PYTHON_VERSION_MAJOR_MINOR ${Python_VERSION})
@@ -54,6 +70,11 @@ SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE")
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
 add_definitions(-DLLVM_DEMANGLE=${LLVM_DEMANGLE})
+if (APPLE)
+    set(VAR "Python_LINK_OPTIONS" CACHE STRING "LINKER:-rpath,/Library/Developer/CommandLineTools/Library/Frameworks")
+    add_link_options(${Python_LINK_OPTIONS})
+endif (APPLE)
+
 add_executable(ImHex
         source/main.cpp
         source/window.cpp
@@ -104,12 +125,16 @@ if (LLVM_FOUND)
     target_link_directories(ImHex PRIVATE ${LLVM_LIBRARY_DIR})
 endif (LLVM_FOUND)
 
+if (APPLE)
+    target_link_libraries(ImHex PRIVATE ${GLFW_LIBRARIES} ${MAGIC_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${CAPSTONE_LIBRARY} ${Python_LIBRARIES})
+endif (APPLE)
+
 if (WIN32)
     target_link_libraries(ImHex libglfw3.a libgcc.a libstdc++.a libmagic.a libgnurx.a libtre.a libintl.a libiconv.a shlwapi.lib libcrypto.a libwinpthread.a libcapstone.a ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
 endif (WIN32)
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
     target_link_libraries(ImHex libglfw.so libmagic.so libcrypto.so libdl.so libcapstone.so ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
 
 install(TARGETS ImHex DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,15 @@ pkg_search_module(GLFW REQUIRED glfw3)
 pkg_search_module(GLM REQUIRED glm)
 pkg_search_module(CRYPTO REQUIRED libcrypto)
 pkg_search_module(CAPSTONE REQUIRED capstone)
+if (NOT LLVM_DEMANGLE)
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(abi::__cxa_demangle "cxxabi.h" HAVE_CXXABI)
+endif (NOT LLVM_DEMANGLE)
+
 find_package(OpenGL REQUIRED)
-find_package(LLVM REQUIRED CONFIG)
+if (LLVM_DEMANGLE OR NOT HAVE_CXXABI)
+    find_package(LLVM REQUIRED CONFIG)
+endif (LLVM_DEMANGLE OR NOT HAVE_CXXABI)
 find_package(nlohmann_json REQUIRED)
 find_package(Python COMPONENTS Interpreter Development)
 
@@ -22,10 +29,14 @@ if(Python_VERSION LESS 3)
     message(FATAL_ERROR "No valid version of Python 3 was found.")
 endif()
 
-llvm_map_components_to_libnames(_llvm_libs demangle)
-llvm_expand_dependencies(llvm_libs ${_llvm_libs})
 
-include_directories(include ${GLFW_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} libs/ImGui/include libs/glad/include ${Python_INCLUDE_DIRS})
+if (LLVM_FOUND)
+    llvm_map_components_to_libnames(_llvm_libs demangle)
+    llvm_expand_dependencies(llvm_libs ${_llvm_libs})
+    include_directories(include ${LLVM_INCLUDE_DIRS})
+endif (LLVM_FOUND)
+
+include_directories(include ${GLFW_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS} libs/ImGui/include libs/glad/include ${Python_INCLUDE_DIRS})
 
 # Get Python major and minor
 string(REPLACE "." ";" PYTHON_VERSION_MAJOR_MINOR ${Python_VERSION})
@@ -42,6 +53,7 @@ endif (WIN32)
 SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE")
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
+add_definitions(-DLLVM_DEMANGLE=${LLVM_DEMANGLE})
 add_executable(ImHex
         source/main.cpp
         source/window.cpp
@@ -88,7 +100,9 @@ add_executable(ImHex
         resource.rc
         )
 
-target_link_directories(ImHex PRIVATE ${LLVM_LIBRARY_DIR})
+if (LLVM_FOUND)
+    target_link_directories(ImHex PRIVATE ${LLVM_LIBRARY_DIR})
+endif (LLVM_FOUND)
 
 if (WIN32)
     target_link_libraries(ImHex libglfw3.a libgcc.a libstdc++.a libmagic.a libgnurx.a libtre.a libintl.a libiconv.a shlwapi.lib libcrypto.a libwinpthread.a libcapstone.a ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You need a C++20 compatible compiler such as GCC 10.2.0 to compile ImHex. Moreov
 - nlohmann json
 - Python3
 
-Find all in one dependency installation scripts for Arch Linux, Fedora, Debian/Ubuntu and/or MSYS2 in [dist](dist).
+Find all in one dependency installation scripts for Arch Linux, Fedora, Debian/Ubuntu, Homebrew and/or MSYS2 in [dist](dist).
 
 After all the dependencies are installed, run the following commands to build ImHex:
 
@@ -123,6 +123,19 @@ On both Windows and Linux:
 - Place your magic databases in the `magic` folder next to your built executable
 - Place your patterns in the `pattern` folder next to your built executable
 - Place your include pattern files in the `include` folder next to your built executable
+
+On macOS:
+
+- Install Homebrew (https://brew.sh)
+- Run `./dist/get_deps_homebrew.sh`
+- Finally run:
+
+```sh
+mkdir build
+cd build
+CXX=g++-10 PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig cmake ..
+make -j
+```
 
 By default the cxxabi demangler is used when available.
 To use the LLVM demangler anyway add `-DLLVM_DEMANGLE=1` as first `cmake` argument.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ On both Windows and Linux:
 - Place your patterns in the `pattern` folder next to your built executable
 - Place your include pattern files in the `include` folder next to your built executable
 
+By default the cxxabi demangler is used when available.
+To use the LLVM demangler anyway add `-DLLVM_DEMANGLE=1` as first `cmake` argument.
+
 ## Credits
 
 - Thanks a lot to ocornut for their amazing [Dear ImGui](https://github.com/ocornut/imgui) which is used for building the entire interface

--- a/dist/get_deps_homebrew.sh
+++ b/dist/get_deps_homebrew.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+brew install \
+  cmake \
+  pkg-config \
+  gcc \
+  glfw \
+  file-formula \
+  openssl \
+  capstone \
+  nlohmann-json \
+  glm \
+  python3

--- a/include/helpers/project_file_handler.hpp
+++ b/include/helpers/project_file_handler.hpp
@@ -7,6 +7,13 @@
 #include "patches.hpp"
 #include "utils.hpp"
 
+#ifdef __APPLE__
+#define off64_t off_t
+#define fopen64 fopen
+#define fseeko64 fseek
+#define ftello64 ftell
+#endif
+
 namespace hex {
 
     class ProjectFile {

--- a/include/helpers/utils.hpp
+++ b/include/helpers/utils.hpp
@@ -61,6 +61,7 @@ namespace hex {
 
     std::string toByteString(u64 bytes);
     std::string makePrintable(char c);
+    std::string demangle(const std::string &mangled_name);
 
     template<typename T>
     struct always_false : std::false_type {};

--- a/source/helpers/utils.cpp
+++ b/source/helpers/utils.cpp
@@ -3,6 +3,13 @@
 #include <cstdio>
 #include <codecvt>
 #include <locale>
+#include <iostream>
+
+#if !(LLVM_DEMANGLE + 0) && (defined(__clang__) || defined(__GNUG__))
+#include <cxxabi.h>
+#else
+#include <llvm/Demangle/Demangle.h>
+#endif
 
 namespace hex {
 
@@ -89,5 +96,24 @@ namespace hex {
 
         return result;
     }
+
+#if !(LLVM_DEMANGLE + 0) && (defined(__clang__) || defined(__GNUG__))
+    std::string demangle(const std::string &mangled_name) {
+        int status = 0;
+        int skip_underscore = mangled_name.find("__") == 0;
+        char *realname = abi::__cxa_demangle(mangled_name.c_str() + skip_underscore,
+                                             0, 0, &status);
+        std::string result{mangled_name};
+        if (status == 0 && realname) {
+            result = realname;
+            std::free(realname);
+        }
+        return result;
+    }
+#else
+    std::string demangle(const std::string &mangled_name) {
+        return llvm::demangle(mangled_name);
+    }
+#endif
 
 }

--- a/source/lang/evaluator.cpp
+++ b/source/lang/evaluator.cpp
@@ -189,7 +189,7 @@ namespace hex::lang {
             }
             else {
                 members.push_back(pattern);
-                unionSize = std::max(memberSize, unionSize);
+                unionSize = std::max(memberSize, (u64)unionSize);
             }
         }
 

--- a/source/providers/file_provider.cpp
+++ b/source/providers/file_provider.cpp
@@ -10,13 +10,6 @@
 #include "helpers/project_file_handler.hpp"
 
 
-#ifdef __APPLE__
-    #define off64_t off_t
-    #define fopen64 fopen
-    #define fseeko64 fseek
-    #define ftello64 ftell
-#endif
-
 namespace hex::prv {
 
     FileProvider::FileProvider(std::string_view path) : Provider(), m_path(path) {

--- a/source/views/view_strings.cpp
+++ b/source/views/view_strings.cpp
@@ -5,8 +5,6 @@
 
 #include <cstring>
 
-#include <llvm/Demangle/Demangle.h>
-
 using namespace std::literals::string_literals;
 
 namespace hex {
@@ -37,7 +35,7 @@ namespace hex {
             }
             ImGui::Separator();
             if (ImGui::MenuItem("Demangle")) {
-                this->m_demangledName = llvm::demangle(this->m_selectedString);
+                this->m_demangledName = demangle(this->m_selectedString);
                 if (!this->m_demangledName.empty())
                     View::doLater([]{ ImGui::OpenPopup("Demangled Name"); });
             }

--- a/source/views/view_tools.cpp
+++ b/source/views/view_tools.cpp
@@ -7,8 +7,6 @@
 #include "providers/provider.hpp"
 #include "helpers/utils.hpp"
 
-#include <llvm/Demangle/Demangle.h>
-
 namespace hex {
 
     ViewTools::ViewTools(hex::prv::Provider* &provider) : View("Tools"), m_dataProvider(provider) {
@@ -76,7 +74,7 @@ namespace hex {
     void ViewTools::drawDemangler() {
         if (ImGui::CollapsingHeader("Itanium/MSVC demangler")) {
             if (ImGui::InputText("Mangled name", this->m_mangledBuffer, 0xF'FFFF)) {
-                this->m_demangledName = llvm::demangle(this->m_mangledBuffer);
+                this->m_demangledName = demangle(this->m_mangledBuffer);
             }
 
             ImGui::InputText("Demangled name", this->m_demangledName.data(), this->m_demangledName.size(), ImGuiInputTextFlags_ReadOnly);


### PR DESCRIPTION
First commit:
On macOS ImHex must be build with g++-10 which clashes with the homebrew llvm build that uses libc++ intead of libstdc++.
I added a cxxabi demangler so LLVM is no longer needed to demangle but LLVM demangling can still be used by `cmake -DLLVM_DEMANGLE=1` anyway if needed.

Second commit:
The remaining compiler fixes for macOS, added cmake directives to find the necessary Homebrew libraries and set the rpath for the dynamic linking of the Python libraries.

I have built and run the program successfully on macOS 10.14, macOS 10.15 and Ubuntu 20.04.1.