### PR TITLE
pattern: add single_color attribute, fixed static array color override

### DIFF
--- a/lib/libimhex/include/hex/pattern_language/ast_node.hpp
+++ b/lib/libimhex/include/hex/pattern_language/ast_node.hpp
@@ -732,6 +732,8 @@ namespace hex::pl {
         if (auto value = attributable->getAttributeValue("color"); value) {
             u32 color = strtoul(value->c_str(), nullptr, 16);
             pattern->setColor(hex::changeEndianess(color, std::endian::big) >> 8);
+        } else if (auto value = attributable->hasAttribute("single_color", false); value) {
+            pattern->setColor(ContentRegistry::PatternLanguage::getNextColor());
         }
 
         if (auto value = attributable->getAttributeValue("name"); value) {
@@ -819,7 +821,7 @@ namespace hex::pl {
             if (array == nullptr)
                 LogConsole::abortEvaluation("inline_array attribute can only be applied to array types", node);
 
-            for (const auto& entry : array->getEntries()) {
+            for (const auto &entry : array->getEntries()) {
                 entry->setFormatterFunction(function);
             }
         }
@@ -1050,7 +1052,6 @@ namespace hex::pl {
 
             outputPattern->setVariableName(this->m_name);
             outputPattern->setEndian(templatePattern->getEndian());
-            outputPattern->setColor(templatePattern->getColor());
             outputPattern->setTypeName(templatePattern->getTypeName());
             outputPattern->setSize(templatePattern->getSize() * entryCount);
 
@@ -1407,6 +1408,15 @@ namespace hex::pl {
             pattern->setSize(evaluator->dataOffset() - startOffset);
 
             structCleanup.release();
+
+            if (!pattern->hasOverriddenColor()) {
+                if (auto value = getAttributeValue("color"); value) {
+                    u32 color = strtoul(value->c_str(), nullptr, 16);
+                    pattern->setColor(hex::changeEndianess(color, std::endian::big) >> 8);
+                } else if (auto value = hasAttribute("single_color", false); value) {
+                    pattern->setColor(ContentRegistry::PatternLanguage::getNextColor());
+                }
+            }
 
             return { pattern };
         }

--- a/lib/libimhex/include/hex/pattern_language/pattern_data.hpp
+++ b/lib/libimhex/include/hex/pattern_language/pattern_data.hpp
@@ -1019,6 +1019,7 @@ namespace hex::pl {
         void setColor(u32 color) override {
             PatternData::setColor(color);
             this->m_template->setColor(color);
+            this->m_highlightTemplate->setColor(color);
         }
 
         [[nodiscard]] std::string getFormattedName() const override {


### PR DESCRIPTION
Added a few little things.

Fixed color attributes not working on static arrays/structs.
Added new attribute `single_color`, this attribute sets same color for all elements inside struct, basically color per struct.
`color` and `single_color` attributes can now be set for struct definitions if user wishes so.