### PR TITLE
build: Add option to disable update checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(IMHEX_PATTERNS_PULL_MASTER "Download latest files from master branch of t
 option(IMHEX_IGNORE_BAD_COMPILER "Allow compiling with an unsupported compiler" OFF)
 option(IMHEX_USE_GTK_FILE_PICKER "Use GTK file picker instead of xdg-desktop-portals" OFF)
 option(IMHEX_DISABLE_STACKTRACE "Disables support for printing stack traces" OFF)
+option(IMHEX_DISABLE_UPDATE_CHECK "Disables built-in update check" OFF)
 
 # Basic compiler and cmake configurations
 set(CMAKE_CXX_STANDARD 23)
@@ -41,7 +42,7 @@ set(PLUGINS
 # Add various defines
 detectOS()
 detectArch()
-addVersionDefines()
+addDefines()
 configurePackingResources()
 setUninstallTarget()
 addBundledLibraries()

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -9,7 +9,7 @@ if(IMHEX_STRIP_RELEASE)
     endif()
 endif()
 
-macro(addVersionDefines)
+macro(addDefines)
     if (NOT IMHEX_VERSION)
         message(FATAL_ERROR "IMHEX_VERSION is not defined")
     endif ()
@@ -71,6 +71,9 @@ macro(addVersionDefines)
 
     add_compile_definitions(IMHEX_VERSION="${IMHEX_VERSION_STRING}")
 
+    if (NOT IMHEX_DISABLE_UPDATE_CHECK)
+        add_compile_definitions(HEX_UPDATE_CHECK)
+    endif()
 endmacro()
 
 # Detect current OS / System

--- a/main/source/init/tasks.cpp
+++ b/main/source/init/tasks.cpp
@@ -30,6 +30,7 @@ namespace hex::init {
 
     using namespace std::literals::string_literals;
 
+#if defined(HEX_UPDATE_CHECK)
     static bool checkForUpdates() {
         int showCheckForUpdates = ContentRegistry::Settings::read("hex.builtin.setting.general", "hex.builtin.setting.general.check_for_updates", 2);
 
@@ -69,6 +70,7 @@ namespace hex::init {
         }
         return true;
     }
+#endif
 
     bool setupEnvironment() {
         hex::log::debug("Using romfs: '{}'", romfs::name());
@@ -475,7 +477,9 @@ namespace hex::init {
             #endif
             { "Loading settings",        loadSettings,        false },
             { "Loading plugins",         loadPlugins,         false },
+#if defined(HEX_UPDATE_CHECK)
             { "Checking for updates",    checkForUpdates,     true  },
+#endif
             { "Loading fonts",           loadFonts,           true  },
         };
     }

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -45,6 +45,7 @@ namespace hex::plugin::builtin {
         1 - check for updates on startup
         2 - default value - ask the user if he wants to check for updates. This value should only be encountered on the first startup.
         */
+#if defined(HEX_UPDATE_CHECK)
         ContentRegistry::Settings::add("hex.builtin.setting.general", "hex.builtin.setting.general.check_for_updates", 2, [](auto name, nlohmann::json &setting) {
             static bool enabled = static_cast<int>(setting) == 1;
 
@@ -55,6 +56,7 @@ namespace hex::plugin::builtin {
 
             return false;
         });
+#endif
 
         ContentRegistry::Settings::add("hex.builtin.setting.general", "hex.builtin.setting.general.show_tips", 1, [](auto name, nlohmann::json &setting) {
             static bool enabled = static_cast<int>(setting);

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -535,6 +535,7 @@ namespace hex::plugin::builtin {
                 loadDefaultLayout();
         });
 
+#if defined(HEX_UPDATE_CHECK)
         EventManager::subscribe<EventWindowInitialized>([] {
             // documentation of the value above the setting definition
             auto showCheckForUpdates = ContentRegistry::Settings::read("hex.builtin.setting.general", "hex.builtin.setting.general.check_for_updates", 2);
@@ -550,6 +551,7 @@ namespace hex::plugin::builtin {
                 );
             }
         });
+#endif
 
         // Clear project context if we go back to the welcome screen
         EventManager::subscribe<EventProviderChanged>([](hex::prv::Provider *oldProvider, hex::prv::Provider *newProvider) {


### PR DESCRIPTION
This is aimed at use by linux distros, where package updates come from a central location, and users shouldn't need to worry about updating ImHex on their own. This disables parts of the ImHex UI that would not be useful in that case.

Tested and confirmed that this works in both states of the of the `-DIMHEX_DISABLE_UPDATE_CHECK` switch.
