### PR TITLE
Support non standard LLVM library names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,11 @@ if(Python_VERSION LESS 3)
     message(FATAL_ERROR "No valid version of Python 3 was found.")
 endif()
 
-llvm_map_components_to_libnames(_llvm_libs demangle)
-llvm_expand_dependencies(llvm_libs ${_llvm_libs})
+llvm_map_components_to_libnames(_llvm_demangle_lib demangle)
+llvm_expand_dependencies(_llvm_demangle_lib ${_llvm_demangle_lib})
+
+# NOTE: if the demangle library cannot be found try to fallback to libLLVM (that is required on openSUSE and Gentoo)
+find_library(llvm_demangle_lib NAMES ${_llvm_demangle_lib} LLVM PATHS ${LLVM_LIBRARY_DIR})
 
 include_directories(include ${GLFW_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} libs/ImGui/include libs/glad/include ${Python_INCLUDE_DIRS})
 
@@ -91,11 +94,11 @@ add_executable(ImHex
 target_link_directories(ImHex PRIVATE ${LLVM_LIBRARY_DIR})
 
 if (WIN32)
-    target_link_libraries(ImHex libglfw3.a libgcc.a libstdc++.a libmagic.a libgnurx.a libtre.a libintl.a libiconv.a shlwapi.lib libcrypto.a libwinpthread.a libcapstone.a ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
+    target_link_libraries(ImHex libglfw3.a libgcc.a libstdc++.a libmagic.a libgnurx.a libtre.a libintl.a libiconv.a shlwapi.lib libcrypto.a libwinpthread.a libcapstone.a ${llvm_demangle_lib} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
 endif (WIN32)
 
 if (UNIX)
-    target_link_libraries(ImHex libglfw.so libmagic.so libcrypto.so libdl.so libcapstone.so ${llvm_libs} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
+    target_link_libraries(ImHex libglfw.so libmagic.so libcrypto.so libdl.so libcapstone.so ${llvm_demangle_lib} ${Python_LIBRARIES} nlohmann_json::nlohmann_json)
 endif (UNIX)
 
 install(TARGETS ImHex DESTINATION bin)


### PR DESCRIPTION
This fix openSUSE and Gentoo issue mentioned in https://github.com/WerWolv/ImHex/issues/37#issuecomment-739503138.

(tested on openSUSE tumbleweed via Docker)

I also took the liberty of renaming llvm_lib to llvm_demangle_lib to be more specific in the ``CMakeLists.txt``.