### PR TITLE
Fix various crashes on bad settings data.

### DIFF
--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -5,7 +5,7 @@ namespace hex::plugin::builtin {
     void registerSettings() {
 
         ContentRegistry::Settings::add("hex.builtin.setting.interface", "hex.builtin.setting.interface.color", 0, [](auto name, nlohmann::json &setting) {
-            static int selection = setting;
+            static int selection = setting.is_number() ? static_cast<int>(setting) : 0;
 
             const char* themes[] = {
                     "hex.builtin.setting.interface.color.dark"_lang,

--- a/plugins/libimhex/include/hex/api/content_registry.hpp
+++ b/plugins/libimhex/include/hex/api/content_registry.hpp
@@ -51,7 +51,7 @@ namespace hex {
             static std::vector<std::string> read(std::string_view unlocalizedCategory, std::string_view unlocalizedName, const std::vector<std::string>& defaultValue = { });
 
             static std::map<std::string, std::vector<Entry>>& getEntries();
-            static std::optional<nlohmann::json> getSetting(std::string_view unlocalizedCategory, std::string_view unlocalizedName);
+            static nlohmann::json getSetting(std::string_view unlocalizedCategory, std::string_view unlocalizedName);
             static nlohmann::json& getSettingsData();
         };
 

--- a/plugins/libimhex/source/api/content_registry.cpp
+++ b/plugins/libimhex/source/api/content_registry.cpp
@@ -119,7 +119,7 @@ namespace hex {
         return SharedData::settingsEntries;
     }
 
-    std::optional<nlohmann::json> ContentRegistry::Settings::getSetting(std::string_view unlocalizedCategory, std::string_view unlocalizedName) {
+    nlohmann::json ContentRegistry::Settings::getSetting(std::string_view unlocalizedCategory, std::string_view unlocalizedName) {
         auto &settings = getSettingsData();
 
         if (!settings.contains(unlocalizedCategory)) return { };

--- a/source/views/view_data_processor.cpp
+++ b/source/views/view_data_processor.cpp
@@ -20,8 +20,8 @@ namespace hex {
         View::subscribeEvent(Events::SettingsChanged, [](auto) {
             auto theme = ContentRegistry::Settings::getSetting("hex.builtin.setting.interface", "hex.builtin.setting.interface.color");
 
-            if (theme.has_value()) {
-                switch (static_cast<int>(theme.value())) {
+            if (theme.is_number()) {
+                switch (static_cast<int>(theme)) {
                     default:
                     case 0: /* Dark theme */
                         imnodes::StyleColorsDark();

--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -182,8 +182,8 @@ namespace hex {
             View::subscribeEvent(Events::SettingsChanged, [this](auto) {
                 auto theme = ContentRegistry::Settings::getSetting("hex.builtin.setting.interface", "hex.builtin.setting.interface.color");
 
-                if (theme.has_value()) {
-                    switch (static_cast<int>(theme.value())) {
+                if (theme.is_number()) {
+                    switch (static_cast<int>(theme)) {
                         default:
                         case 0: /* Dark theme */
                             this->m_textEditor.SetPalette(TextEditor::GetDarkPalette());

--- a/source/window.cpp
+++ b/source/window.cpp
@@ -61,8 +61,8 @@ namespace hex {
             {
                 auto theme = ContentRegistry::Settings::getSetting("hex.builtin.setting.interface", "hex.builtin.setting.interface.color");
 
-                if (theme.has_value()) {
-                    switch (static_cast<int>(theme.value())) {
+                if (theme.is_number()) {
+                    switch (static_cast<int>(theme)) {
                         default:
                         case 0: /* Dark theme */
                             ImGui::StyleColorsDark();
@@ -87,8 +87,8 @@ namespace hex {
             {
                 auto language = ContentRegistry::Settings::getSetting("hex.builtin.setting.interface", "hex.builtin.setting.interface.language");
 
-                if (language.has_value())
-                    LangEntry::loadLanguage(static_cast<std::string>(language.value()));
+                if (language.is_string())
+                    LangEntry::loadLanguage(static_cast<std::string>(language));
             }
 
             return { };


### PR DESCRIPTION
getSetting now returns a straight nlohmann::json instead of an optional.
If the data isn't present, it will return a json null.

All accesses to the settings will first check that the data has the
expected type.