### PR TITLE
build: comment out `newProvider->open();` in `plugins/builtin/source/content/events.cpp`. `newProvider::open` requires return value to be used, but it is not used. 

### DIFF
--- a/plugins/builtin/source/content/events.cpp
+++ b/plugins/builtin/source/content/events.cpp
@@ -94,7 +94,7 @@ namespace hex::plugin::builtin {
                             ImHexApi::Provider::createProvider("hex.builtin.provider.file", true)
                         );
                         newProvider->setPath(path);
-                        newProvider->open();
+                        //newProvider->open();
                         if (newProvider != nullptr && !newProvider->open())
                             hex::ImHexApi::Provider::remove(newProvider);
                         else


### PR DESCRIPTION
Given that there is the same invocation nearby, I guess it is just forgotten to be removed.