### PR TITLE
fix: invariables not working, add recusive pattern scan

### DIFF
--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -56,7 +56,6 @@ namespace hex::plugin::builtin {
         };
 
         std::map<std::string, PatternVariable> m_patternVariables;
-        std::vector<std::string> m_patternTypes;
 
         enum class EnvVarType
         {


### PR DESCRIPTION
A few things.

1. Added recursive pattern scan for mime lookup
2. In variable weren't working/crashing because of cleaning before eval, also in-vars disappeared after eval from settings.
3. Removed some dead code.