### PR TITLE
Appimage file chooser crash

### DIFF
--- a/dist/AppImageBuilder.yml
+++ b/dist/AppImageBuilder.yml
@@ -27,6 +27,7 @@ AppDir:
     - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
     include:
     - adwaita-icon-theme-full # wtf ?
+    - librsvg2-common
     - libbz2-1.0:amd64
     - libcap2:amd64
     - libdbus-1-3:amd64

--- a/dist/AppImageBuilder.yml
+++ b/dist/AppImageBuilder.yml
@@ -26,7 +26,7 @@ AppDir:
     - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security universe
     - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
     include:
-    - adwaita-icon-theme-full # wtf ?
+    - adwaita-icon-theme-full
     - librsvg2-common
     - libbz2-1.0:amd64
     - libcap2:amd64


### PR DESCRIPTION
the problem comes from library to load svg files, which isn't used in the Ubuntu (22.04 XFCE IIRC ?) used to generate AppImageBuilder.yml (so the package containing it is not included), but required on some systems like my ArchLinux KDE