### PR TITLE
detect system theme with xdg portal

### DIFF
--- a/main/source/window/linux_window.cpp
+++ b/main/source/window/linux_window.cpp
@@ -30,6 +30,7 @@ namespace hex {
             std::string result;
 
             // TODO: Make a cleaner implementation
+            // Implementation taken from https://github.com/pbek/QOwnNotes/issues/2525
             FILE *pipe = popen("dbus-send --session --print-reply=literal --reply-timeout=1000 --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' string:'color-scheme' 2>&1", "r");
             if (pipe == nullptr) return;
 


### PR DESCRIPTION
The implementation is still awful (popen) but I honestly didn't want to spend much time make a clean implementation, I just wanted to make a quickfix to make it use a standard (org.freedesktop.appearance color-theme)

I understand this is still ugly, and would understand if you rejected the merge