### PR TITLE
Fix infinite loop on signal handling.

### DIFF
--- a/source/window/window.cpp
+++ b/source/window/window.cpp
@@ -242,8 +242,8 @@ namespace hex {
             EventManager::post<EventAbnormalTermination>(signalNumber);
 
             // Let's not loop on this...
-            std::signal(SIGABRT, nullptr);
-            std::raise(SIGABRT);
+            std::signal(signalNumber, nullptr);
+            std::raise(signalNumber);
         };
 
         std::signal(SIGTERM, signalHandler);

--- a/source/window/window.cpp
+++ b/source/window/window.cpp
@@ -241,6 +241,8 @@ namespace hex {
         auto signalHandler = [](int signalNumber) {
             EventManager::post<EventAbnormalTermination>(signalNumber);
 
+            // Let's not loop on this...
+            std::signal(SIGABRT, nullptr);
             std::raise(SIGABRT);
         };
 


### PR DESCRIPTION
ImHex catch the SIGABRT but the signal handler raising the same signal makes the whole thing doing an infinite call loop (SIGABRT -> sighandler -> raise SIGABRT -> SIGABRT -> sighandler -> etc.)

The fix is simply to unregister the signal handler when catching a signal, as it terminates the whole program with SIGABRT anyway (maybe re-raising the same signal instead of SIGABRT?)