### PR TITLE
Add rpath to binary executable on macOS

### DIFF
--- a/cmake/modules/PostprocessBundle.cmake
+++ b/cmake/modules/PostprocessBundle.cmake
@@ -57,3 +57,7 @@ if (CODE_SIGN_CERTIFICATE_ID)
 	execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${BUNDLE_PATH}")
 	execute_process(COMMAND ${CMAKE_COMMAND} -E rename "${BUNDLE_PATH}.temp" "${BUNDLE_PATH}")
 endif()
+
+# Add a necessary rpath to the imhex binary
+get_bundle_main_executable("${BUNDLE_PATH}" IMHEX_EXECUTABLE)
+execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @executable_path/../Frameworks/ "${IMHEX_EXECUTABLE}")

--- a/plugins/libimhex/source/helpers/utils_mac.mm
+++ b/plugins/libimhex/source/helpers/utils_mac.mm
@@ -19,29 +19,29 @@
                 NSURL * result = nil;
                 switch (path) {
                     case ImHexPath::Patterns:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/patterns"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/patterns"];
                         break;
 
                     case ImHexPath::PatternsInclude:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/patterns"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/patterns"];
                         break;
                     case ImHexPath::Magic:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/magic"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/magic"];
                         break;
                     case ImHexPath::Python:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex"];
                         break;
                     case ImHexPath::Plugins:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/plugins"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/plugins"];
                         break;
                     case ImHexPath::Yara:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/yara"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/yara"];
                         break;
                     case ImHexPath::Config:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/config"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/config"];
                         break;
                     case ImHexPath::Resources:
-                        result = [appSupportDir URLByAppendingPathComponent:@"/imhex/resources"];
+                        result = [appSupportDir URLByAppendingPathComponent:@"imhex/resources"];
                         break;
                 }
 

--- a/source/helpers/plugin_manager.cpp
+++ b/source/helpers/plugin_manager.cpp
@@ -15,8 +15,10 @@ namespace hex {
     Plugin::Plugin(std::string_view path) {
         this->m_handle = dlopen(path.data(), RTLD_LAZY);
 
-        if (this->m_handle == nullptr)
+        if (this->m_handle == nullptr) {
+            fprintf(stderr, "dlopen failed: %s", dlerror());
             return;
+        }
 
         auto pluginName = fs::path(path).stem().string();
 

--- a/source/helpers/plugin_manager.cpp
+++ b/source/helpers/plugin_manager.cpp
@@ -16,7 +16,7 @@ namespace hex {
         this->m_handle = dlopen(path.data(), RTLD_LAZY);
 
         if (this->m_handle == nullptr) {
-            fprintf(stderr, "dlopen failed: %s", dlerror());
+            hex::log::error("dlopen failed: {}", dlerror());
             return;
         }
 

--- a/source/window.cpp
+++ b/source/window.cpp
@@ -100,8 +100,12 @@ namespace hex {
             {
                 auto language = ContentRegistry::Settings::getSetting("hex.builtin.setting.interface", "hex.builtin.setting.interface.language");
 
-                if (language.is_string())
+                if (language.is_string()) {
                     LangEntry::loadLanguage(static_cast<std::string>(language));
+                } else {
+                    // If no language is specified, fall back to English.
+                    LangEntry::loadLanguage("en-US");
+                }
             }
 
             {


### PR DESCRIPTION
The loading of `builtin.hexplug` was causing the runtime also load `libimhex.dylib` as specified by the path `@rpath/libimhex.dylib`. The macOS runtime to looks up the array of rpaths (runtime paths) within the application binary itself in an attempt to discover and load the `libimhex.dylib`. Unfortunately the binary had no rpaths specified, and the runtime would either find no `libimhex.dylib` (causing the plugin to fail to load) or a _totally different_ `libimhex.dylib` than the one inside the application bundle (causing ODR violations and all kinds of other strange behaviors.)

The fix here is to inject an rpath into the imhex binary that causes `@rpath/libimhex.dylib` to resolve to the `libimhex.dylib` embedded within the application bundle. This will cause the runtime to realize that dylib is already loaded, and the `builtin.hexplug` is then able to load correctly.

Note that recent macOS versions now include Gatekeeper, which may block the loading of dylibs to applications that do not have appropriate permissions. As a result, users may have to grant `imhex.app` full disk access in order to load plugins:

<img width="668" alt="imhex_access" src="https://user-images.githubusercontent.com/1664117/122483000-7cb90680-cf86-11eb-8fdf-8c4ad3186acd.png">


If many users hit this issue, a note should be added to the README.

There are a couple other minor changes that come along with this PR, hopefully none of which are too surprising.
