### PR TITLE
Store environment variables and use on restart

### DIFF
--- a/include/init/splash_window.hpp
+++ b/include/init/splash_window.hpp
@@ -14,7 +14,7 @@ namespace hex::init {
 
     class WindowSplash {
     public:
-        WindowSplash(int &argc, char **&argv);
+        WindowSplash(int &argc, char **&argv, char **&envp);
         ~WindowSplash();
 
         bool loop();

--- a/plugins/libimhex/include/hex/helpers/shared_data.hpp
+++ b/plugins/libimhex/include/hex/helpers/shared_data.hpp
@@ -93,6 +93,7 @@ namespace hex {
 
         static int mainArgc;
         static char **mainArgv;
+        static char **mainEnvp;
 
         static ImFontAtlas *fontAtlas;
         static ImFontConfig fontConfig;

--- a/plugins/libimhex/source/api/imhex_api.cpp
+++ b/plugins/libimhex/source/api/imhex_api.cpp
@@ -16,7 +16,7 @@ namespace hex {
     void ImHexApi::Common::restartImHex() {
         EventManager::post<RequestCloseImHex>(false);
         std::atexit([]{
-            execve(SharedData::mainArgv[0], SharedData::mainArgv, nullptr);
+            execve(SharedData::mainArgv[0], SharedData::mainArgv, SharedData::mainEnvp);
         });
     }
 

--- a/plugins/libimhex/source/helpers/shared_data.cpp
+++ b/plugins/libimhex/source/helpers/shared_data.cpp
@@ -43,6 +43,7 @@ namespace hex {
 
     int SharedData::mainArgc;
     char **SharedData::mainArgv;
+    char **SharedData::mainEnvp;
 
     ImFontAtlas *SharedData::fontAtlas;
     ImFontConfig SharedData::fontConfig;

--- a/source/init/splash_window.cpp
+++ b/source/init/splash_window.cpp
@@ -25,9 +25,10 @@ using namespace std::literals::chrono_literals;
 
 namespace hex::init {
 
-    WindowSplash::WindowSplash(int &argc, char **&argv) : m_window(nullptr) {
+    WindowSplash::WindowSplash(int &argc, char **&argv, char **&envp) : m_window(nullptr) {
         SharedData::mainArgc = argc;
         SharedData::mainArgv = argv;
+        SharedData::mainEnvp = envp;
 
         this->initGLFW();
         this->initImGui();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -10,14 +10,14 @@
 
 #include <hex/helpers/file.hpp>
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv, char **envp) {
     using namespace hex;
 
     // Initialization
     {
         Window::initNative();
 
-        init::WindowSplash splashWindow(argc, argv);
+        init::WindowSplash splashWindow(argc, argv, envp);
 
         for (const auto &[name, task] : init::getInitTasks())
             splashWindow.addStartupTask(name, task);


### PR DESCRIPTION
- Fixes WerWolv/ImHex#373 on Linux

ImHex does not restart properly due to missing environment variables
```
[ERROR] GLFW Error [65544] : X11: The DISPLAY environment variable is missing
[FATAL] Failed to initialize GLFW!
```

#373 seems to have different issues on macOS though