### PR TITLE
Basic macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ find_package(Python COMPONENTS Interpreter Development)
 
 add_subdirectory(external/llvm/Demangle)
 
+pkg_search_module(MAGIC libmagic)
+if(NOT MAGIC_FOUND)
+    # Some linux distros don't ship pkgconfig files for libmagic. Try to find it in another way
+    find_library(MAGIC magic REQUIRED)
+endif()
+
 if(Python_VERSION LESS 3)
     message(STATUS ${PYTHON_VERSION_MAJOR_MINOR})
     message(FATAL_ERROR "No valid version of Python 3 was found.")

--- a/include/helpers/utils.hpp
+++ b/include/helpers/utils.hpp
@@ -25,6 +25,24 @@
     #define ftello64 ftell
 #endif
 
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION <= 12000
+#if __has_include(<concepts>)
+// Make sure we break when derived_from is implemented in libc++. Then we can fix a compatibility version above
+#include <concepts>
+#endif
+// libcpp 12 still doesn't have derived_from implemented
+// [concept.derived] (patch from https://reviews.llvm.org/D74292 )
+namespace hex {
+template<class _Dp, class _Bp>
+    concept derived_from =
+      __is_base_of(_Bp, _Dp) && __is_convertible_to(const volatile _Dp*, const volatile _Bp*);
+}
+#else
+#include <concepts>
+namespace hex {
+    using std::derived_from;
+}
+#endif
 
 namespace hex {
 

--- a/include/helpers/utils.hpp
+++ b/include/helpers/utils.hpp
@@ -18,6 +18,14 @@
 
 #include "lang/token.hpp"
 
+#ifdef __APPLE__
+    #define off64_t off_t
+    #define fopen64 fopen
+    #define fseeko64 fseek
+    #define ftello64 ftell
+#endif
+
+
 namespace hex {
 
     template<typename ... Args>

--- a/include/providers/provider.hpp
+++ b/include/providers/provider.hpp
@@ -3,7 +3,6 @@
 #include <hex.hpp>
 
 #include <cmath>
-#include <concepts>
 #include <map>
 #include <optional>
 #include <string>

--- a/include/views/view_pattern.hpp
+++ b/include/views/view_pattern.hpp
@@ -7,7 +7,6 @@
 
 #include "providers/provider.hpp"
 
-#include <concepts>
 #include <cstring>
 #include <filesystem>
 

--- a/include/window.hpp
+++ b/include/window.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <concepts>
 #include <filesystem>
 #include <memory>
 #include <vector>
 
+#include "helpers/utils.hpp"
 #include "views/view.hpp"
 
 struct GLFWwindow;
@@ -19,7 +19,7 @@ namespace hex {
 
         void loop();
 
-        template<std::derived_from<View> T, typename ... Args>
+        template<derived_from<View> T, typename ... Args>
         T* addView(Args&& ... args) {
             this->m_views.emplace_back(new T(std::forward<Args>(args)...));
 

--- a/source/helpers/patches.cpp
+++ b/source/helpers/patches.cpp
@@ -1,6 +1,5 @@
 #include "helpers/patches.hpp"
 
-#include <concepts>
 #include <cstring>
 #include <string_view>
 #include <type_traits>

--- a/source/lang/evaluator.cpp
+++ b/source/lang/evaluator.cpp
@@ -128,7 +128,7 @@ namespace hex::lang {
             const auto typeDeclNode = static_cast<ASTNodeTypeDecl*>(this->m_types[member->getCustomVariableTypeName()]);
 
             PatternData *pattern = nullptr;
-            u64 memberSize = 0;
+            size_t memberSize = 0;
 
             if (member->getVariableType() == Token::TypeToken::Type::Signed8Bit && member->getArraySize() > 1) {
                 std::tie(pattern, memberSize) = this->createStringPattern(member, memberOffset);

--- a/source/lang/lexer.cpp
+++ b/source/lang/lexer.cpp
@@ -1,5 +1,6 @@
 #include "lang/lexer.hpp"
 
+#include <optional>
 #include <vector>
 #include <functional>
 

--- a/source/providers/file_provider.cpp
+++ b/source/providers/file_provider.cpp
@@ -9,14 +9,6 @@
 #include "helpers/utils.hpp"
 #include "helpers/project_file_handler.hpp"
 
-
-#ifdef __APPLE__
-    #define off64_t off_t
-    #define fopen64 fopen
-    #define fseeko64 fseek
-    #define ftello64 ftell
-#endif
-
 namespace hex::prv {
 
     FileProvider::FileProvider(std::string_view path) : Provider(), m_path(path) {

--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -245,7 +245,7 @@ namespace hex {
         lang::PatternData::resetPalette();
     }
 
-    template<std::derived_from<lang::ASTNode> T>
+    template<derived_from<lang::ASTNode> T>
     static std::vector<T*> findNodes(const lang::ASTNode::Type type, const std::vector<lang::ASTNode*> &nodes) {
         std::vector<T*> result;
 

--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -300,7 +300,7 @@ namespace hex {
             return;
         }
 
-        hex::ScopeExit deleteAst([&ast]{ for(auto &node : ast) delete node; });
+        hex::ScopeExit deleteAst([&ast=ast]{ for(auto &node : ast) delete node; });
 
         hex::lang::Validator validator;
         auto validatorResult = validator.validate(ast);


### PR DESCRIPTION
Hi all,

I've made ImHex compile on macOS and have a few commits to push if you'll accept them. All of the commits fix a single issue.
Some things are fixes to everything (making some stuff explicit instead of implicitly finding libraries). Other things are portability issues which aren't necessarily macOS-only.

My script to build is... sketchy, so I'm not pushing for any GitHub action to automatically build on macOS or anything, as I don't think we have an llvm release we can use.

Script:
```
#!/bin/sh

HOMEBREW_PREFIX="FILL YOURS IN, IT'S USUALLY /usr/local"

# assumes openssl@1.1 is installed via homebrew
export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/openssl@1.1/lib/pkgconfig":"$HOMEBREW_PREFIX/lib/pkgconfig"
export FREETYPE_DIR="$HOMEBREW_PREFIX"
# I build mine (llvm+clang+libcxx)... It requires a patch to libcxx
export LLVM_DIR=~/dev/llvm/install
export CC=$LLVM_DIR/bin/clang
export CXX=$LLVM_DIR/bin/clang++
export CXXFLAGS="-stdlib=libc++ -nostdinc++ -I$LLVM_DIR/include/c++/v1"

# last rpath is so we can link to the (system) python framework
export LDFLAGS="-L$LLVM_DIR/lib -Wl,-rpath,$LLVM_DIR/lib -Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks"

set -xe
cmake -H. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
ninja -C build
```

Then the program is available as `./build/ImHex` (not a Mac app bundle)

Patch for libcxx (needed as of yesterday):
```
diff --git a/libcxx/include/concepts b/libcxx/include/concepts
index 047e2c290f4e..b8178131f6a0 100644
--- a/libcxx/include/concepts
+++ b/libcxx/include/concepts
@@ -157,6 +157,12 @@ concept __same_as_impl = _VSTD::_IsSame<_Tp, _Up>::value;
 template<class _Tp, class _Up>
 concept same_as = __same_as_impl<_Tp, _Up> && __same_as_impl<_Up, _Tp>;
 
+// [concept.derived] (patch from https://reviews.llvm.org/D74292 )
+
+template<class _Dp, class _Bp>
+concept derived_from =
+  __is_base_of(_Bp, _Dp) && __is_convertible_to(const volatile _Dp*, const volatile _Bp*);
+
 #endif //_LIBCPP_STD_VER > 17 && defined(__cpp_concepts) && __cpp_concepts >= 201811L
 
 _LIBCPP_END_NAMESPACE_STD
```