### PR TITLE
fix: don't change list while iteration

### DIFF
--- a/lib/libimhex/source/helpers/file.cpp
+++ b/lib/libimhex/source/helpers/file.cpp
@@ -56,7 +56,8 @@ namespace hex {
     std::vector<u8> File::readBytes(size_t numBytes) {
         if (!isValid()) return {};
 
-        std::vector<u8> bytes(numBytes ?: getSize());
+        auto size = numBytes ?: getSize();
+        std::vector<u8> bytes(size);
         auto bytesRead = fread(bytes.data(), 1, bytes.size(), this->m_file);
 
         bytes.resize(bytesRead);

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -415,8 +415,11 @@ namespace hex::plugin::builtin {
             }
 
             if (ImGui::BeginMenu("hex.builtin.view.hex_editor.menu.file.open_recent"_lang, !s_recentFilePaths.empty())) {
-                for (auto &path : s_recentFilePaths) {
-                    if (ImGui::MenuItem(fs::path(path).filename().string().c_str())) {
+                // Copy to avoid chaning list while iteration
+                std::list<fs::path> recentFilePaths = s_recentFilePaths;
+                for (auto &path : recentFilePaths) {
+                    auto filename = fs::path(path).filename().string();
+                    if (ImGui::MenuItem(filename.c_str())) {
                         EventManager::post<RequestOpenFile>(path);
                     }
                 }


### PR DESCRIPTION
Event posting triggers updating `s_recentFilePaths`, which replaces list elements after uniqueness check. It lead to a segfault