### PR TITLE
Macos app bundle compatibiltiy for older versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCREATE_BUNDLE=ON \
           -DCREATE_PACKAGE=ON \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
           ..
         make -j 4 package
 


### PR DESCRIPTION
This makes the app bundle compatible with macos 10.12+, currently the app bundle generated by the github workflow only supports macos11+.
 It compiles on my machine and the app bundle comes out okay. But unfortunately I can't test the github workflow because github decided to make macos11 pool private. :/ 