### PR TITLE
fix: correctly show checked plugin files

### DIFF
--- a/main/source/window/window.cpp
+++ b/main/source/window/window.cpp
@@ -348,11 +348,12 @@ namespace hex {
                     ImGui::TableHeadersRow();
 
                     for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Plugins, true)) {
+                        const auto filePath = path / "builtin.hexplug";
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
-                        ImGui::TextUnformatted(path.string().c_str());
+                        ImGui::TextUnformatted(filePath.string().c_str());
                         ImGui::TableNextColumn();
-                        ImGui::TextUnformatted(fs::exists(path) ? ICON_VS_CHECK : ICON_VS_CLOSE);
+                        ImGui::TextUnformatted(fs::exists(filePath) ? ICON_VS_CHECK : ICON_VS_CLOSE);
                     }
                     ImGui::EndTable();
                 }


### PR DESCRIPTION
In current implementation table show if directory with file exists, but not the file itself