### PR TITLE
feature: User now can add custom directories

### DIFF
--- a/lib/libimhex/include/hex/api/content_registry.hpp
+++ b/lib/libimhex/include/hex/api/content_registry.hpp
@@ -66,6 +66,8 @@ namespace hex {
             void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &defaultValue, const Callback &callback);
             void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue, const Callback &callback);
 
+            void addCategoryDescrition(const std::string &unlocalizedCategory, const std::string &unlocalizedCategoryDescription);
+
             void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 value);
             void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &value);
             void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &value);
@@ -75,6 +77,7 @@ namespace hex {
             std::vector<std::string> read(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue = {});
 
             std::map<Category, std::vector<Entry>> &getEntries();
+            std::map<std::string, std::string> &getCategoryDescriptions();
             nlohmann::json getSetting(const std::string &unlocalizedCategory, const std::string &unlocalizedName);
             nlohmann::json &getSettingsData();
             std::vector<std::string> getStringArray(const std::string &unlocalizedCategory, const std::string &unlocalizedName);

--- a/lib/libimhex/include/hex/api/content_registry.hpp
+++ b/lib/libimhex/include/hex/api/content_registry.hpp
@@ -46,6 +46,19 @@ namespace hex {
                 Callback callback;
             };
 
+            struct Category {
+                std::string name;
+                size_t slot = 0;
+                
+                bool operator<(const Category &other) const {
+                    return name < other.name;
+                }
+
+                operator const std::string &() const {
+                    return name;
+                }
+            };
+
             void load();
             void store();
 
@@ -61,7 +74,7 @@ namespace hex {
             std::string read(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &defaultValue);
             std::vector<std::string> read(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue = {});
 
-            std::map<std::string, std::vector<Entry>> &getEntries();
+            std::map<Category, std::vector<Entry>> &getEntries();
             nlohmann::json getSetting(const std::string &unlocalizedCategory, const std::string &unlocalizedName);
             nlohmann::json &getSettingsData();
             std::vector<std::string> getStringArray(const std::string &unlocalizedCategory, const std::string &unlocalizedName);

--- a/lib/libimhex/include/hex/api/content_registry.hpp
+++ b/lib/libimhex/include/hex/api/content_registry.hpp
@@ -51,6 +51,7 @@ namespace hex {
 
             void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 defaultValue, const Callback &callback);
             void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &defaultValue, const Callback &callback);
+            void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue, const Callback &callback);
 
             void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 value);
             void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &value);
@@ -63,6 +64,7 @@ namespace hex {
             std::map<std::string, std::vector<Entry>> &getEntries();
             nlohmann::json getSetting(const std::string &unlocalizedCategory, const std::string &unlocalizedName);
             nlohmann::json &getSettingsData();
+            std::vector<std::string> getStringArray(const std::string &unlocalizedCategory, const std::string &unlocalizedName);
         }
 
         /* Command Palette Command Registry. Allows adding of new commands to the command palette */

--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -93,6 +93,10 @@ namespace hex {
                 json[unlocalizedCategory][unlocalizedName] = defaultValue;
         }
 
+        void addCategoryDescrition(const std::string &unlocalizedCategory, const std::string &unlocalizedCategoryDescription) {
+            getCategoryDescriptions()[unlocalizedCategory] = unlocalizedCategoryDescription;
+        }
+
         void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 value) {
             auto &json = getSettingsData();
 
@@ -171,6 +175,12 @@ namespace hex {
             static std::map<Category, std::vector<Entry>> entries;
 
             return entries;
+        }
+
+        std::map<std::string, std::string> &getCategoryDescriptions() {
+            static std::map<std::string, std::string> descriptions;
+
+            return descriptions;
         }
 
         nlohmann::json getSetting(const std::string &unlocalizedCategory, const std::string &unlocalizedName) {

--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -67,6 +67,19 @@ namespace hex {
                 json[unlocalizedCategory][unlocalizedName] = std::string(defaultValue);
         }
 
+        void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue, const Callback &callback) {
+            log::info("Registered new string array setting: [{}]: {}", unlocalizedCategory, unlocalizedName);
+
+            getEntries()[unlocalizedCategory].emplace_back(Entry { unlocalizedName, callback });
+
+            auto &json = getSettingsData();
+
+            if (!json.contains(unlocalizedCategory))
+                json[unlocalizedCategory] = nlohmann::json::object();
+            if (!json[unlocalizedCategory].contains(unlocalizedName) || !json[unlocalizedCategory][unlocalizedName].is_array())
+                json[unlocalizedCategory][unlocalizedName] = defaultValue;
+        }
+
         void write(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 value) {
             auto &json = getSettingsData();
 
@@ -160,6 +173,15 @@ namespace hex {
             static nlohmann::json settings;
 
             return settings;
+        }
+
+        std::vector<std::string> getStringArray(const std::string &unlocalizedCategory, const std::string &unlocalizedName) {
+            auto setting = getSetting(unlocalizedCategory, unlocalizedName);
+            if (setting.is_array()) {
+                return setting;
+            }
+
+            return {};
         }
 
     }

--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -41,10 +41,23 @@ namespace hex {
             }
         }
 
+        static auto getCategoryEntry(const std::string &unlocalizedCategory) {
+            auto &entries        = getEntries();
+            const size_t curSlot = entries.size();
+            auto found           = entries.find(Category { unlocalizedCategory });
+
+            if (found == entries.end()) {
+                auto [iter, _] = entries.emplace(Category { unlocalizedCategory, curSlot }, std::vector<Entry> {});
+                return iter;
+            }
+
+            return found;
+        }
+
         void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, i64 defaultValue, const Callback &callback) {
             log::info("Registered new integer setting: [{}]: {}", unlocalizedCategory, unlocalizedName);
 
-            getEntries()[unlocalizedCategory.c_str()].emplace_back(Entry { unlocalizedName.c_str(), callback });
+            getCategoryEntry(unlocalizedCategory)->second.emplace_back(Entry { unlocalizedName.c_str(), callback });
 
             auto &json = getSettingsData();
 
@@ -57,7 +70,7 @@ namespace hex {
         void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::string &defaultValue, const Callback &callback) {
             log::info("Registered new string setting: [{}]: {}", unlocalizedCategory, unlocalizedName);
 
-            getEntries()[unlocalizedCategory].emplace_back(Entry { unlocalizedName, callback });
+            getCategoryEntry(unlocalizedCategory)->second.emplace_back(Entry { unlocalizedName, callback });
 
             auto &json = getSettingsData();
 
@@ -70,7 +83,7 @@ namespace hex {
         void add(const std::string &unlocalizedCategory, const std::string &unlocalizedName, const std::vector<std::string> &defaultValue, const Callback &callback) {
             log::info("Registered new string array setting: [{}]: {}", unlocalizedCategory, unlocalizedName);
 
-            getEntries()[unlocalizedCategory].emplace_back(Entry { unlocalizedName, callback });
+            getCategoryEntry(unlocalizedCategory)->second.emplace_back(Entry { unlocalizedName, callback });
 
             auto &json = getSettingsData();
 
@@ -154,8 +167,8 @@ namespace hex {
         }
 
 
-        std::map<std::string, std::vector<Entry>> &getEntries() {
-            static std::map<std::string, std::vector<Entry>> entries;
+        std::map<Category, std::vector<Entry>> &getEntries() {
+            static std::map<Category, std::vector<Entry>> entries;
 
             return entries;
         }

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -224,6 +224,8 @@ namespace hex::plugin::builtin {
 
         static const std::string dirsSetting { "hex.builtin.setting.folders" };
 
+        ContentRegistry::Settings::addCategoryDescrition(dirsSetting, "hex.builtin.setting.folders.description");
+
         ContentRegistry::Settings::add(dirsSetting, dirsSetting, std::vector<std::string> {}, [](auto name, nlohmann::json &setting) {
             static std::vector<std::string> folders = setting;
             static int currentItemIndex             = 0;

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -4,6 +4,8 @@
 #include <hex/api/localization.hpp>
 
 #include <imgui.h>
+#include <hex/ui/imgui_imhex_extensions.h>
+#include <fonts/codicons_font.h>
 
 #include <nlohmann/json.hpp>
 
@@ -218,6 +220,48 @@ namespace hex::plugin::builtin {
             }
 
             return false;
+        });
+
+        static const std::string dirsSetting { "hex.builtin.setting.folders" };
+
+        ContentRegistry::Settings::add(dirsSetting, dirsSetting, std::vector<std::string> {}, [](auto name, nlohmann::json &setting) {
+            static std::vector<std::string> folders = setting;
+            static int currentItemIndex             = 0;
+
+            if (!ImGui::BeginListBox("", ImVec2(-38, -FLT_MIN))) {
+                return false;
+            } else {
+                for (size_t n = 0; n < folders.size(); n++) {
+                    const bool isSelected = (currentItemIndex == n);
+                    if (ImGui::Selectable(folders.at(n).c_str(), isSelected)) { currentItemIndex = n; }
+                    if (isSelected) { ImGui::SetItemDefaultFocus(); }
+                }
+                ImGui::EndListBox();
+            }
+            ImGui::SameLine();
+            ImGui::BeginGroup();
+
+            if (ImGui::IconButton(ICON_VS_NEW_FOLDER, ImGui::GetCustomColorVec4(ImGuiCustomCol_DescButton), ImVec2(30, 30))) {
+                hex::openFileBrowser("Select include folder", hex::DialogMode::Folder, {}, [&](fs::path path) {
+                    auto pathStr = path.string();
+
+                    if (std::find(folders.begin(), folders.end(), pathStr) == folders.end()) {
+                        folders.emplace_back(pathStr);
+                        ContentRegistry::Settings::write(dirsSetting, dirsSetting, folders);
+                    }
+                });
+            }
+
+            if (ImGui::IconButton(ICON_VS_REMOVE_CLOSE, ImGui::GetCustomColorVec4(ImGuiCustomCol_DescButton), ImVec2(30, 30))) {
+                if (!folders.empty()) {
+                    folders.erase(std::next(folders.begin(), currentItemIndex));
+                    ContentRegistry::Settings::write(dirsSetting, dirsSetting, folders);
+                }
+            }
+
+            ImGui::EndGroup();
+
+            return true;
         });
     }
 

--- a/plugins/builtin/source/content/views/view_settings.cpp
+++ b/plugins/builtin/source/content/views/view_settings.cpp
@@ -42,14 +42,17 @@ namespace hex::plugin::builtin {
                     return item0->first.slot < item1->first.slot;
                 });
 
+                const auto &descriptions = ContentRegistry::Settings::getCategoryDescriptions();
+
                 for (auto &it : sortedCategories) {
                     auto &[category, entries] = *it;
                     if (ImGui::BeginTabItem(LangEntry(category))) {
-                        ImGui::TextUnformatted(LangEntry(category));
+                        const std::string &categoryDesc = descriptions.count(category) ? descriptions.at(category) : category.name;
+                        ImGui::TextUnformatted(LangEntry(categoryDesc));
                         ImGui::Separator();
 
                         for (auto &[name, callback] : entries) {
-                            if (callback(LangEntry(name), ContentRegistry::Settings::getSettingsData()[category][name]))
+                            if (callback(LangEntry(name), ContentRegistry::Settings::getSettingsData()[category.name][name]))
                                 EventManager::post<EventSettingsChanged>();
                         }
 

--- a/plugins/builtin/source/content/views/view_settings.cpp
+++ b/plugins/builtin/source/content/views/view_settings.cpp
@@ -30,7 +30,20 @@ namespace hex::plugin::builtin {
 
         if (ImGui::BeginPopupModal(View::toWindowName("hex.builtin.view.settings.name").c_str(), &this->getWindowOpenState(), ImGuiWindowFlags_NoResize)) {
             if (ImGui::BeginTabBar("settings")) {
-                for (auto &[category, entries] : ContentRegistry::Settings::getEntries()) {
+                auto &entries = ContentRegistry::Settings::getEntries();
+
+                std::vector<std::decay_t<decltype(entries)>::const_iterator> sortedCategories;
+
+                for (auto it = entries.cbegin(); it != entries.cend(); it++) {
+                    sortedCategories.emplace_back(std::move(it));
+                }
+
+                std::sort(sortedCategories.begin(), sortedCategories.end(), [](auto &item0, auto &item1) {
+                    return item0->first.slot < item1->first.slot;
+                });
+
+                for (auto &it : sortedCategories) {
+                    auto &[category, entries] = *it;
                     if (ImGui::BeginTabItem(LangEntry(category))) {
                         ImGui::TextUnformatted(LangEntry(category));
                         ImGui::Separator();

--- a/plugins/builtin/source/lang/en_US.cpp
+++ b/plugins/builtin/source/lang/en_US.cpp
@@ -675,6 +675,7 @@ namespace hex::plugin::builtin {
                     { "hex.builtin.setting.hex_editor.uppercase_hex", "Upper case Hex characters" },
                     { "hex.builtin.setting.hex_editor.extra_info", "Display extra information" },
                 { "hex.builtin.setting.folders", "Folders" },
+                { "hex.builtin.setting.folders.description", "Specify additional search paths for patterns, scripts, rules and more" },
 
                 { "hex.builtin.provider.file.path", "File path" },
                 { "hex.builtin.provider.file.size", "Size" },

--- a/plugins/builtin/source/lang/en_US.cpp
+++ b/plugins/builtin/source/lang/en_US.cpp
@@ -674,6 +674,7 @@ namespace hex::plugin::builtin {
                     { "hex.builtin.setting.hex_editor.grey_zeros", "Grey out zeros" },
                     { "hex.builtin.setting.hex_editor.uppercase_hex", "Upper case Hex characters" },
                     { "hex.builtin.setting.hex_editor.extra_info", "Display extra information" },
+                { "hex.builtin.setting.folders", "Folders" },
 
                 { "hex.builtin.provider.file.path", "File path" },
                 { "hex.builtin.provider.file.size", "Size" },


### PR DESCRIPTION
Helo.
Created new setting category, where user can specify custom directories.
Custom dirs are only used for patterns, pattern includes, python scripts, magics, yara rules, constants and encodings.
Main reason is that anyone might want to use multiple git repos or sources for such files.
Not implemented for macos, because it uses only one path, but can be implemented as well.

Also added ux change, where setting categories are sorted the way they were actually created instead of alphabetical order.

Tested on linux.