### PR TITLE
Update CMakeLists.txt minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 # Options
 option(IMHEX_PLUGINS_IN_SHARE "Put the plugins in share/imhex/plugins instead of lib[..]/imhex/plugins" OFF)


### PR DESCRIPTION
As per cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html,
`set(CMAKE_CXX_STANDARD 23)` requires minimum cmake version bump to 3.20