### PR TITLE
add hints to debug build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Configuration: ~/Library/Application Support/imhex/config
 Resources: ~/Library/Application Support/imhex/resources
 ```
 
+If the build fails while trying to find the macOS libraries, make sure you have
+XCode installed with `xcode-select --install`. Homebrew will also help get the
+most recent SDK installed and configured with `brew doctor`.
+
 ### Linux
 
 Dependency installation scripts are available for many common Linux distributions in the [/dist](dist) folder.


### PR DESCRIPTION
I added a line with a few commands to help sort out issues with building on macOS. `brew doctor` will complain about not updated SDKs etc. I purposely kept it short, because it's just a hint. Let me know if I should refine it (I would then maybe put it in the wiki)