### PR TITLE
refactor(imgui-rs): Rust code readability improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -44,6 +44,6 @@ body:
     label: Additional context?
     value: |
       - Additional information about your environment.
-      - If possible and useful, please upload the binary you've been editing when the bug occured.
+      - If possible and useful, please upload the binary you've been editing when the bug occurred.
   validations:
     required: false

--- a/lib/libimhex-rs/imgui-rs/src/drag_drop.rs
+++ b/lib/libimhex-rs/imgui-rs/src/drag_drop.rs
@@ -5,7 +5,7 @@
 //! some data from one [source](DragDropSource) to one [target](DragDropTarget).
 //! A source and a target must both have some `name` identifier, which is declared when they
 //! are created. If these names are equal, then a `payload` of some kind
-//! will be given to the target caller whne the user releases their mouse button over
+//! will be given to the target caller when the user releases their mouse button over
 //! the target (additionally, the UI will reflect that the payload *can* be deposited
 //! in the target).
 //!
@@ -282,7 +282,7 @@ impl<T: AsRef<str>> DragDropSource<T> {
     }
 }
 
-/// A helper struct for RAII drap-drop support.
+/// A helper struct for RAII drag-drop support.
 pub struct DragDropSourceToolTip<'ui>(PhantomData<Ui<'ui>>);
 
 impl DragDropSourceToolTip<'_> {
@@ -429,7 +429,7 @@ impl<'ui> DragDropTarget<'ui> {
     ///
     /// Moreover, if the `DragDropSource` has also used `Condition::Once` or similar when they sent the data,
     /// ImGui will assume its data is still valid even after your preview, so corrupting that data could
-    /// lead to all sorts of unsafe behvaior on ImGui's side. In summary, using this function for any data
+    /// lead to all sorts of unsafe behavior on ImGui's side. In summary, using this function for any data
     /// which isn't truly `Copy` or "plain old data" is difficult, and requires substantial knowledge
     /// of the various edge cases.
     pub unsafe fn accept_payload_unchecked(

--- a/lib/libimhex-rs/imgui-rs/src/draw_list.rs
+++ b/lib/libimhex-rs/imgui-rs/src/draw_list.rs
@@ -5,7 +5,7 @@
 //! list and draw custom primitives. You can interleave normal widget
 //! calls and adding primitives to the current draw list.
 //!
-//! Interaction is mostly through the mtehods [`DrawListMut`] struct,
+//! Interaction is mostly through the methods [`DrawListMut`] struct,
 //! such as [`DrawListMut::add_line`], however you can also construct
 //!  structs like [`Line`] directly, then call
 //!  `Line::build` with a reference to your draw list
@@ -396,7 +396,7 @@ impl<'ui> DrawListMut<'ui> {
         ImageQuad::new(self, texture_id, p1, p2, p3, p4)
     }
 
-    /// Draw the speciied image, with rounded corners
+    /// Draw the specified image, with rounded corners
     pub fn add_image_rounded(
         &'ui self,
         texture_id: TextureId,

--- a/lib/libimhex-rs/imgui-rs/src/fonts/atlas.rs
+++ b/lib/libimhex-rs/imgui-rs/src/fonts/atlas.rs
@@ -444,7 +444,7 @@ impl SharedFontAtlas {
 }
 
 impl Drop for SharedFontAtlas {
-    #[doc(alias = "ImFontAtlas::Destory")]
+    #[doc(alias = "ImFontAtlas::Destroy")]
     fn drop(&mut self) {
         unsafe { sys::ImFontAtlas_destroy(self.0) };
     }

--- a/lib/libimhex-rs/imgui-rs/src/input/mouse.rs
+++ b/lib/libimhex-rs/imgui-rs/src/input/mouse.rs
@@ -14,7 +14,7 @@ pub enum MouseButton {
 }
 
 impl MouseButton {
-    /// All possible `MouseButton` varirants
+    /// All possible `MouseButton` variants
     pub const VARIANTS: [MouseButton; MouseButton::COUNT] = [
         MouseButton::Left,
         MouseButton::Right,
@@ -64,7 +64,7 @@ pub enum MouseCursor {
 }
 
 impl MouseCursor {
-    /// All possible `MouseCursor` varirants
+    /// All possible `MouseCursor` variants
     pub const VARIANTS: [MouseCursor; MouseCursor::COUNT] = [
         MouseCursor::Arrow,
         MouseCursor::TextInput,

--- a/lib/libimhex-rs/imgui-rs/src/input_widget.rs
+++ b/lib/libimhex-rs/imgui-rs/src/input_widget.rs
@@ -221,7 +221,7 @@ where
     // we may resize the buffer no matter what, and we must do that.
     // The solution for this will be, I suspect, to build a second api channel that takes
     // an `&mut CStr`, which is ugly! I suspect few to none will want no-resizing, so I'm deferring
-    // fixing the problem. -- sanbox-irl 09/15/2021, see #523 for more
+    // fixing the problem. -- sandbox-irl 09/15/2021, see #523 for more
     //
     // /// By default (as of 0.8.0), imgui-rs will automatically handle string resizes
     // /// for [InputText] and [InputTextMultiline].
@@ -323,7 +323,7 @@ where
         }
 
         if o {
-            // if a truncation occured, we'll find another one too on the end.
+            // if a truncation occurred, we'll find another one too on the end.
             // this might end up deleting user `\0` though!
             // this hack is working but WOW is it hacky!
             if let Some(null_terminator_position) = self.buf.rfind('\0') {
@@ -379,7 +379,7 @@ impl<'ui, 'p, T: InputTextCallbackHandler, L: AsRef<str>> InputTextMultiline<'ui
     // we may resize the buffer no matter what, and we must do that.
     // The solution for this will be, I suspect, to build a second api channel that takes
     // an `&mut CStr`, which is ugly! I suspect few to none will want no-resizing, so I'm deferring
-    // fixing the problem. -- sanbox-irl 09/15/2021, see #523 for more
+    // fixing the problem. -- sandbox-irl 09/15/2021, see #523 for more
     // /// By default (as of 0.8.0), imgui-rs will automatically handle string resizes
     // /// for [InputText] and [InputTextMultiline].
     // ///
@@ -463,7 +463,7 @@ impl<'ui, 'p, T: InputTextCallbackHandler, L: AsRef<str>> InputTextMultiline<'ui
         }
 
         if o {
-            // if a truncation occured, we'll find another one too on the end.
+            // if a truncation occurred, we'll find another one too on the end.
             // this might end up deleting user `\0` though!
             if let Some(null_terminator_position) = self.buf.rfind('\0') {
                 self.buf.truncate(null_terminator_position);

--- a/lib/libimhex-rs/imgui-rs/src/lib.rs
+++ b/lib/libimhex-rs/imgui-rs/src/lib.rs
@@ -123,7 +123,7 @@ impl Context {
 pub struct Ui<'ui> {
     ctx: &'ui Context,
     font_atlas: Option<cell::RefMut<'ui, SharedFontAtlas>>,
-    // imgui isn't mutli-threaded -- so no one will ever access twice.
+    // imgui isn't multi-threaded -- so no one will ever access twice.
     buffer: cell::UnsafeCell<string::UiBuffer>,
 }
 
@@ -431,7 +431,7 @@ impl<'ui> Ui<'ui> {
     ///     }
     /// }
     /// ```
-    #[doc(alias = "BeginTooltip", alias = "EndTootip")]
+    #[doc(alias = "BeginTooltip", alias = "EndTooltip")]
     pub fn tooltip<F: FnOnce()>(&self, f: F) {
         unsafe { sys::igBeginTooltip() };
         f();
@@ -460,7 +460,7 @@ impl<'ui> Ui<'ui> {
     ///     }
     /// }
     /// ```
-    #[doc(alias = "BeginTooltip", alias = "EndTootip")]
+    #[doc(alias = "BeginTooltip", alias = "EndTooltip")]
     pub fn tooltip_text<T: AsRef<str>>(&self, text: T) {
         self.tooltip(|| self.text(text));
     }

--- a/lib/libimhex-rs/imgui-rs/src/string.rs
+++ b/lib/libimhex-rs/imgui-rs/src/string.rs
@@ -323,7 +323,7 @@ impl Deref for ImString {
     fn deref(&self) -> &ImStr {
         // as_ptr() is used, because we need to look at the bytes to figure out the length
         // self.0.len() is incorrect, because there might be more than one nul byte in the end, or
-        // some interior nuls in the data
+        // some interior nulls in the data
         unsafe {
             &*(CStr::from_ptr(self.0.as_ptr() as *const c_char) as *const CStr as *const ImStr)
         }

--- a/lib/libimhex-rs/imgui-rs/src/style.rs
+++ b/lib/libimhex-rs/imgui-rs/src/style.rs
@@ -101,7 +101,7 @@ pub struct Style {
     /// `= 0.0`: always show when hovering
     /// `= f32::MAX`: never show close button unless selected
     pub tab_min_width_for_close_button: f32,
-    /// Side of the color buttonton pubin color editor widgets (left/right).
+    /// Side of the color button position color editor widgets (left/right).
     pub color_button_position: Direction,
     /// Alignment of button text when button is larger than text.
     ///
@@ -132,7 +132,7 @@ pub struct Style {
     ///
     /// Require back-end to render with bilinear filtering. Latched at the beginning of the frame.
     pub anti_aliased_lines_use_tex: bool,
-    /// Enable anti-aliased edges around filled shapes (rounded recatngles, circles, etc.).
+    /// Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.).
     ///
     /// Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame.
     pub anti_aliased_fill: bool,
@@ -162,7 +162,7 @@ impl Style {
         }
     }
     /// Replaces current colors with classic Dear ImGui style
-    #[doc(alias = "StyleColors", alias = "StlyeColorsClassic")]
+    #[doc(alias = "StyleColors", alias = "StyleColorsClassic")]
     pub fn use_classic_colors(&mut self) -> &mut Self {
         unsafe {
             sys::igStyleColorsClassic(self.raw_mut());

--- a/lib/libimhex-rs/imgui-rs/src/tables.rs
+++ b/lib/libimhex-rs/imgui-rs/src/tables.rs
@@ -250,7 +250,7 @@ pub enum TableSortDirection {
 }
 
 impl<'ui> Ui<'ui> {
-    /// Begins a table with no flags and with standard sizing contraints.
+    /// Begins a table with no flags and with standard sizing constraints.
     ///
     /// This does no work on styling the headers (the top row) -- see either
     /// [begin_table_header](Self::begin_table_header) or the more complex
@@ -267,7 +267,7 @@ impl<'ui> Ui<'ui> {
         self.begin_table_with_flags(str_id, column_count, TableFlags::empty())
     }
 
-    /// Begins a table with flags and standard sizing contraints.
+    /// Begins a table with flags and standard sizing constraints.
     ///
     /// This does no work on styling the headers (the top row) -- see either
     /// [begin_table_header](Self::begin_table_header) or the more complex
@@ -285,7 +285,7 @@ impl<'ui> Ui<'ui> {
         self.begin_table_with_sizing(str_id, column_count, flags, [0.0, 0.0], 0.0)
     }
 
-    /// Begins a table with all flags and sizing contraints. This is the base method,
+    /// Begins a table with all flags and sizing constraints. This is the base method,
     /// and gives users the most flexibility.
     ///
     /// This does no work on styling the headers (the top row) -- see either
@@ -321,7 +321,7 @@ impl<'ui> Ui<'ui> {
         }
     }
 
-    /// Begins a table with no flags and with standard sizing contraints.
+    /// Begins a table with no flags and with standard sizing constraints.
     ///
     /// Takes an array of table header information, the length of which determines
     /// how many columns will be created.
@@ -335,7 +335,7 @@ impl<'ui> Ui<'ui> {
         self.begin_table_header_with_flags(str_id, column_data, TableFlags::empty())
     }
 
-    /// Begins a table with flags and standard sizing contraints.
+    /// Begins a table with flags and standard sizing constraints.
     ///
     /// Takes an array of table header information, the length of which determines
     /// how many columns will be created.
@@ -350,7 +350,7 @@ impl<'ui> Ui<'ui> {
         self.begin_table_header_with_sizing(str_id, column_data, flags, [0.0, 0.0], 0.0)
     }
 
-    /// Begins a table with all flags and sizing contraints. This is the base method,
+    /// Begins a table with all flags and sizing constraints. This is the base method,
     /// and gives users the most flexibility.
     /// Takes an array of table header information, the length of which determines
     /// how many columns will be created.
@@ -485,7 +485,7 @@ impl<'ui> Ui<'ui> {
     /// though you can choose to not as an optimization.
     ///
     /// # Panics
-    /// If `column_index >= ui.table_columm_count`, this function will panic. In `debug` releases,
+    /// If `column_index >= ui.table_column_count`, this function will panic. In `debug` releases,
     /// we will panic on the Rust side, for a nicer error message, though in release, we will
     /// panic in C++, which will result in an ugly stack overflow.
     pub fn table_set_column_index(&self, column_index: usize) -> bool {
@@ -807,7 +807,7 @@ impl TableSortSpecsMut<'_> {
     /// told that the data has been sorted.
     ///
     /// If you need manual control over sorting, consider using [should_sort], [specs],
-    /// and [set_sorted] youself.
+    /// and [set_sorted] yourself.
     ///
     /// [should_sort]: Self::should_sort
     /// [specs]: Self::specs

--- a/lib/libimhex-rs/imgui-rs/src/widget/color_editors.rs
+++ b/lib/libimhex-rs/imgui-rs/src/widget/color_editors.rs
@@ -47,7 +47,7 @@ pub enum ColorEditInputMode {
 }
 
 impl ColorEditInputMode {
-    // Note: Probably no point in deprecating these since they're ~0 maintance burden.
+    // Note: Probably no point in deprecating these since they're ~0 maintenance burden.
     /// Edit as RGB(A). Alias for [`Self::Rgb`] for backwards-compatibility.
     pub const RGB: Self = Self::Rgb;
     /// Edit as HSV(A). Alias for [`Self::Hsv`] for backwards-compatibility.
@@ -66,7 +66,7 @@ pub enum ColorEditDisplayMode {
 }
 
 impl ColorEditDisplayMode {
-    // Note: Probably no point in deprecating these since they're ~0 maintance burden.
+    // Note: Probably no point in deprecating these since they're ~0 maintenance burden.
     /// Display as RGB(A). Alias for [`Self::Rgb`] for backwards-compatibility.
     pub const RGB: Self = Self::Rgb;
     /// Display as HSV(A). Alias for [`Self::Hsv`] for backwards-compatibility.

--- a/lib/libimhex-rs/imgui-rs/src/widget/selectable.rs
+++ b/lib/libimhex-rs/imgui-rs/src/widget/selectable.rs
@@ -15,7 +15,7 @@ bitflags!(
         const ALLOW_DOUBLE_CLICK = sys::ImGuiSelectableFlags_AllowDoubleClick;
         /// Cannot be selected, display greyed out text
         const DISABLED = sys::ImGuiSelectableFlags_Disabled;
-        /// (WIP) Hit testing to allow subsequent willdgets to overlap this one
+        /// (WIP) Hit testing to allow subsequent widgets to overlap this one
         const ALLOW_ITEM_OVERLAP = sys::ImGuiSelectableFlags_AllowItemOverlap;
     }
 );

--- a/lib/libimhex-rs/imgui-rs/src/window/child_window.rs
+++ b/lib/libimhex-rs/imgui-rs/src/window/child_window.rs
@@ -62,7 +62,7 @@ impl<'a> ChildWindow<'a> {
     }
     /// Sets the window focused state, which can be used to bring the window to front
     #[inline]
-    #[doc(alias = "SetNextWindwowFocus")]
+    #[doc(alias = "SetNextWindowFocus")]
     pub fn focused(mut self, focused: bool) -> Self {
         self.focused = focused;
         self


### PR DESCRIPTION
Readability fixes focused in the `lib/libimhex-rs/imgui-rs/.rs` path

Summary:
- Doc alias readability improvements are in one commit
- Comment readability improvements are in a separate commit
- There was also a small fix in the bug report yaml that didn't make sense for a separate PR

