### PR TITLE
revert fallback lang

### DIFF
--- a/plugins/builtin/source/lang/pt_BR.cpp
+++ b/plugins/builtin/source/lang/pt_BR.cpp
@@ -5,7 +5,6 @@ namespace hex::plugin::builtin {
 
     void registerLanguagePtBR() {
         ContentRegistry::Language::registerLanguage("Portuguese (Brazilian)", "pt-BR");
-        LangEntry::setFallbackLanguage("pt-BR");
 
         ContentRegistry::Language::addLocalizations("pt-BR", {
                 { "hex.builtin.welcome.header.main", "Bem-vindo ao ImHex" },


### PR DESCRIPTION
Hi,

wondered why my "Datei"-menu (german language selected in settings) got mixed with brazilian items after updating ImHex. The new brazilian language file overwrites the fallback language from english to brazilian. I don't think this was done on purpose ;)