### PR TITLE
fix: Frame rate not unlocking correctly

### DIFF
--- a/main/source/window/window.cpp
+++ b/main/source/window/window.cpp
@@ -212,6 +212,7 @@ namespace hex {
 
                 bool frameRateUnlocked = ImGui::IsPopupOpen(ImGuiID(0), ImGuiPopupFlags_AnyPopupId) || TaskManager::getRunningTaskCount() > 0 || this->m_mouseButtonDown || this->m_hadEvent || !this->m_pressedKeys.empty();
                 const double timeout = std::max(0.0, (1.0 / 5.0) - (glfwGetTime() - this->m_lastFrameTime));
+                this->m_hadEvent = false;
 
                 if ((this->m_lastFrameTime - this->m_frameRateUnlockTime) > 5 && this->m_frameRateTemporarilyUnlocked && !frameRateUnlocked) {
                     this->m_frameRateTemporarilyUnlocked = false;
@@ -239,8 +240,6 @@ namespace hex {
             }
 
             this->m_lastFrameTime = glfwGetTime();
-
-            this->m_hadEvent = false;
         }
     }
 


### PR DESCRIPTION
Repeatedly mashing a key (**not** holding it down) eventually starts to lag.

https://user-images.githubusercontent.com/25270458/212798881-120a792d-c481-4f1d-9138-12c6b6fe689e.mp4

I believe this is because m_hadEvent could be set during glfwWaitEventsTimeout and then immediately cleared before ever being checked. This patch changes the order so that m_hadEvent is preserved until the next check so that the frame rate can be unlocked. This also no longer clears m_hadEvent when the window is invisible or iconified but I'm not sure if that matters.