### PR TITLE
Tell users patterns are being downloaded

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -390,7 +390,9 @@ function(downloadImHexPatternsFiles dest)
             GIT_TAG master
         )
 
+        message(STATUS "Downloading ImHex patterns from branch ${PATTERNS_BRANCH}..")
         FetchContent_Populate(imhex_patterns)
+        message(STATUS "Downloaded ImHex patterns !")
 
     else ()
         # Maybe patterns are cloned to a subdirectory

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -390,9 +390,9 @@ function(downloadImHexPatternsFiles dest)
             GIT_TAG master
         )
 
-        message(STATUS "Downloading ImHex patterns from branch ${PATTERNS_BRANCH}..")
+        message(STATUS "Downloading ImHex-Patterns repo branch ${PATTERNS_BRANCH}...")
         FetchContent_Populate(imhex_patterns)
-        message(STATUS "Downloaded ImHex patterns !")
+        message(STATUS "Finished downloading ImHex-Patterns")
 
     else ()
         # Maybe patterns are cloned to a subdirectory


### PR DESCRIPTION
I've been wondering for months why configuring CMake took so long (sometimes 30secs ?), I thought users would like to know what's happening