### PR TITLE
Rework libimhex-rs to use autocxx

### DIFF
--- a/lib/libimhex-rs/Cargo.lock
+++ b/lib/libimhex-rs/Cargo.lock
@@ -3,6 +3,149 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "aquamarine"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e14cb2a51c8b45d26a4219981985c7350fc05eacb7b5b2939bceb2ffefdf3e"
+dependencies = [
+ "itertools 0.9.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocxx"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e6384cb95b48be8c5b83764ef800858322436f57aa17974915d23dadb6a7d5"
+dependencies = [
+ "aquamarine",
+ "autocxx-engine",
+ "autocxx-macro",
+ "cxx",
+ "moveit",
+]
+
+[[package]]
+name = "autocxx-bindgen"
+version = "0.59.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e603c1eb79e21068072ef990e5463f613e0cedddd6712ff11afeae2a90b2510"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "itertools 0.10.3",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
+name = "autocxx-build"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f5b45a4fe71d3ac68d8b4fd11abe54c791046ec4def7effe27961269b6ab3"
+dependencies = [
+ "autocxx-engine",
+ "env_logger",
+ "syn",
+]
+
+[[package]]
+name = "autocxx-engine"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02323905bec49fde96ff028fcff1c478d0eba14fa34ea5eb5e4d17439748e42a"
+dependencies = [
+ "aquamarine",
+ "autocxx-bindgen",
+ "autocxx-parser",
+ "cc",
+ "cxx",
+ "cxx-gen",
+ "indoc",
+ "itertools 0.10.3",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "strum_macros",
+ "syn",
+ "tempfile",
+ "unzip-n",
+ "version_check",
+]
+
+[[package]]
+name = "autocxx-macro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8106ca477cbe6edf188311f2e05606b81bf463c41748ce7120c31d1b11875515"
+dependencies = [
+ "autocxx-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocxx-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0ad08260adcecc119b08f460b0633b6e306ea2f6fda4f27e4dd28e20b9a2f4"
+dependencies = [
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +177,32 @@ name = "chlorine"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd650552110e39b7c5058986cf177decd3365841836578ac50a286094eac0be6"
+
+[[package]]
+name = "clang-sys"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -49,17 +227,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx-build"
-version = "1.0.55"
+name = "cxx-gen"
+version = "0.7.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83363b96cfd226eb820e37a21088c30c55e47f9fc8299c2d08a6090d50414ccc"
+checksum = "836e95ae34fc21fb39c206444879afda2c6e704424c9c621662764f1b459e83a"
 dependencies = [
- "cc",
  "codespan-reporting",
- "lazy_static",
  "proc-macro2",
  "quote",
- "scratch",
  "syn",
 ]
 
@@ -81,14 +256,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "libimhex-rs"
-version = "0.1.0"
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
- "cxx",
- "cxx-build",
- "imgui",
- "macros",
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "imgui"
@@ -108,6 +331,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "imhex-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "indoc"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,16 +357,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "libimhex-rs"
+version = "0.1.0"
+dependencies = [
+ "autocxx",
+ "autocxx-build",
+ "cxx",
+ "imgui",
+ "imhex-macros",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "link-cplusplus"
@@ -147,12 +438,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "macros"
-version = "0.1.0"
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "quote",
- "syn",
+ "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "moveit"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd833d6adefa6bcfc56948d061c1d697dfa3ab63711963c7ef4aa23eda945676"
+dependencies = [
+ "cxx",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "parking_lot"
@@ -177,6 +507,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -207,22 +567,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.0"
+name = "serde"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -236,6 +687,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +708,21 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -255,6 +735,46 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
+
+[[package]]
+name = "unzip-n"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "which"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/lib/libimhex-rs/Cargo.toml
+++ b/lib/libimhex-rs/Cargo.toml
@@ -11,6 +11,8 @@ imhex-macros = { path = "proc_macros" }
 imgui = { path = "imgui-rs" }
 
 cxx = "1.0.55"
+autocxx = "0.16"
 
 [build-dependencies]
-cxx-build = "1.0.55"
+autocxx-build = "0.16"
+#cxx-build = "1.0.55"

--- a/lib/libimhex-rs/build.rs
+++ b/lib/libimhex-rs/build.rs
@@ -1,11 +1,22 @@
 fn main() {
     println!("cargo:rustc-link-lib=dylib=imhex");
-    println!("cargo:rustc-link-search=all={}", env!("LIBIMHEX_OUTPUT_DIRECTORY"));
+    println!(
+        "cargo:rustc-link-search=all={}",
+        env!("LIBIMHEX_OUTPUT_DIRECTORY")
+    );
 
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/imhex_api.rs");
 
-    cxx_build::bridge("src/imhex_api.rs")
+    let include = format!("-I{}/include", env!("LIBIMHEX_SOURCE_DIRECTORY"));
+
+    let path = std::path::PathBuf::from("src");
+    let mut build = autocxx_build::Builder::new("src/lib.rs", &[&path])
+        .extra_clang_args(&[&include, "-x", "c++", "-std=gnu++20"])
+        .auto_allowlist(true)
+        .expect_build();
+
+    build
         .include(format!("{}/include", env!("LIBIMHEX_SOURCE_DIRECTORY")))
         .flag_if_supported("-std=gnu++20")
         .flag_if_supported("-std=gnu++2a")

--- a/lib/libimhex-rs/src/bookmarks.rs
+++ b/lib/libimhex-rs/src/bookmarks.rs
@@ -1,15 +1,7 @@
+use autocxx::c_ulong;
+
 use crate::Color;
 use std::ops::Range;
-
-#[cxx::bridge]
-mod ffi {
-    #[namespace = "hex::ImHexApi::Bookmarks"]
-    extern "C++" {
-        include!("hex/api/imhex_api.hpp");
-
-        pub unsafe fn add(addr: u64, size: u64, name: &CxxString, comment: &CxxString, color: u32);
-    }
-}
 
 /// Add a bookmark to a region of the current imhex view with an optionally provided color
 ///
@@ -25,13 +17,11 @@ pub fn add(region: Range<u64>, name: &str, comment: &str, color: impl Into<Optio
     cxx::let_cxx_string!(cpp_name = name);
     cxx::let_cxx_string!(cpp_comment = comment);
 
-    unsafe {
-        ffi::add(
-            region.start,
-            region.end.saturating_sub(region.start),
-            &cpp_name,
-            &cpp_comment,
-            color.into().unwrap_or(crate::Color::new(0, 0, 0, 0)).rgba(),
-        );
-    }
+    crate::ffi::hex::ImHexApi::Bookmarks::add(
+        region.start,
+        c_ulong::from(region.end.saturating_sub(region.start)),
+        &cpp_name,
+        &cpp_comment,
+        color.into().unwrap_or(crate::Color::new(0, 0, 0, 0)).rgba(),
+    );
 }

--- a/lib/libimhex-rs/src/bookmarks.rs
+++ b/lib/libimhex-rs/src/bookmarks.rs
@@ -1,0 +1,37 @@
+use crate::Color;
+use std::ops::Range;
+
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "hex::ImHexApi::Bookmarks"]
+    extern "C++" {
+        include!("hex/api/imhex_api.hpp");
+
+        pub unsafe fn add(addr: u64, size: u64, name: &CxxString, comment: &CxxString, color: u32);
+    }
+}
+
+/// Add a bookmark to a region of the current imhex view with an optionally provided color
+///
+/// ```rust,ignore
+/// use hex::bookmarks;
+///
+/// bookmarks::add(0..0x10, "header", "this is the header of the file", None);
+///
+/// let red = Color::new(0xFF, 0, 0, 0xFF);
+/// bookmarks::add(0x10..0x30, "table", "this is the table of the file", red);
+/// ```
+pub fn add(region: Range<u64>, name: &str, comment: &str, color: impl Into<Option<Color>>) {
+    cxx::let_cxx_string!(cpp_name = name);
+    cxx::let_cxx_string!(cpp_comment = comment);
+
+    unsafe {
+        ffi::add(
+            region.start,
+            region.end.saturating_sub(region.start),
+            &cpp_name,
+            &cpp_comment,
+            color.into().unwrap_or(crate::Color::new(0, 0, 0, 0)).rgba(),
+        );
+    }
+}

--- a/lib/libimhex-rs/src/imhex.rs
+++ b/lib/libimhex-rs/src/imhex.rs
@@ -1,0 +1,11 @@
+use crate::ffi::hex::ImHexApi::Common;
+
+/// Close ImHex, optionally prompting the user if they'd like to quit
+pub fn close_imhex(without_question: bool) {
+    Common::closeImHex(without_question)
+}
+
+/// Close and reopen ImHex
+pub fn restart_imhex() {
+    Common::restartImHex()
+}

--- a/lib/libimhex-rs/src/imhex_api.rs
+++ b/lib/libimhex-rs/src/imhex_api.rs
@@ -1,99 +1,17 @@
-pub mod ffi {
-
-    pub mod ImHexApi {
-
-        #[cxx::bridge]
-        pub mod Common {
-
-            #[namespace = "hex::ImHexApi::Common"]
-            extern "C++" {
-                include!("hex/api/imhex_api.hpp");
-
-                pub unsafe fn closeImHex(no_questions: bool);
-                pub unsafe fn restartImHex();
-            }
-
-        }
-
-        #[cxx::bridge]
-        pub mod Bookmarks {
-
-            #[namespace = "hex::ImHexApi::Bookmarks"]
-            extern "C++" {
-                include!("hex/api/imhex_api.hpp");
-
-                pub unsafe fn add(addr : u64, size : usize, name : &CxxString, comment : &CxxString, color : u32);
-            }
-
-        }
-
-    }
-}
-
-pub struct Region {
-    pub address : u64,
-    pub size : usize
-}
-
+/// A highlight color for use with the bookmarks API
 pub struct Color {
-    pub a : u8,
-    pub g : u8,
-    pub b : u8,
-    pub r : u8
-}
-
-impl Region {
-
-    pub fn new(address : u64, size : usize) -> Self {
-        Region { address, size }
-    }
-
+    pub a: u8,
+    pub g: u8,
+    pub b: u8,
+    pub r: u8,
 }
 
 impl Color {
-
-    pub fn new(r : u8, g : u8, b : u8, a : u8) -> Self {
+    pub const fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
         Color { a, g, b, r }
     }
 
-    pub fn rgba(self) -> u32 {
+    pub const fn rgba(self) -> u32 {
         (self.a as u32) << 24 | (self.b as u32) << 16 | (self.g as u32) << 8 | (self.r as u32) << 0
     }
-}
-
-pub mod ImHexApi {
-
-    pub mod Common {
-
-        pub fn closeImHex() {
-
-            unsafe {
-                crate::imhex_api::ffi::ImHexApi::Common::closeImHex(false);
-            }
-
-        }
-
-        pub fn restartImmHex() {
-
-            unsafe {
-                crate::imhex_api::ffi::ImHexApi::Common::restartImHex();
-            }
-
-        }
-
-    }
-
-    pub mod Bookmarks {
-
-        pub fn add(region : crate::Region, name : &str, comment : &str, color : Option<crate::Color>) {
-            cxx::let_cxx_string!(cpp_name = name);
-            cxx::let_cxx_string!(cpp_comment = comment);
-
-            unsafe {
-                crate::imhex_api::ffi::ImHexApi::Bookmarks::add(region.address, region.size, &cpp_name, &cpp_comment, color.unwrap_or(crate::Color::new(0, 0, 0, 0)).rgba());
-            }
-        }
-
-    }
-
 }

--- a/lib/libimhex-rs/src/lib.rs
+++ b/lib/libimhex-rs/src/lib.rs
@@ -7,6 +7,7 @@ include_cpp! {
 
     generate!("hex::ImHexApi::Common::closeImHex")
     generate!("hex::ImHexApi::Common::restartImHex")
+    generate!("hex::ImHexApi::Bookmarks::add")
 }
 
 //pub use crate::ffi::*;

--- a/lib/libimhex-rs/src/lib.rs
+++ b/lib/libimhex-rs/src/lib.rs
@@ -1,9 +1,41 @@
-#![allow(non_snake_case)]
+use autocxx::prelude::*;
+
+include_cpp! {
+    #include "hex/api/imhex_api.hpp"
+
+    safety!(unsafe)
+
+    generate!("hex::ImHexApi::Common::closeImHex")
+    generate!("hex::ImHexApi::Common::restartImHex")
+}
+
+//pub use crate::ffi::*;
+
+/// API for working with imhex bookmarks/highlights
+pub mod bookmarks;
+
+/// API for working with imhex itself
+pub mod imhex;
 
 mod imhex_api;
 
-pub use imhex_macros::plugin_setup;
-pub use imhex_api::ImHexApi;
-pub use imhex_api::Region;
-pub use imhex_api::Color;
 pub use imgui;
+
+#[doc(inline)]
+pub use imhex_api::Color;
+
+/// A macro for declaring the init function for your plugin
+///
+/// ## Example
+///
+/// ```
+/// #[hex::plugin_setup(
+///     /* Display name*/ "Example Rust",
+///     /* Author */ "WerWolv",
+///     /* Description */ "Example Rust plugin used as template for plugin devs"
+/// )]
+/// fn init() {
+///     // plugin initialization logic here
+/// }
+/// ```
+pub use imhex_macros::plugin_setup;

--- a/lib/libimhex/include/hex/api/imhex_api.hpp
+++ b/lib/libimhex/include/hex/api/imhex_api.hpp
@@ -80,7 +80,6 @@ namespace hex {
                 u32 highlightId;
             };
 
-            void add(Region region, const std::string &name, const std::string &comment, color_t color = 0x00000000);
             void add(u64 address, size_t size, const std::string &name, const std::string &comment, color_t color = 0x00000000);
 
         }


### PR DESCRIPTION
* Restructure and rename parts of library to better fit idiomatic Rust
* Add documentation to the items in the library
* Move from just cxx to autocxx (while falling back to cxx for a function which autocxx has an issue detecting all the overloads of)
* General cleanup
* Have bookmark API use Rust-native Range type for describing regions