### PR TITLE
Fix DEBUG without GIT_* variables defined

### DIFF
--- a/main/source/init/splash_window.cpp
+++ b/main/source/init/splash_window.cpp
@@ -99,7 +99,7 @@ namespace hex::init {
 
                 drawList->AddText(ImVec2(15, 120) * scale, ImColor(0xFF, 0xFF, 0xFF, 0xFF), hex::format("WerWolv 2020 - {0}", &__DATE__[7]).c_str());
 
-#if defined(DEBUG)
+#if defined(DEBUG) && defined(GIT_BRANCH) && defined(GIT_COMMIT_HASH)
                 drawList->AddText(ImVec2(15, 140) * scale, ImColor(0xFF, 0xFF, 0xFF, 0xFF), hex::format("{0} : {1} {2}@{3}", IMHEX_VERSION, ICON_FA_CODE_BRANCH, GIT_BRANCH, GIT_COMMIT_HASH).c_str());
 #else
                 drawList->AddText(ImVec2(15, 140) * scale, ImColor(0xFF, 0xFF, 0xFF, 0xFF), hex::format("{0}", IMHEX_VERSION).c_str());


### PR DESCRIPTION
When building ImHex in debug mode outside of a git repo, the build would fail due to missing GIT_ variables.