### PR TITLE
Update deps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You need a C++20 compatible compiler such as GCC 10.2.0 to compile ImHex. Moreov
 
 - GLFW3
 - libmagic, libgnurx, libtre, libintl, libiconv
-- libcrypto
+- libmbedtls
 - capstone
 - Python3
 - freetype2


### PR DESCRIPTION
This change is to reflect the commit made in 785ecb8a7858edfb88747623b7437da0c02b5317, which changes openssl libcrypto to libmbedtls, making changes everywhere except in the README documentation.

This seems to be the root of the issue in #171 and #113 (see the very last comment made)

May also be nice to update the CMake files to make a more friendlier error message (not added here)