### PR TITLE
Explicitly connect to desired signals, rather than every one.

### DIFF
--- a/main/source/window/window.cpp
+++ b/main/source/window/window.cpp
@@ -146,10 +146,10 @@ namespace hex {
             this->m_popupsToOpen.push_back(name);
         });
 
-        for (u32 signal = 0; signal < NSIG; signal++) {
-            if (signal != SIGTERM && signal != SIGINT)
-                std::signal(signal, signalHandler);
-        }
+		std::signal(SIGSEGV, signalHandler);
+		std::signal(SIGILL, signalHandler);
+		std::signal(SIGABRT, signalHandler);
+		std::signal(SIGFPE, signalHandler);
         std::set_terminate([]{ signalHandler(SIGABRT); });
 
         auto imhexLogo      = romfs::get("logo.png");


### PR DESCRIPTION
This avoids a crash on POSIX after running a command from the command
pallete; on completion, a SIGCHILD will be raised, which was incorrectly
calling the error handler and terminating ImHex.