### PR TITLE
fix: Pattern auto-loading issue on Windows

### DIFF
--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -266,12 +266,13 @@ namespace hex::fs {
 
     std::fs::path toShortPath(const std::fs::path &path) {
         #if defined(OS_WINDOWS)
-            size_t size = GetShortPathNameW(path.c_str(), nullptr, 0) * sizeof(TCHAR);
+            size_t size = GetShortPathNameW(path.c_str(), nullptr, 0);
             if (size == 0)
                 return path;
 
             std::wstring newPath(size, 0x00);
             GetShortPathNameW(path.c_str(), newPath.data(), newPath.size());
+            newPath.pop_back();
 
             return newPath;
         #else


### PR DESCRIPTION
Both Windows API and `std::wstring` constructor use wide-char count as size parameter, so the ` * sizeof(TCHAR)` is not needed.

And the size and output content of Windows API include the terminating null character, but C++ string should not. If includes, [magic.cpp#L30](https://github.com/WerWolv/ImHex/blob/bececff9e5a9d1e5f42b3227ea9c2bb1f46c1e83/lib/libimhex/source/helpers/magic.cpp#L30) will concatenate a string like `"path1\0:path2\0:"`, and only the part before `\0` is passed to libmagic when use `.c_str()`.