### PR TITLE
fix(lang): fixes occurrence index in findSequence built-in function

### DIFF
--- a/source/lang/builtin_functions.cpp
+++ b/source/lang/builtin_functions.cpp
@@ -24,7 +24,7 @@ namespace hex::lang {
             this->m_provider->read(offset, bytes.data(), bytes.size());
 
             if (bytes == sequence) {
-                if (LITERAL_COMPARE(occurrenceIndex, occurrenceIndex < occurrences)) {
+                if (LITERAL_COMPARE(occurrenceIndex, occurrences < occurrenceIndex)) {
                     occurrences++;
                     continue;
                 }


### PR DESCRIPTION
Hi! A little fix to make `findSequence` works as described :)