### PR TITLE
Close button in pattern popup

### DIFF
--- a/source/views/view_pattern_editor.cpp
+++ b/source/views/view_pattern_editor.cpp
@@ -337,7 +337,8 @@ namespace hex {
             ImGui::EndPopup();
         }
 
-        if (ImGui::BeginPopupModal("hex.view.pattern.menu.file.load_pattern"_lang, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        bool opened = true;
+        if (ImGui::BeginPopupModal("hex.view.pattern.menu.file.load_pattern"_lang, &opened, ImGuiWindowFlags_AlwaysAutoResize)) {
 
             if (ImGui::BeginListBox("##patterns", ImVec2(-FLT_MIN, 0))) {
 


### PR DESCRIPTION
Hi,

There is no close button in the "Load pattern..." popup window. You can't close that popup without loading a pattern.

I just added that button.