### PR TITLE
ci/win: use option 'pacboy' of setup-msys2 to install dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: recursive
-        
+
     - name: 📜 Restore cache
       uses: actions/cache@v2
       with:
@@ -33,7 +33,7 @@ jobs:
       run: |
         sudo apt update
         sudo bash dist/get_deps_debian.sh
-        
+
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
         sh rustup-init.sh -y --default-toolchain none
         rm rustup-init.sh
@@ -92,14 +92,26 @@ jobs:
       with:
         fetch-depth: 0
         submodules: recursive
-        
+
     - name: 🟦 Install msys2
       uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        pacboy: >-
+          gcc:p
+          cmake:p
+          make:p
+          ccache:p
+          capstone:p
+          glfw:p
+          file:p
+          mbedtls:p
+          python:p
+          freetype:p
+          dlfcn:p
 
     - name: ⬇️ Install dependencies
       run: |
-        bash dist/get_deps_msys2.sh
-        
         curl --proto '=https' --tlsv1.2 -sSf https://win.rustup.rs > rustup-init.exe
         ./rustup-init.exe -y --default-host=x86_64-pc-windows-gnu --default-toolchain=none
         rm rustup-init.exe


### PR DESCRIPTION
This PR uses option 'pacboy' of setup-msys2 in order to install build dependencies, and take advantage of setup-msys2's caching feature.