### PR TITLE
Fix deprecated MAINTAINER flag.

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:latest
 
-MAINTAINER WerWolv "hey@werwolv.net"
+LABEL maintainer="hey@werwolv.net" = WerWolv
 
 # Install dependencies
 RUN pacman -Syy --needed --noconfirm


### PR DESCRIPTION
According to DockerFile reference: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

The MAINTAINER flag is now deprecated, as such I turned it into a label flag as shown in https://docs.docker.com/engine/reference/builder/#label