### PR TITLE
ImGui: Nearest-Neighbour Font Upscaling

### DIFF
--- a/external/ImGui/include/imgui_impl_opengl3_loader.h
+++ b/external/ImGui/include/imgui_impl_opengl3_loader.h
@@ -149,6 +149,7 @@ typedef khronos_uint8_t GLubyte;
 #define GL_FILL                           0x1B02
 #define GL_VERSION                        0x1F02
 #define GL_EXTENSIONS                     0x1F03
+#define GL_NEAREST                        0x2600
 #define GL_LINEAR                         0x2601
 #define GL_TEXTURE_MAG_FILTER             0x2800
 #define GL_TEXTURE_MIN_FILTER             0x2801

--- a/external/ImGui/source/imgui_impl_opengl3.cpp
+++ b/external/ImGui/source/imgui_impl_opengl3.cpp
@@ -525,7 +525,7 @@ bool ImGui_ImplOpenGL3_CreateFontsTexture()
     glGenTextures(1, &bd->FontTexture);
     glBindTexture(GL_TEXTURE_2D, bd->FontTexture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 #ifdef GL_UNPACK_ROW_LENGTH // Not on WebGL/ES
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 #endif


### PR DESCRIPTION
Switch from `GL_LINEAR` to `GL_NEAREST` for font texture upscaling.

This makes the bitmap font crisp on hidpi displays (tested on a retina Macbook Pro 14", 2021)

This needs further testing on other configurations - it's plausible that I've made other usecases worse.

Before:
![image](https://user-images.githubusercontent.com/13520633/143836157-f2d16c43-9256-4617-8653-f538e0f15d0b.png)

After:
![image](https://user-images.githubusercontent.com/13520633/143836247-a8c838cf-d454-4fa2-9de6-5e95d76b4ed9.png)
