### PR TITLE
fix: Prevent segfault when opening a file w/o read access (linux)

### DIFF
--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -238,11 +238,13 @@ namespace hex::plugin::builtin::prv {
 
 #else
         const auto &path = this->m_path.native();
+        int mmapprot = PROT_READ | PROT_WRITE;
 
         this->m_file = ::open(path.c_str(), O_RDWR);
         if (this->m_file == -1) {
             this->m_file     = ::open(path.c_str(), O_RDONLY);
             this->m_writable = false;
+            mmapprot &= ~(PROT_WRITE);
         }
 
         if (this->m_file == -1) {
@@ -252,8 +254,8 @@ namespace hex::plugin::builtin::prv {
 
         this->m_fileSize = this->m_fileStats.st_size;
 
-        this->m_mappedFile = ::mmap(nullptr, this->m_fileSize, PROT_READ | PROT_WRITE, MAP_SHARED, this->m_file, 0);
-        if (this->m_mappedFile == nullptr) {
+        this->m_mappedFile = ::mmap(nullptr, this->m_fileSize, mmapprot, MAP_SHARED, this->m_file, 0);
+        if (this->m_mappedFile == MAP_FAILED) {
             ::close(this->m_file);
             this->m_file = -1;
 


### PR DESCRIPTION
When opening a file that you do not have write access to, the file provider will first open the file for reading and writing, discover it does not have permission, then attempt to open the file for reading only. This works as intended. Then, mmap is called with the PROT_WRITE flag which is forbidden, as the file was opened for reading (see `mmap(2)`). Finally, the if condition to check if mmap failed checks if mmap returned a null pointer, which it never will (instead returning `MAP_FAILED` or `(void *)-1` if an error occurred).

This PR removes the PROT_WRITE flag from the mmap call if the file is opened for reading, and properly checks if the mmap call failed.