### PR TITLE
Setting an env var for macOS 10.15 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,7 @@ jobs:
         CC=$(brew --prefix llvm)/bin/clang \
         CXX=$(brew --prefix llvm)/bin/clang++ \
         PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig":"$(brew --prefix)/lib/pkgconfig" \
+        MACOSX_DEPLOYMENT_TARGET=10.15 \
         cmake \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCREATE_BUNDLE=ON \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         CC=$(brew --prefix llvm)/bin/clang \
         CXX=$(brew --prefix llvm)/bin/clang++ \
         PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig":"$(brew --prefix)/lib/pkgconfig" \
-        MACOSX_DEPLOYMENT_TARGET=10.15 \
+        MACOSX_DEPLOYMENT_TARGET="10.15" \
         cmake \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCREATE_BUNDLE=ON \


### PR DESCRIPTION
CMake [seems to have trouble](https://stackoverflow.com/questions/34208360/cmake-seems-to-ignore-cmake-osx-deployment-target) setting the minimum macOS target unless it's done just right. This change sets an environment variable so it will get picked up directly, instead of through cmake.