### PR TITLE
Fix: ignore non-existent magic directories

### DIFF
--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -105,6 +105,9 @@ namespace hex {
 
             std::error_code error;
             for (const auto &dir : hex::getPath(ImHexPath::Magic)) {
+                if (!std::filesystem::is_directory(dir))
+                    continue;
+
                 for (const auto &entry : std::filesystem::directory_iterator(dir, error)) {
                     if (entry.is_regular_file() && entry.path().extension() == ".mgc")
                         magicFiles += entry.path().string() + MAGIC_PATH_SEPARATOR;


### PR DESCRIPTION
Many of the default directories searched for mgc files do not actually exists into some systems (e.g. `/usr/share/ubuntu/imhex/`), which is setting error to non-zero error code so mgc files end up ignored.