### PR TITLE
Fix: patterns popup

### DIFF
--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -225,7 +225,7 @@ namespace hex {
     }
 
     void ViewPattern::drawContent() {
-        if (ImGui::Begin(View::toWindowName("hex.view.pattern.name").c_str(), &this->getWindowOpenState(), ImGuiWindowFlags_None | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+        if (ImGui::Begin(View::toWindowName("hex.view.pattern.name").c_str(), &this->getWindowOpenState(), ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
             auto provider = SharedData::currentProvider;
 
             if (provider != nullptr && provider->isAvailable()) {

--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -144,6 +144,7 @@ namespace hex {
             preprocessor.addDefaultPragmaHandlers();
 
 
+            m_possiblePatternFiles.clear();
             std::error_code errorCode;
             for (const auto &dir : hex::getPath(ImHexPath::Patterns)) {
                 for (auto &entry : std::filesystem::directory_iterator(dir, errorCode)) {

--- a/source/views/view_pattern.cpp
+++ b/source/views/view_pattern.cpp
@@ -144,7 +144,7 @@ namespace hex {
             preprocessor.addDefaultPragmaHandlers();
 
 
-            m_possiblePatternFiles.clear();
+            this->m_possiblePatternFiles.clear();
             std::error_code errorCode;
             for (const auto &dir : hex::getPath(ImHexPath::Patterns)) {
                 for (auto &entry : std::filesystem::directory_iterator(dir, errorCode)) {


### PR DESCRIPTION
This PR fixes two minor issues:
- Available .hexpat list not cleaned between each scan
- .hexpat list popup not showing up first time it is opened, which is problematic for usage of command-line argument / recent files to open file at startup

As a side effect, pattern editor view is now dismissed while .hexpat list is open, but it show up again as soon as popup has been closed.