### PR TITLE
Display a more detailed error when opening a raw disk provider

### DIFF
--- a/lib/libimhex/include/hex/providers/provider.hpp
+++ b/lib/libimhex/include/hex/providers/provider.hpp
@@ -103,6 +103,9 @@ namespace hex::prv {
         void skipLoadInterface() { this->m_skipLoadInterface = true; }
         [[nodiscard]] bool shouldSkipLoadInterface() const { return this->m_skipLoadInterface; }
 
+        void setErrorMessage(const std::string &errorMessage) { this->m_errorMessage = errorMessage; }
+        [[nodiscard]] const std::string& getErrorMessage() const { return this->m_errorMessage; }
+
     protected:
         u32 m_currPage    = 0;
         u64 m_baseAddress = 0;
@@ -115,6 +118,8 @@ namespace hex::prv {
 
         bool m_dirty = false;
         bool m_skipLoadInterface = false;
+
+        std::string m_errorMessage;
 
     private:
         static u32 s_idCounter;

--- a/plugins/builtin/romfs/lang/base.json
+++ b/plugins/builtin/romfs/lang/base.json
@@ -335,6 +335,8 @@
   "hex.builtin.provider.disk.reload",
   "hex.builtin.provider.disk.sector_size",
   "hex.builtin.provider.disk.selected_disk",
+  "hex.builtin.provider.disk.error.read_ro",
+  "hex.builtin.provider.disk.error.read_rw",
   "hex.builtin.provider.file",
   "hex.builtin.provider.file.access",
   "hex.builtin.provider.file.creation",

--- a/plugins/builtin/romfs/lang/base.json
+++ b/plugins/builtin/romfs/lang/base.json
@@ -745,6 +745,7 @@
   "hex.builtin.view.pattern_editor.sections",
   "hex.builtin.view.pattern_editor.settings",
   "hex.builtin.view.provider_settings.load_error",
+  "hex.builtin.view.provider_settings.load_error_details",
   "hex.builtin.view.provider_settings.load_popup",
   "hex.builtin.view.provider_settings.name",
   "hex.builtin.view.settings.name",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -778,6 +778,7 @@
         "hex.builtin.view.pattern_editor.sections": "Sections",
         "hex.builtin.view.pattern_editor.settings": "Settings",
         "hex.builtin.view.provider_settings.load_error": "An error occurred while trying to open this provider!",
+        "hex.builtin.view.provider_settings.load_error_details": "An error occurred while trying to open this provider!\nDetails: {}",
         "hex.builtin.view.provider_settings.load_popup": "Open Provider",
         "hex.builtin.view.provider_settings.name": "Provider Settings",
         "hex.builtin.view.settings.name": "Settings",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -366,6 +366,8 @@
         "hex.builtin.provider.disk.reload": "Reload",
         "hex.builtin.provider.disk.sector_size": "Sector Size",
         "hex.builtin.provider.disk.selected_disk": "Disk",
+        "hex.builtin.provider.disk.error.read_ro": "Failed to open disk {} in read/write: {}",
+        "hex.builtin.provider.disk.error.read_rw": "Failed to open disk {} in read/write: {}",
         "hex.builtin.provider.file": "File Provider",
         "hex.builtin.provider.file.access": "Last access time",
         "hex.builtin.provider.file.creation": "Creation time",

--- a/plugins/builtin/source/content/providers/disk_provider.cpp
+++ b/plugins/builtin/source/content/providers/disk_provider.cpp
@@ -123,14 +123,14 @@ namespace hex::plugin::builtin {
 
             this->m_diskHandle = ::open(path.c_str(), O_RDWR);
             if (this->m_diskHandle == -1) {
-                this->setErrorMessage(hex::format("Failed to open disk {} in read/write: {}", path, ::strerror(errno)));
+                this->setErrorMessage(hex::format("hex.builtin.provider.disk.error.read_rw"_lang, path, ::strerror(errno)));
                 log::warn(this->getErrorMessage());
                 this->m_diskHandle = ::open(path.c_str(), O_RDONLY);
                 this->m_writable   = false;
             }
 
             if (this->m_diskHandle == -1) {
-                this->setErrorMessage(hex::format("Failed to open disk {} in read-only: {}", path, ::strerror(errno)));
+                this->setErrorMessage(hex::format("hex.builtin.provider.disk.error.read_ro"_lang, path, ::strerror(errno)));
                 log::warn(this->getErrorMessage());
                 this->m_readable = false;
                 return false;

--- a/plugins/builtin/source/content/providers/disk_provider.cpp
+++ b/plugins/builtin/source/content/providers/disk_provider.cpp
@@ -1,3 +1,5 @@
+#include <hex/helpers/logger.hpp>
+
 #include "content/providers/disk_provider.hpp"
 
 #include <hex/api/localization.hpp>
@@ -121,11 +123,15 @@ namespace hex::plugin::builtin {
 
             this->m_diskHandle = ::open(path.c_str(), O_RDWR);
             if (this->m_diskHandle == -1) {
+                this->setErrorMessage(hex::format("Failed to open disk {} in read/write: {}", path, ::strerror(errno)));
+                log::warn(this->getErrorMessage());
                 this->m_diskHandle = ::open(path.c_str(), O_RDONLY);
                 this->m_writable   = false;
             }
 
             if (this->m_diskHandle == -1) {
+                this->setErrorMessage(hex::format("Failed to open disk {} in read-only: {}", path, ::strerror(errno)));
+                log::warn(this->getErrorMessage());
                 this->m_readable = false;
                 return false;
             }

--- a/plugins/builtin/source/content/views/view_provider_settings.cpp
+++ b/plugins/builtin/source/content/views/view_provider_settings.cpp
@@ -41,7 +41,7 @@ namespace hex::plugin::builtin {
                     }
                     else {
                         auto errorMessage = provider->getErrorMessage();
-                        if(errorMessage.empty()) {
+                        if (errorMessage.empty()) {
                             View::showErrorPopup("hex.builtin.view.provider_settings.load_error"_lang);
                         } else {
                             View::showErrorPopup(hex::format("hex.builtin.view.provider_settings.load_error_details"_lang, errorMessage));

--- a/plugins/builtin/source/content/views/view_provider_settings.cpp
+++ b/plugins/builtin/source/content/views/view_provider_settings.cpp
@@ -40,7 +40,12 @@ namespace hex::plugin::builtin {
                         ImGui::CloseCurrentPopup();
                     }
                     else {
-                        View::showErrorPopup("hex.builtin.view.provider_settings.load_error"_lang);
+                        auto errorMessage = provider->getErrorMessage();
+                        if(errorMessage.empty()) {
+                            View::showErrorPopup("hex.builtin.view.provider_settings.load_error"_lang);
+                        } else {
+                            View::showErrorPopup(hex::format("hex.builtin.view.provider_settings.load_error_details"_lang, errorMessage));
+                        }
                         TaskManager::doLater([=] { ImHexApi::Provider::remove(provider); });
                     }
                 }


### PR DESCRIPTION
PR title is self explaining

I may modify other providers implementations to display a detailed error message later

I'm not sure how to deal with other locales because the format changed. Before, I had to add and comment the key in all locale files, now I'm not so sure.