### PR TITLE
Change "Esc" key behavior on hex editor popups

### DIFF
--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -44,8 +44,10 @@ namespace hex::plugin::builtin {
                     ImGui::EndTabItem();
                 }
 
-                ImGui::SetKeyboardFocusHere();
-                ImGui::SetNextFrameWantCaptureKeyboard(true);
+                if(this->m_requestFocus){
+                    ImGui::SetKeyboardFocusHere();
+                    this->m_requestFocus = false;
+                }
                 if (ImGui::InputTextIcon("##input", ICON_VS_SYMBOL_OPERATOR, this->m_input, ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll)) {
                     if (auto result = this->m_evaluator.evaluate(this->m_input); result.has_value()) {
                         const auto inputResult = result.value();
@@ -92,6 +94,7 @@ namespace hex::plugin::builtin {
 
         Mode m_mode = Mode::Absolute;
 
+        bool m_requestFocus = true;
         std::string m_input;
         MathEvaluator<i128> m_evaluator;
     };

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -784,6 +784,11 @@ namespace hex::plugin::builtin {
 
         ImGui::SetNextWindowPos(ImGui::GetWindowPos() + ImGui::GetWindowContentRegionMin() - ImGui::GetStyle().WindowPadding, ImGuiCond_Appearing);
         if (ImGui::BeginPopup("##hex_editor_popup", ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |ImGuiWindowFlags_NoTitleBar)) {
+            
+            // Force close the popup when user is editing an input
+            if(ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Escape))){
+                ImGui::CloseCurrentPopup();
+            }
 
             if (this->m_currPopup != nullptr)
                 this->m_currPopup->draw(this);


### PR DESCRIPTION
This PR fix the "'Esc" key on the Ctrl+G (goto) ( helps #809 )

It also closes popups directly instead of exiting the input **and then** exiting the popup (it doesn't seem to be possible to do globally per an option in imgui, see https://github.com/ocornut/imgui/issues/2620#issuecomment-501136289)