### PR TITLE
Fix string search missing end string

### DIFF
--- a/plugins/builtin/source/content/views/view_find.cpp
+++ b/plugins/builtin/source/content/views/view_find.cpp
@@ -253,6 +253,7 @@ namespace hex::plugin::builtin {
 
         size_t countedCharacters = 0;
         u64 startAddress = reader.begin().getAddress();
+        u64 endAddress = reader.end().getAddress();
         for (u8 byte : reader) {
             bool validChar =
                 (settings.m_lowerCaseLetters    && std::islower(byte))  ||
@@ -275,7 +276,7 @@ namespace hex::plugin::builtin {
 
             if (validChar)
                 countedCharacters++;
-            else {
+            if (!validChar || startAddress + countedCharacters == endAddress) {
                 if (countedCharacters >= size_t(settings.minLength)) {
                     if (!(settings.nullTermination && byte != 0x00)) {
                         results.push_back(Occurrence { Region { startAddress, countedCharacters }, decodeType, endian });


### PR DESCRIPTION
Before:  
![before](https://user-images.githubusercontent.com/18598419/222937056-fec74305-21a3-4bbf-a439-e8df7031bca9.png)  

After:  
![after](https://user-images.githubusercontent.com/18598419/222937069-a04cb748-4266-4fbb-8182-727bb8858329.png)  
