### PR TITLE
Fix dynamic arrays till EOF: off-by-one

### DIFF
--- a/lib/libimhex/include/hex/pattern_language/ast_node.hpp
+++ b/lib/libimhex/include/hex/pattern_language/ast_node.hpp
@@ -1037,7 +1037,7 @@ namespace hex::pl {
             } else {
                 std::vector<u8> buffer(templatePattern->getSize());
                 while (true) {
-                    if (evaluator->dataOffset() >= evaluator->getProvider()->getActualSize() - buffer.size())
+                    if (evaluator->dataOffset() > evaluator->getProvider()->getActualSize() - buffer.size())
                         LogConsole::abortEvaluation("reached end of file before finding end of unsized array", this);
 
                     evaluator->getProvider()->read(evaluator->dataOffset(), buffer.data(), buffer.size());
@@ -1183,7 +1183,7 @@ namespace hex::pl {
                     for (auto pattern : patterns) {
                         std::vector<u8> buffer(pattern->getSize());
 
-                        if (evaluator->dataOffset() >= evaluator->getProvider()->getActualSize() - buffer.size()) {
+                        if (evaluator->dataOffset() > evaluator->getProvider()->getActualSize() - buffer.size()) {
                             delete pattern;
                             LogConsole::abortEvaluation("reached end of file before finding end of unsized array", this);
                         }


### PR DESCRIPTION
I got the error `Evaluator: reached end of file before finding end of unsized array` while searching for `char[]` at end of a file, although it was a zero-terminated string there.

Adding **another** `0x00` byte at end of file fixxed it temporarily. It would be better to adjust the off-by-one range check.

### Minimal sample:
**example.bin** (containg "example\0")
```
65 78 61 6D 70 6C 65 00
```

with **DynamicCharArray.hexpat**
```
char example[] @ 0x00;
```

produces `Evaluator: reached end of file before finding end of unsized array`.
