### PR TITLE
fix: crash when evaluating patterns

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_data.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_data.cpp
@@ -108,7 +108,7 @@ namespace hex::plugin::builtin {
     void ViewPatternData::drawContent() {
         if (ImGui::Begin(View::toWindowName("hex.builtin.view.pattern_data.name").c_str(), &this->getWindowOpenState(), ImGuiWindowFlags_NoCollapse)) {
             auto provider = ImHexApi::Provider::get();
-            if (ImHexApi::Provider::isValid() && provider->isReadable()) {
+            if (ImHexApi::Provider::isValid() && provider->isReadable() && !ProviderExtraData::get(provider).patternLanguage.runtime->isRunning()) {
 
                 auto &sortedPatterns = this->m_sortedPatterns[ImHexApi::Provider::get()];
                 if (beginPatternTable(provider, ProviderExtraData::get(provider).patternLanguage.runtime->getPatterns(), sortedPatterns)) {


### PR DESCRIPTION
App crashed when pattern was evaluating caused by race condition resulting in SEGV.
Fix might be a bit crude.