### PR TITLE
nodes: Allow immediate values on node inputs

### DIFF
--- a/lib/libimhex/include/hex/data_processor/attribute.hpp
+++ b/lib/libimhex/include/hex/data_processor/attribute.hpp
@@ -20,8 +20,7 @@ namespace hex::dp {
         };
 
         enum class IOType {
-            In,
-            Out
+            In, Out
         };
 
         Attribute(IOType ioType, Type type, std::string unlocalizedName);
@@ -33,6 +32,11 @@ namespace hex::dp {
         [[nodiscard]] IOType getIOType() const { return this->m_ioType; }
         [[nodiscard]] Type getType() const { return this->m_type; }
         [[nodiscard]] const std::string &getUnlocalizedName() const { return this->m_unlocalizedName; }
+        [[nodiscard]] bool allowsImmediate() const { return this->m_allowsImmediate; }
+        [[nodiscard]] u64 integerImmediate() const { return this->m_integerImmediate; }
+        [[nodiscard]] float floatImmediate() const { return this->m_floatImmediate; }
+        [[nodiscard]] u64* integerImmediatePtr() { return &this->m_integerImmediate; }
+        [[nodiscard]] float* floatImmediatePtr() { return &this->m_floatImmediate; }
 
         void addConnectedAttribute(u32 linkId, Attribute *to) { this->m_connectedAttributes.insert({ linkId, to }); }
         void removeConnectedAttribute(u32 linkId) { this->m_connectedAttributes.erase(linkId); }
@@ -47,6 +51,8 @@ namespace hex::dp {
                 Attribute::s_idCounter = id;
         }
 
+        void setIntegerImmediate(u64 value) { this->m_integerImmediate = value; }
+        void setFloatImmediate(float value) { this->m_floatImmediate = value; }
     private:
         u32 m_id;
         IOType m_ioType;
@@ -54,6 +60,13 @@ namespace hex::dp {
         std::string m_unlocalizedName;
         std::map<u32, Attribute *> m_connectedAttributes;
         Node *m_parentNode = nullptr;
+
+        bool m_allowsImmediate;
+
+        union {
+            u64 m_integerImmediate = 0;
+            float m_floatImmediate;
+        };
 
         std::optional<std::vector<u8>> m_outputData;
 

--- a/lib/libimhex/include/hex/data_processor/node.hpp
+++ b/lib/libimhex/include/hex/data_processor/node.hpp
@@ -98,6 +98,7 @@ namespace hex::dp {
         void setFloatOnOutput(u32 index, float floatingPoint);
 
         void setOverlayData(u64 address, const std::vector<u8> &data);
+        void allowImmediateOnInput(u32 index, bool allow);
     };
 
 }

--- a/lib/libimhex/source/data_processor/attribute.cpp
+++ b/lib/libimhex/source/data_processor/attribute.cpp
@@ -6,6 +6,8 @@ namespace hex::dp {
     u32 Attribute::s_idCounter = 1;
 
     Attribute::Attribute(IOType ioType, Type type, std::string unlocalizedName) : m_id(Attribute::s_idCounter++), m_ioType(ioType), m_type(type), m_unlocalizedName(std::move(unlocalizedName)) {
+        this->m_allowsImmediate = ioType == Attribute::IOType::In &&
+            (type == Attribute::Type::Integer || type == Attribute::Type::Float);
     }
 
     Attribute::~Attribute() {

--- a/plugins/builtin/source/content/data_processor_nodes.cpp
+++ b/plugins/builtin/source/content/data_processor_nodes.cpp
@@ -223,7 +223,9 @@ namespace hex::plugin::builtin {
 
     class NodeDisplayInteger : public dp::Node {
     public:
-        NodeDisplayInteger() : Node("hex.builtin.nodes.display.int.header", { dp::Attribute(dp::Attribute::IOType::In, dp::Attribute::Type::Integer, "hex.builtin.nodes.common.input") }) { }
+        NodeDisplayInteger() : Node("hex.builtin.nodes.display.int.header", { dp::Attribute(dp::Attribute::IOType::In, dp::Attribute::Type::Integer, "hex.builtin.nodes.common.input") }) {
+            this->allowImmediateOnInput(0, false);
+        }
 
         void drawNode() override {
             ImGui::PushItemWidth(150);
@@ -247,7 +249,9 @@ namespace hex::plugin::builtin {
 
     class NodeDisplayFloat : public dp::Node {
     public:
-        NodeDisplayFloat() : Node("hex.builtin.nodes.display.float.header", { dp::Attribute(dp::Attribute::IOType::In, dp::Attribute::Type::Float, "hex.builtin.nodes.common.input") }) { }
+        NodeDisplayFloat() : Node("hex.builtin.nodes.display.float.header", { dp::Attribute(dp::Attribute::IOType::In, dp::Attribute::Type::Float, "hex.builtin.nodes.common.input") }) {
+            this->allowImmediateOnInput(0, false);
+        }
 
         void drawNode() override {
             ImGui::PushItemWidth(150);


### PR DESCRIPTION
In numeric inputs, a textbox where you can input a value manually will be shown when it doesn't have a connection. I think it needs a bit of work on UI/UX though.

![screenshot](https://cdn.discordapp.com/attachments/789840633414025246/941409334364090408/unknown.png)