### PR TITLE
Move config file to XDG_CONFIG_HOME

### DIFF
--- a/lib/libimhex/include/hex/helpers/fs.hpp
+++ b/lib/libimhex/include/hex/helpers/fs.hpp
@@ -48,4 +48,7 @@ namespace hex::fs {
 
     std::vector<std::fs::path> getDefaultPaths(ImHexPath path, bool listNonExisting = false);
 
+    // temporarily expose these for the migration function
+    std::vector<std::fs::path> getDataPaths();
+    std::vector<std::fs::path> appendPath(std::vector<std::fs::path> paths, const std::fs::path &folder);
 }

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -177,7 +177,7 @@ namespace hex::fs {
                 result = appendPath(getDataPaths(), "encodings");
                 break;
             case ImHexPath::Logs:
-                result = appendPath(getConfigPaths(), "logs");
+                result = appendPath(getDataPaths(), "logs");
                 break;
             case ImHexPath::Plugins:
                 result = appendPath(getPluginPaths(), "plugins");

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -73,7 +73,7 @@ namespace hex::fs {
         return result == NFD_OKAY;
     }
 
-    static std::vector<std::fs::path> getDataPaths() {
+    std::vector<std::fs::path> getDataPaths() {
         std::vector<std::fs::path> paths;
 
         #if defined(OS_WINDOWS)

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -131,17 +131,7 @@ namespace hex::fs {
         #elif defined(OS_MACOS)
             return getDataPaths();
         #elif defined(OS_LINUX)
-            std::vector<std::fs::path> paths;
-
-            paths.push_back(xdg::DataHomeDir());
-
-            auto dataDirs = xdg::DataDirs();
-            std::copy(dataDirs.begin(), dataDirs.end(), std::back_inserter(paths));
-
-            for (auto &path : paths)
-                path = path / "imhex";
-
-            return paths;
+            return {xdg::ConfigHomeDir() / "imhex"};
         #endif
     }
 

--- a/main/source/init/tasks.cpp
+++ b/main/source/init/tasks.cpp
@@ -110,6 +110,44 @@ namespace hex::init {
         return result;
     }
 
+    bool migrateConfig(){
+
+        // check if there is a new config in folder
+        auto configPaths = hex::fs::getDefaultPaths(hex::fs::ImHexPath::Config, false);
+        // There should always be exactly one config path on Linux
+        std::fs::path newConfigPath = configPaths[0];
+        wolv::io::File newConfigFile(newConfigPath / "settings.json", wolv::io::File::Mode::Read);
+        if (!newConfigFile.isValid()) {
+
+            // find an old config
+            std::fs::path oldConfigPath;
+            for(auto dir : hex::fs::appendPath(hex::fs::getDataPaths(), "config")) {
+                wolv::io::File oldConfigFile(dir / "settings.json", wolv::io::File::Mode::Read);
+                if (oldConfigFile.isValid()) {
+                    oldConfigPath = dir;
+                    break;
+                }
+            }
+
+            if (!oldConfigPath.empty()) {
+                // move it to new location
+                auto configPaths = hex::fs::getDefaultPaths(hex::fs::ImHexPath::Config, false);
+                // There should always be exactly one config path on Linux
+                std::fs::path newConfigPath = configPaths[0];
+                log::info("Found config file in {} ! Migrating to {}", oldConfigPath.string(), newConfigPath.string());
+
+                std::fs::rename(oldConfigPath / "settings.json", newConfigPath / "settings.json");
+                wolv::io::File oldIniFile(oldConfigPath / "interface.ini", wolv::io::File::Mode::Read);
+                if (oldIniFile.isValid()) {
+                    std::fs::rename(oldConfigPath / "interface.ini", newConfigPath / "interface.ini");
+                }
+
+                std::fs::remove(oldConfigPath);
+            }
+        }
+        return true;
+    }
+
     static bool loadFontsImpl(bool loadUnicode) {
         float fontSize = ImHexApi::System::getFontSize();
 
@@ -425,6 +463,7 @@ namespace hex::init {
         return {
             { "Setting up environment",  setupEnvironment,    false },
             { "Creating directories",    createDirectories,   false },
+            { "Migrate config to .config", migrateConfig,     false },
             { "Loading settings",        loadSettings,        false },
             { "Loading plugins",         loadPlugins,         false },
             { "Checking for updates",    checkForUpdates,     true  },

--- a/main/source/init/tasks.cpp
+++ b/main/source/init/tasks.cpp
@@ -463,7 +463,9 @@ namespace hex::init {
         return {
             { "Setting up environment",  setupEnvironment,    false },
             { "Creating directories",    createDirectories,   false },
+            #if defined(OS_LINUX)
             { "Migrate config to .config", migrateConfig,     false },
+            #endif
             { "Loading settings",        loadSettings,        false },
             { "Loading plugins",         loadPlugins,         false },
             { "Checking for updates",    checkForUpdates,     true  },


### PR DESCRIPTION
This pull request changes Config Directories on Linux to only include the XDG_CONFIG_HOME directory, as opposed to all directories in XDG_DATA_DIRS before (introduced in https://github.com/WerWolv/ImHex/pull/644/files#diff-c1a4d2b63fed168a9a3568944e9cadeae096f2ddcec3649e4a9b2d29fd104be0L162-L166).

Reasons:
- This changes the location of the config file to the standard directory meant for configurations
- This prevents the config file from being read/written in system locations, like /usr/share

This PR also includes a migration task that will run on Linux and move config/GUI dimensions to the new directory

as a bonus, as discussed on discord, it writes the logs to a Data directory instead of a Config directory