### PR TITLE
apply patch to appimage-builder for version parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
           sudo apt install -y python3-pip python3-setuptools desktop-file-utils libgdk-pixbuf2.0-dev fuse
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
-          sudo pip3 install appimage-builder
+          sudo pip3 install git+https://github.com/iTrooz/appimage-builder@dpkg-package-versions
 
       # Ubuntu cmake build
       - name: 🛠️ Build


### PR DESCRIPTION
Temporary fix until appimage-builder merges https://github.com/AppImageCrafters/appimage-builder/pull/281 and make a new release

Related issue : https://github.com/AppImageCrafters/appimage-builder/issues/280