### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ set(Python_FIND_FRAMEWORK NEVER)
 
 # Find packages
 find_package(PkgConfig REQUIRED)
-pkg_search_module(CRYPTO REQUIRED libcrypto)
+if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+    find_library(CRYPTO crypto REQUIRED)
+else()
+    pkg_search_module(CRYPTO REQUIRED libcrypto)
+endif()
 pkg_search_module(CAPSTONE REQUIRED capstone)
 find_package(OpenGL REQUIRED)
 find_package(nlohmann_json REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,9 @@ set(Python_FIND_FRAMEWORK NEVER)
 
 # Find packages
 find_package(PkgConfig REQUIRED)
-if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+pkg_search_module(CRYPTO libcrypto)
+if(NOT CRYPTO_FOUND)
     find_library(CRYPTO crypto REQUIRED)
-else()
-    pkg_search_module(CRYPTO REQUIRED libcrypto)
 endif()
 pkg_search_module(CAPSTONE REQUIRED capstone)
 find_package(OpenGL REQUIRED)

--- a/plugins/libimhex/include/helpers/utils.hpp
+++ b/plugins/libimhex/include/helpers/utils.hpp
@@ -17,7 +17,7 @@
 #include <arpa/inet.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
     #define off64_t off_t
     #define fopen64 fopen
     #define fseeko64 fseek

--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -13,10 +13,6 @@
 #undef __STRICT_ANSI__
 #include <cstdio>
 
-#if defined(__FreeBSD__)
-    #define ftello64 ftell
-#endif
-
 namespace hex {
 
     ViewHexEditor::ViewHexEditor(std::vector<lang::PatternData*> &patternData)

--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -13,6 +13,10 @@
 #undef __STRICT_ANSI__
 #include <cstdio>
 
+#if defined(__FreeBSD__)
+    #define ftello64 ftell
+#endif
+
 namespace hex {
 
     ViewHexEditor::ViewHexEditor(std::vector<lang::PatternData*> &patternData)


### PR DESCRIPTION
Hello,

This pull request fixes build error on FreeBSD. The added lines are conditional and they do not affect build on other operating systems.

On FreeBSD, libcrypto is installed by default but pkg-config related files are not installed.
So it is necessary to use find_library instead of pkg_search_module in CMakeLists.txt.
