### PR TITLE
feat: allow loading and saving pattern code via events

### DIFF
--- a/lib/libimhex/include/hex/api/event.hpp
+++ b/lib/libimhex/include/hex/api/event.hpp
@@ -165,6 +165,8 @@ namespace hex {
     EVENT_DEF(RequestSelectionChange, Region);
     EVENT_DEF(RequestAddBookmark, Region, std::string, std::string, color_t);
     EVENT_DEF(RequestSetPatternLanguageCode, std::string);
+    EVENT_DEF(RequestLoadPatternLanguageFile, std::fs::path);
+    EVENT_DEF(RequestSavePatternLanguageFile, std::fs::path);
     EVENT_DEF(RequestUpdateWindowTitle);
     EVENT_DEF(RequestCloseImHex, bool);
     EVENT_DEF(RequestRestartImHex);

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -748,6 +748,15 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::registerEvents() {
+        EventManager::subscribe<RequestLoadPatternLanguageFile>(this, [this](const std::fs::path &path) {
+            this->loadPatternFile(path, ImHexApi::Provider::get());
+        });
+
+        EventManager::subscribe<RequestSavePatternLanguageFile>(this, [this](const std::fs::path &path) {
+            wolv::io::File file(path, wolv::io::File::Mode::Create);
+            file.writeString(wolv::util::trim(this->m_textEditor.GetText()));
+        });
+
         EventManager::subscribe<RequestSetPatternLanguageCode>(this, [this](const std::string &code) {
             this->m_textEditor.SetText(code);
         });


### PR DESCRIPTION
Currently there is no way to save the pattern code progamically from a plugin unless the builtin plugin is modified to add those events. This pull request will be adding ability to load and save pattern code from specified file.