### PR TITLE
build, capstone: Move WASM enum values and related code into the condtional block of API >= 5 (since it was introduced then).

### DIFF
--- a/lib/libimhex/include/hex/helpers/disassembler.hpp
+++ b/lib/libimhex/include/hex/helpers/disassembler.hpp
@@ -20,9 +20,9 @@ namespace hex {
         TMS320C64X  = CS_ARCH_TMS320C64X,
         M680X       = CS_ARCH_M680X,
         EVM         = CS_ARCH_EVM,
-        WASM        = CS_ARCH_WASM,
 
         #if CS_API_MAJOR >= 5
+            WASM    = CS_ARCH_WASM,
             RISCV   = CS_ARCH_RISCV,
             MOS65XX = CS_ARCH_MOS65XX,
             BPF     = CS_ARCH_BPF,
@@ -57,9 +57,9 @@ namespace hex {
             names[CS_ARCH_TMS320C64X]   = "TMS320C64x";
             names[CS_ARCH_M680X]        = "M680X";
             names[CS_ARCH_EVM]          = "Ethereum Virtual Machine";
-            names[CS_ARCH_WASM]         = "WebAssembly";
 
             #if CS_API_MAJOR >= 5
+                names[CS_ARCH_WASM]     = "WebAssembly";
                 names[CS_ARCH_RISCV]    = "RISC-V";
                 names[CS_ARCH_MOS65XX]  = "MOS Technology 65xx";
                 names[CS_ARCH_BPF]      = "Berkeley Packet Filter";

--- a/plugins/builtin/source/content/views/view_disassembler.cpp
+++ b/plugins/builtin/source/content/views/view_disassembler.cpp
@@ -299,13 +299,13 @@ namespace hex::plugin::builtin {
                                 this->m_mode = cs_mode(mode);
                             }
                             break;
+                        case Architecture::WASM:
                         #endif
                         case Architecture::EVM:
                         case Architecture::TMS320C64X:
                         case Architecture::ARM64:
                         case Architecture::SYSZ:
                         case Architecture::XCORE:
-                        case Architecture::WASM:
                         case Architecture::MAX:
                             this->m_mode = cs_mode(0);
                             break;


### PR DESCRIPTION
This fixes build on Debian with Capstone from packages.