### PR TITLE
add Ctrl+Shift+Z shortcut to redo

### DIFF
--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -1532,6 +1532,10 @@ namespace hex::plugin::builtin {
             if (ImHexApi::Provider::isValid())
                 ImHexApi::Provider::get()->redo();
         });
+        ShortcutManager::addShortcut(this, CTRL + SHIFT + Keys::Z, [] {
+            if (ImHexApi::Provider::isValid())
+                ImHexApi::Provider::get()->redo();
+        });
     }
 
     void ViewHexEditor::registerEvents() {


### PR DESCRIPTION
On some editors, the redo shortcut is mapped to Ctrl+Shift+Z

I think it would be great to support both shortcuts (the other one being Ctrl+Y)