### PR TITLE
Nightly support for Windows and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,8 @@ jobs:
         name: Windows EXE
         path: |
           build/*.exe
-          C:/msys64/bin/libpython3*.dll
-          C:/msys64/bin/libwinpthread-?.dll
+          D:/a/_temp/msys/msys64/mingw64/bin/libpython3*.dll
+          D:/a/_temp/msys/msys64/mingw64/bin/libwinpthread-?.dll
 
 
   macos-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,6 @@ jobs:
           mingw-w64-${{ matrix.arch }}-dlfcn
           mingw-w64-${{ matrix.arch }}-freetype
 
-    - name: Debugging with tmate
-      uses: mxschmitt/action-tmate@v3.1
-      
     - name: ✋ Build
       run: |
         mkdir build
@@ -104,7 +101,7 @@ jobs:
         name: Windows EXE
         path: |
           build/*.exe
-          build/libpython3*.dll
+          build/python39.dll
           build/libwinpthread-?.dll
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,8 @@ jobs:
       run: |
         mkdir build
         cd build
+        ls -1 D:/a/_temp/msys/msys64/mingw64/bin/libpython3*.dll | xargs -L1 -I{} cp {} .
+        ls -1 D:/a/_temp/msys/msys64/mingw64/bin/libwinpthread-?.dll | xargs -L1 -I{} cp {} .
         cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         mingw32-make -j 4
     - name: 📦 Uploading artifact
@@ -99,8 +101,8 @@ jobs:
         name: Windows EXE
         path: |
           build/*.exe
-          D:/a/_temp/msys/msys64/mingw64/bin/libpython3*.dll
-          D:/a/_temp/msys/msys64/mingw64/bin/libwinpthread-?.dll
+          build/libpython3*.dll
+          build/libwinpthread-?.dll
 
 
   macos-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        ls -1 D:/a/_temp/msys/msys64/mingw64/bin/libpython3*.dll | xargs -L1 -I{} cp {} .
+        ls -1 D:/a/_temp/msys/msys64/mingw64/bin/python3?.dll | xargs -L1 -I{} cp {} .
         ls -1 D:/a/_temp/msys/msys64/mingw64/bin/libwinpthread-?.dll | xargs -L1 -I{} cp {} .
         cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         mingw32-make -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        ls -1 D:/a/_temp/msys/msys64/mingw64/bin/python3?.dll | xargs -L1 -I{} cp {} .
+        ls -1 C:/hostedtoolcache/windows/Python/3.9.1/x64/python39.dll | xargs -L1 -I{} cp {} .
         ls -1 D:/a/_temp/msys/msys64/mingw64/bin/libwinpthread-?.dll | xargs -L1 -I{} cp {} .
         cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         mingw32-make -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
         CC=gcc-10 CXX=g++-10 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         make -j 4
 
+    - name: 📦 Uploading artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Linux ELF
+        path: build/imhex
+
 
   win-manual:
     runs-on: windows-latest
@@ -103,7 +109,6 @@ jobs:
           build/*.exe
           build/python39.dll
           build/libwinpthread-?.dll
-
 
   macos-build:
     runs-on: macos-11.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,14 @@ jobs:
         cd build
         cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         mingw32-make -j 4
+    - name: 📦 Uploading artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Windows EXE
+        path: |
+          build/*.exe
+          /bin/libpython3.?.dll
+          /bin/libwinpthread-*.dll
 
 
   macos-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,8 @@ jobs:
         name: Windows EXE
         path: |
           build/*.exe
-          /bin/libpython3.?.dll
-          /bin/libwinpthread-*.dll
+          C:/msys64/bin/libpython3*.dll
+          C:/msys64/bin/libwinpthread-?.dll
 
 
   macos-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
           mingw-w64-${{ matrix.arch }}-dlfcn
           mingw-w64-${{ matrix.arch }}-freetype
 
+    - name: Debugging with tmate
+      uses: mxschmitt/action-tmate@v3.1
+      
     - name: ✋ Build
       run: |
         mkdir build


### PR DESCRIPTION
This PR adds nightlies for both Windows and Linux so all three supported platforms now also have nightlies