### PR TITLE
do not check for writable provider to save project

### DIFF
--- a/plugins/builtin/source/content/global_actions.cpp
+++ b/plugins/builtin/source/content/global_actions.cpp
@@ -15,8 +15,10 @@ namespace hex::plugin::builtin {
     }
 
     void saveProject() {
-        if (!ProjectFile::store()) {
-            View::showErrorPopup("hex.builtin.popup.error.project.save"_lang);
+        if (ImHexApi::Provider::isValid() && ProjectFile::hasPath()) {
+            if (!ProjectFile::store()) {
+                View::showErrorPopup("hex.builtin.popup.error.project.save"_lang);
+            }
         }
     }
 

--- a/plugins/builtin/source/content/global_actions.cpp
+++ b/plugins/builtin/source/content/global_actions.cpp
@@ -1,6 +1,7 @@
 
 #include <hex/ui/view.hpp>
 #include <hex/api/project_file_manager.hpp>
+#include <hex/helpers/logger.hpp>
 
 
 namespace hex::plugin::builtin {
@@ -18,6 +19,8 @@ namespace hex::plugin::builtin {
         if (ImHexApi::Provider::isValid() && ProjectFile::hasPath()) {
             if (!ProjectFile::store()) {
                 View::showErrorPopup("hex.builtin.popup.error.project.save"_lang);
+            } else {
+                log::debug("Project saved");
             }
         }
     }

--- a/plugins/builtin/source/content/main_menu_items.cpp
+++ b/plugins/builtin/source/content/main_menu_items.cpp
@@ -77,7 +77,7 @@ namespace hex::plugin::builtin {
                 openProject();
             }
 
-            if (ImGui::MenuItem("hex.builtin.menu.file.save_project"_lang, "ALT + S", false, providerValid && provider->isWritable() && ProjectFile::hasPath())) {
+            if (ImGui::MenuItem("hex.builtin.menu.file.save_project"_lang, "ALT + S", false, providerValid && ProjectFile::hasPath())) {
                 saveProject();
             }
 


### PR DESCRIPTION
This will disable Alt+S when there is no save file set

Bonus commit to not check for a writable provider in order to save, as discussed on discord