### PR TITLE
Fix passing path through argv

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     ContentRegistry::Views::add<ViewYara>();
 
     if (argc > 1)
-        View::postEvent(Events::FileDropped, argv[1]);
+        View::postEvent(Events::FileDropped, const_cast<const char*>(argv[1]));
 
     window.loop();
 


### PR DESCRIPTION
This is necessary to fix the bad any_cast error that occurs otherwise.