### PR TITLE
Fix saving files

### DIFF
--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -244,7 +244,7 @@ namespace hex::plugin::builtin::prv {
 
             this->m_fileSize = this->m_fileStats.st_size;
 
-            this->m_mappedFile = ::mmap(nullptr, this->m_fileSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, this->m_file, 0);
+            this->m_mappedFile = ::mmap(nullptr, this->m_fileSize, PROT_READ | PROT_WRITE, MAP_SHARED, this->m_file, 0);
             if (this->m_mappedFile == nullptr) {
                 ::close(this->m_file);
                 this->m_file = -1;

--- a/plugins/libimhex/source/providers/provider.cpp
+++ b/plugins/libimhex/source/providers/provider.cpp
@@ -58,8 +58,9 @@ namespace hex::prv {
     }
 
     void Provider::applyPatches() {
-        for (auto &[patchAddress, patch] : getPatches())
-            this->writeRaw( - this->getBaseAddress(), &patch, 1);
+        for (auto &[patchAddress, patch] : getPatches()) {
+            this->writeRaw(patchAddress - this->getBaseAddress(), &patch, 1);
+        }
     }
 
 


### PR DESCRIPTION
The file save functionality is currently broken on Linux. This patch fixes it, but note that saving a file does not set `ProjectFile::s_hasUnsavedChanged` to `true`, so the dirty indicator `(*)` stays in the title bar. I don't know what project files are used for so I'm not sure what the expected behavior here is.