### PR TITLE
Fix "build twice" bug in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: 📜 Restore cache
+      - name: 📜 Restore ccache
         uses: actions/cache@v3
         with:
           path: |
@@ -232,7 +232,7 @@ jobs:
           cd build
           CC=gcc-12 CXX=g++-12 cmake                  \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE            \
-            -DCMAKE_INSTALL_PREFIX="/usr" 	          \
+            -DCMAKE_INSTALL_PREFIX="/usr"             \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache        \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache      \
             -DCMAKE_C_FLAGS="-fuse-ld=lld"            \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
             -DRUST_PATH="$HOME/.cargo/bin/"           \
             -DIMHEX_PATTERNS_PULL_MASTER=ON           \
             ..
-          make -j 4 install DESTDIR=AppDir
+          make -j 4 install DESTDIR=DebDir
 
       - name: 📜 Set version variable
         run: |
@@ -256,10 +256,9 @@ jobs:
 
       - name: 📦 Bundle DEB
         run: |
-          cp -r build/DEBIAN build/AppDir
-          dpkg-deb -Zgzip --build build/AppDir
-          mv build/AppDir.deb imhex-${{env.IMHEX_VERSION}}.deb
-          rm -rf build/AppDir/DEBIAN
+          cp -r build/DEBIAN build/DebDir
+          dpkg-deb -Zgzip --build build/DebDir
+          mv build/DebDir.deb imhex-${{env.IMHEX_VERSION}}.deb
 
       - name: 🛠️ Reconfigure build for AppImage
         run: |
@@ -271,7 +270,6 @@ jobs:
           -DIMHEX_PLUGINS_IN_SHARE=ON \
           ..
 
-          rm -rf AppDir
           make -j 4 install DESTDIR=AppDir
 
       - name: 📦 Bundle AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,7 @@ jobs:
         with:
           path: |
             build/CMakeCache.txt
+            build-appimage/CMakeCache.txt
             .flatpak-builder
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
           
@@ -261,21 +262,27 @@ jobs:
           dpkg-deb -Zgzip --build build/DebDir
           mv build/DebDir.deb imhex-${{env.IMHEX_VERSION}}.deb
 
+      # AppImage cmake build
       - name: 🛠️ Reconfigure build for AppImage
         run: |
-          # Reconfigure CMake to  include a flag needed for AppImage
-          # Other flags are kept from old configuration
-
-          cd build
-          cmake \
-          -DIMHEX_PLUGINS_IN_SHARE=ON \
-          ..
-
+          mkdir -p build-appimage
+          cd build-appimage
+          CC=gcc-12 CXX=g++-12 cmake                  \
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE            \
+            -DCMAKE_INSTALL_PREFIX="/usr"             \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache      \
+            -DCMAKE_C_FLAGS="-fuse-ld=lld"            \
+            -DCMAKE_CXX_FLAGS="-fuse-ld=lld"          \
+            -DRUST_PATH="$HOME/.cargo/bin/"           \
+            -DIMHEX_PATTERNS_PULL_MASTER=ON           \
+            -DIMHEX_PLUGINS_IN_SHARE=ON               \
+            ..
           make -j 4 install DESTDIR=AppDir
 
       - name: 📦 Bundle AppImage
         run: |
-          cd build
+          cd build-appimage
           appimage-builder --recipe ../dist/AppImageBuilder.yml
           mv ImHex-AppImage-x86_64.AppImage ../imhex-${{env.IMHEX_VERSION}}.AppImage
           cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,7 @@ jobs:
           $HOME/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
           $HOME/.cargo/bin/rustup default nightly
 
+      # Ubuntu cmake build
       - name: 🛠️ Build
         run: |
           mkdir -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 option(IMHEX_PLUGINS_IN_SHARE "Put the plugins in share/imhex/plugins instead of lib[..]/imhex/plugins" OFF)
 option(IMHEX_STRIP_RELEASE "Strip the release builds" ON)
 option(IMHEX_OFFLINE_BUILD "Enable offline build" OFF)
-option(IMHEX_IGNORE_BAD_CLONE "Disabled the bad clone prevention checks" OFF)
+option(IMHEX_IGNORE_BAD_CLONE "Disable the bad clone prevention checks" OFF)
 option(IMHEX_PATTERNS_PULL_MASTER "Download latest files from master branch of the ImHex-Patterns repo" OFF)
 option(IMHEX_IGNORE_BAD_COMPILER "Allow compiling with an unsupported compiler" OFF)
 


### PR DESCRIPTION
The pull request to change the install directory structure/add support for Fedora introduced a bug in the CI, essentially caused by the fact that the deb and AppImage version shared the same build directory (I was updating the build directory of the deb with a flag for the appimage).
This caused the cache to not be taken into account for the appimage build (I don't know why), thus rebuilding everything