### PR TITLE
Cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache    \
           -DCMAKE_C_FLAGS="-fuse-ld=lld"          \
           -DCMAKE_CXX_FLAGS="-fuse-ld=lld"        \
+          -DCMAKE_OBJC_COMPILER_LAUNCHER=ccache   \
+          -DCMAKE_OBJCXX_COMPILER_LAUNCHER=ccache \
           -DRUST_PATH="$USERPROFILE/.cargo/bin/"  \
           ..
         mingw32-make -j4 install
@@ -203,6 +205,8 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache      \
             -DCMAKE_C_FLAGS="-fuse-ld=lld"            \
             -DCMAKE_CXX_FLAGS="-fuse-ld=lld"          \
+            -DCMAKE_OBJC_COMPILER_LAUNCHER=ccache   \
+            -DCMAKE_OBJCXX_COMPILER_LAUNCHER=ccache \
             -DRUST_PATH="$HOME/.cargo/bin/"           \
             ..
           make -j 4 install DESTDIR=AppDir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-        restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: 🛠️ Build
       run: |
@@ -124,8 +123,7 @@ jobs:
       with:
         path: ~/Library/Caches/ccache
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-        restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-
+        
     - name: 🛠️ Build
       run: |
         mkdir -p build
@@ -171,8 +169,7 @@ jobs:
             ~/.ccache
             .flatpak-builder
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-
+          
       - name: ⬇️ Install dependencies
         run: |
           sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.ccache
+            ~/.cache/ccache
             .flatpak-builder
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build.yml
+          branch: master
           workflow_conclusion: success
           skip_unpack: true
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.ccache
+          ~/.cache/ccache
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
         restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
 


### PR DESCRIPTION
This PR fixes the cache for Ubuntu 22, and remove `restore-keys`, because according my understanding of the documentation they are redundant

As a bonus (bc from what I saw, you don't mind mixing features in PRs), this fixes a small bug in the release workflow, to always use the artifacts from the master branch