### PR TITLE
build: Update nfd-extended to get correct feature test detection

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -11,7 +11,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../external/microtar ${CMAKE_CURREN
 set_target_properties(microtar PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 set(NFD_PORTAL ON CACHE BOOL "Use Portals for Linux file dialogs" FORCE)
-set(NFD_USE_ALLOWEDCONTENTTYPES OFF CACHE BOOL "Disable allowedContentTypes for macOS file dialogs" FORCE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../external/nativefiledialog ${CMAKE_CURRENT_BINARY_DIR}/external/nativefiledialog EXCLUDE_FROM_ALL)
 set_target_properties(nfd PROPERTIES POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
This update to NFD Extended fixes the deployment target detection so we no longer need to pass the `NFD_USE_ALLOWEDCONTENTTYPES` flag manually.  NFD Extended now detects the correct deployment target that was set by the `MACOSX_DEPLOYMENT_TARGET` export.