### PR TITLE
Fix "Content Store" persist in flatpak.

### DIFF
--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -247,8 +247,8 @@ namespace hex::fs {
         std::vector<std::fs::path> configDirs = xdg::ConfigDirs();
         std::vector<std::fs::path> dataDirs   = xdg::DataDirs();
 
-        configDirs.push_back(xdg::ConfigHomeDir());
-        dataDirs.push_back(xdg::DataHomeDir());
+        configDirs.insert(configDirs.begin(), xdg::ConfigHomeDir());
+        dataDirs.insert(dataDirs.begin(), xdg::DataHomeDir());
 
         for (auto &dir : dataDirs)
             dir = dir / "imhex";


### PR DESCRIPTION
fix not saving to "XDG_DATA_HOME", when "XDG_DATA_DIRS" is available.   
In flatpak, downloaded `libraries/patterns` will be saved to `/run/host/user-share/imhex`, which will be cleared when app exit.  

> XDG specification specifies how to find config and data directories on linux systems. Specifically, it says this:
> - Data should be written to $XDG_DATA_HOME
> - Config should be written to $XDG_CONFIG_HOME
> - Data should be read from $XDG_DATA_HOME:$XDG_DATA_DIRS
> - Config should be read from $XDG_CONFIG_HOME:$XDG_CONFIG_DIRS