### PR TITLE
Fix syntax error when copying rust array to clipboard

### DIFF
--- a/source/views/view_hexeditor.cpp
+++ b/source/views/view_hexeditor.cpp
@@ -881,7 +881,7 @@ namespace hex {
                 str += " };";
                 break;
             case Language::Rust:
-                str += "let data: [u8, " + std::to_string(buffer.size()) + "] = [ ";
+                str += "let data: [u8; " + std::to_string(buffer.size()) + "] = [ ";
 
                 for (const auto &byte : buffer)
                     str += hex::format("0x{0:02X}, ", byte);


### PR DESCRIPTION
`View > Hex Editor > (highlight some bytes) > (right click) > Copy as... > Rust Array` copies code formatted like in the following example: 
```rust
let data: [u8, 16] = [ 0x54, 0x4F, 0x4B, 0x49, 0x4D, 0x45, 0x4B, 0x49, 0x20, 0x43, 0x55, 0x4C, 0x20, 0x20, 0x00, 0x80 ];
```
However, this is incorrect. the type of this array should be `[u8; 16]`, not `[u8, 16]`. For the above example to compile in rust, the above example would have to look like: 
```rust
let data: [u8; 16] = [ 0x54, 0x4F, 0x4B, 0x49, 0x4D, 0x45, 0x4B, 0x49, 0x20, 0x43, 0x55, 0x4C, 0x20, 0x20, 0x00, 0x80 ];
```