### PR TITLE
Ensure projects have .hexproj extension on save

### DIFF
--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -446,7 +446,12 @@ namespace hex {
 
                 if (ProjectFile::getProjectFilePath() == "") {
                     View::openFileBrowser("hex.view.hexeditor.save_project"_lang, DialogMode::Save, { { "Project File", "hexproj" } }, [](auto path) {
-                        ProjectFile::store(path);
+                        if (path.ends_with(".hexproj")) {
+                            ProjectFile::store(path);
+                        }
+                        else {
+                            ProjectFile::store(path + ".hexproj");
+                        }
                     });
                 }
                 else


### PR DESCRIPTION
### Reasoning 

The current behavior shows the extension in the file dialog as being "hexproj", however it will still allow you to use the *.hexproj filter in order to save files without the hexproj extension. This results in an unintuitive save behavior where it appears it will save with an extension even if one is omitted, but the result is actually saving without an extension. Combined with 'open project' having a *.hexproj filter as well, it gives an initial appearance of not having saved your file. 

### Notes about this fix

* NFD doesn't (afaict) have a means of checking which filter you were using when saving, meaning if you manually select "All Files" this change will still append ".hexproj" to your filename
  * This would mean saving with an extension other than .hexproj would be unsupported