### PR TITLE
Drop deployment target flag from libimhex plugin

### DIFF
--- a/plugins/libimhex/CMakeLists.txt
+++ b/plugins/libimhex/CMakeLists.txt
@@ -67,7 +67,6 @@ if (APPLE)
             message(WARNING "CMAKE_OSX_SYSROOT not set and macOS 10.9 SDK not found! Using default one.")
         endif ()
     endif ()
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
 
     set(LIBIMHEX_SOURCES ${LIBIMHEX_SOURCES} source/helpers/utils_mac.mm)
 endif ()


### PR DESCRIPTION
The flag tells the compiler the minimum OS the app is allowed to run on. Unless you have a particular API you're trying to use, it's best to set it to as old an OS as possible (so as many users can use it as possible.) Until a couple days ago it was set to 11.0. Changing it to 10.15 opens the app up to users still running macOS Mojave (10.15.x)

This PR removes the flag specifically for the libimhex dylib, which will now pull this value from the env var that is declared in the build script.
