### PR TITLE
Fix typo in Debian/Ubuntu dependencies script

### DIFF
--- a/dist/get_deps_debian.sh
+++ b/dist/get_deps_debian.sh
@@ -5,7 +5,7 @@ echo "As of 2020-12, Debian stable does not include g++-10, needs debian testing
 # Tested on 2020-12-09 with Docker image bitnami/minideb:unstable
 
 # Install pkgconf (adds minimum dependencies) only if the equivalent pkf-config is not already installed.
-if !which pkg-config
+if ! which pkg-config
 then
     PKGCONF="pkgconf"
 fi


### PR DESCRIPTION
The "!" parameter to if needs to be free-standing. As is the script always outputs this on Ubuntu 20.04:

./get_deps_debian.sh: 8: !which: not found