### PR TITLE
Small fixes for Fedora

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,14 +448,7 @@ jobs:
             ~/.cache/ccache
           key: fedora-${{ matrix.release }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
           restore-keys: fedora-${{ matrix.release }}-${{ secrets.CACHE_VERSION }}-build
-        
-      - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/rpmbuild/BUILDROOT/CMakeCache.txt
-          key: fedora-${{ matrix.release }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-      
+   
       - name: 📜 Set version variable
         run: |
           echo "IMHEX_VERSION=`cat VERSION`" >> $GITHUB_ENV

--- a/dist/rpm/imhex.spec
+++ b/dist/rpm/imhex.spec
@@ -1,7 +1,7 @@
 # ftbfs without this
 %global _lto_cflags %{nil}
 
-Name:           ImHex
+Name:           imhex
 Version:        %{_version}
 Release:        0%{?dist}
 Summary:        A hex editor for reverse engineers and programmers


### PR DESCRIPTION
This PR adds very small fixes directed at Fedora :
- use 'imhex' as package name in imhex.spec, so it's the same name as in the official Fedora repository (it's weird to have "imhex" in the official repository and "ImHex" with the github rpm, plus I think this allowed both packages to be installed at the same time, which I don't think is a good thing)
- Remove CMakeCache cache in the CI : it doesn't work as of now, and after thinking about it, CMake is handled by rpmbuild and not us, which I think makes it risky to try to manage it (by caching it)