### PR TITLE
[Feature] Ignore "Found more than one built-in plugin" if it's a debug build

### DIFF
--- a/main/source/init/tasks.cpp
+++ b/main/source/init/tasks.cpp
@@ -234,6 +234,12 @@ namespace hex::init {
         u32 loadErrors     = 0;
         for (const auto &plugin : plugins) {
             if (!plugin.isBuiltinPlugin()) continue;
+
+            #if defined(DEBUG)
+            bool isLocal = plugin.getPath().parent_path().parent_path().compare(hex::fs::getExecutablePath().value().parent_path()) == 0;
+            if (!isLocal) continue;
+            #endif
+
             builtinPlugins++;
             if (builtinPlugins > 1) continue;
 


### PR DESCRIPTION
Issue: #832

Built-in plugins coming from non-local sources are ignored now in debug builds. This allows developers to run a debug build of ImHex, while still having their normal version installed.