### PR TITLE
Fix Provider::getBaseAddress

### DIFF
--- a/plugins/libimhex/source/providers/provider.cpp
+++ b/plugins/libimhex/source/providers/provider.cpp
@@ -100,7 +100,7 @@ namespace hex::prv {
     }
 
     u64 Provider::getBaseAddress() const {
-        return this->m_baseAddress + PageSize * this->m_currPage;
+        return this->m_baseAddress;
     }
 
     size_t Provider::getSize() const {


### PR DESCRIPTION
Fixes getBaseAddress which also fixes jumping across pages.

What is base address supposed to be anyway?
Is it base address to load file at?
Is it offset in file to load at?
Is it current display address?