### PR TITLE
warnings: fix format-security warnings

### DIFF
--- a/source/views/view_help.cpp
+++ b/source/views/view_help.cpp
@@ -17,7 +17,7 @@ namespace hex {
 
 
     static void drawTitle(const std::string &title) {
-        ImGui::TextColored(ImVec4(0.6F, 0.6F, 1.0F, 1.0F), title.c_str());
+        ImGui::TextColored(ImVec4(0.6F, 0.6F, 1.0F, 1.0F), "%s", title.c_str());
     }
 
     static void drawBuiltinFunction(
@@ -27,9 +27,9 @@ namespace hex {
         const std::string &description
     ) {
         ImGui::Bullet();
-        ImGui::TextColored(ImVec4(0.3F, 0.7F, 0.2F, 1.0F), return_type.c_str());
+        ImGui::TextColored(ImVec4(0.3F, 0.7F, 0.2F, 1.0F), "%s", return_type.c_str());
         ImGui::SameLine();
-        ImGui::TextColored(ImVec4(0.57F, 0.24F, 0.69F, 1.0F), name.c_str());
+        ImGui::TextColored(ImVec4(0.57F, 0.24F, 0.69F, 1.0F), "%s", name.c_str());
         ImGui::SameLine();
         ImGui::TextColored(ImVec4(0.71F, 0.19F, 0.31F, 1.0F), "(");
         ImGui::SameLine();
@@ -77,7 +77,7 @@ namespace hex {
 
             constexpr const char* Links[] = { "https://werwolv.net/donate", "https://www.patreon.com/werwolv", "https://github.com/sponsors/WerWolv" };
 
-            ImGui::TextWrapped("hex.view.help.about.thanks"_lang);
+            ImGui::TextWrapped("%s", static_cast<const char *>("hex.view.help.about.thanks"_lang));
 
             ImGui::NewLine();
 

--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -308,7 +308,7 @@ namespace hex {
 
         if (ImGui::BeginPopupModal("hex.view.hexeditor.script.title"_lang, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::SetCursorPosX(10);
-            ImGui::TextWrapped("hex.view.hexeditor.script.desc"_lang);
+            ImGui::TextWrapped("%s", static_cast<const char *>("hex.view.hexeditor.script.desc"_lang));
 
             ImGui::NewLine();
             ImGui::InputText("##nolabel", this->m_loaderScriptScriptPath.data(), this->m_loaderScriptScriptPath.length(), ImGuiInputTextFlags_ReadOnly);

--- a/source/views/view_pattern_editor.cpp
+++ b/source/views/view_pattern_editor.cpp
@@ -268,7 +268,7 @@ namespace hex {
 
     void ViewPatternEditor::drawAlwaysVisible() {
         if (ImGui::BeginPopupModal("hex.view.pattern.accept_pattern"_lang, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-            ImGui::TextWrapped("hex.view.pattern.accept_pattern.desc"_lang);
+            ImGui::TextWrapped("%s", static_cast<const char *>("hex.view.pattern.accept_pattern.desc"_lang));
 
             std::vector<std::string> entries;
             entries.resize(this->m_possiblePatternFiles.size());
@@ -286,7 +286,7 @@ namespace hex {
             }, &entries, entries.size(), 4);
 
             ImGui::NewLine();
-            ImGui::Text("hex.view.pattern.accept_pattern.question"_lang);
+            ImGui::Text("%s", static_cast<const char *>("hex.view.pattern.accept_pattern.question"_lang));
 
             confirmButtons("hex.common.yes"_lang, "hex.common.no"_lang, [this]{
                 this->loadPatternFile(this->m_possiblePatternFiles[this->m_selectedPatternFile]);


### PR DESCRIPTION
Manjaro and presumably other systems have started adding the `-Werror=format-security` flag, causing the build to fail.

It might make sense to add the `-Werror=format-security` flag to the compiler flags given how easy it is to keep it happy.

Fixes #245 and #295 

