### PR TITLE
Add information on generated artifacts (.deb and ELF)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
       - name: ⬆️ Upload DEB
         uses: actions/upload-artifact@v2
         with:
-          name: Linux DEB
+          name: Linux DEB (Ubuntu 20.04)
           path: |
             imhex.deb
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
       - name: ⬆️ Upload ELF
         uses: actions/upload-artifact@v2
         with:
-          name: Linux ELF
+          name: Linux ELF (Ubuntu 20.04)
           path: |
             build/AppDir/*
 


### PR DESCRIPTION
The .deb/ELF generated from the CI only work for Ubuntu 20.04 (because it's the version of the runner, and dependencies break between major releases like theses)

I renamed the CI artifacts to point out the distribution they are made for