### PR TITLE
Improve crash handling

### DIFF
--- a/lib/libimhex/include/hex/helpers/logger.hpp
+++ b/lib/libimhex/include/hex/helpers/logger.hpp
@@ -9,9 +9,12 @@
 #include <fmt/color.h>
 #include <fmt/chrono.h>
 
+#include <wolv/io/file.hpp>
+
 namespace hex::log {
 
     FILE *getDestination();
+    wolv::io::File& getFile();
     bool isRedirected();
 
     namespace {

--- a/lib/libimhex/source/helpers/logger.cpp
+++ b/lib/libimhex/source/helpers/logger.cpp
@@ -15,6 +15,10 @@ namespace hex::log {
             return stdout;
     }
 
+    wolv::io::File& getFile() {
+        return g_loggerFile;
+    }
+
     bool isRedirected() {
         return g_loggerFile.isValid();
     }

--- a/main/source/window/window.cpp
+++ b/main/source/window/window.cpp
@@ -53,7 +53,7 @@ namespace hex {
         
         for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Config)) {
             wolv::io::File file(path / "crash.json", wolv::io::File::Mode::Write);
-            if(file.isValid()){
+            if (file.isValid()) {
                 file.writeString(crashData.dump(4));
                 file.close();
                 log::info("Wrote crash.json file to {}", wolv::util::toUTF8String(file.getPath()));

--- a/plugins/builtin/romfs/lang/base.json
+++ b/plugins/builtin/romfs/lang/base.json
@@ -842,6 +842,7 @@
   "hex.builtin.welcome.plugins.plugin",
   "hex.builtin.popup.safety_backup.delete",
   "hex.builtin.popup.safety_backup.desc",
+  "hex.builtin.popup.safety_backup.log_file",
   "hex.builtin.popup.safety_backup.restore",
   "hex.builtin.popup.safety_backup.title",
   "hex.builtin.welcome.start.create_file",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -921,6 +921,7 @@
         "hex.builtin.welcome.plugins.plugin": "Plugin",
         "hex.builtin.popup.safety_backup.delete": "No, Delete",
         "hex.builtin.popup.safety_backup.desc": "Oh no, ImHex crashed last time.\nDo you want to restore your past work?",
+        "hex.builtin.popup.safety_backup.log_file": "Log file: ",
         "hex.builtin.popup.safety_backup.restore": "Yes, Restore",
         "hex.builtin.popup.safety_backup.title": "Restore lost data",
         "hex.builtin.welcome.start.create_file": "Create New File",

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -608,16 +608,16 @@ namespace hex::plugin::builtin {
                     crashFileData.value("logFile", ""),
                     // restore callback
                     [=]{
-                        if(hasBackupFile){
+                        if (hasBackupFile) {
                             ProjectFile::load(backupFilePath);
-                            if(hasProject){
+                            if (hasProject) {
                                 ProjectFile::setPath(std::fs::path(crashFileData["project"]));
-                            }else{
+                            } else {
                                 ProjectFile::setPath("");
                             }
                             EventManager::post<RequestUpdateWindowTitle>();
                         }else{
-                            if(hasProject){
+                            if (hasProject) {
                                 ProjectFile::setPath(std::fs::path(crashFileData["project"]));
                             }
                         }
@@ -633,7 +633,7 @@ namespace hex::plugin::builtin {
 
         // Tip of the day
         auto tipsData = romfs::get("tips.json");
-        if(!hasCrashed && tipsData.valid()){
+        if (!hasCrashed && tipsData.valid()) {
             auto tipsCategories = nlohmann::json::parse(tipsData.string());
 
             auto now = std::chrono::system_clock::now();

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -78,7 +78,7 @@ namespace hex::plugin::builtin {
         void drawContent() override {
             ImGui::TextUnformatted("hex.builtin.popup.safety_backup.desc"_lang);
             if (!this->m_logFilePath.empty()) {
-                ImGui::TextUnformatted("Log file: ");
+                ImGui::TextUnformatted("hex.builtin.popup.safety_backup.log_file"_lang);
                 if (ImGui::Hyperlink(this->m_logFilePath.filename().string().c_str())) {
                     fs::openFolderWithSelectionExternal(this->m_logFilePath);
                 }

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -611,14 +611,14 @@ namespace hex::plugin::builtin {
                         if (hasBackupFile) {
                             ProjectFile::load(backupFilePath);
                             if (hasProject) {
-                                ProjectFile::setPath(std::fs::path(crashFileData["project"]));
+                                ProjectFile::setPath(crashFileData["project"].get<std::string>());
                             } else {
                                 ProjectFile::setPath("");
                             }
                             EventManager::post<RequestUpdateWindowTitle>();
                         }else{
                             if (hasProject) {
-                                ProjectFile::setPath(std::fs::path(crashFileData["project"]));
+                                ProjectFile::setPath(crashFileData["project"].get<std::string>());
                             }
                         }
                     },

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -64,30 +64,39 @@ namespace hex::plugin::builtin {
     };
 
     class PopupRestoreBackup : public Popup<PopupRestoreBackup> {
+    private:
+        std::fs::path m_logFilePath;
+        std::function<void()> m_restoreCallback;
+        std::function<void()> m_deleteCallback;
     public:
-        PopupRestoreBackup() : Popup("hex.builtin.popup.safety_backup.title") { }
+        PopupRestoreBackup(std::fs::path logFilePath, std::function<void()> restoreCallback, std::function<void()> deleteCallback)
+                : Popup("hex.builtin.popup.safety_backup.title"),
+                m_logFilePath(logFilePath),
+                m_restoreCallback(restoreCallback),
+                m_deleteCallback(deleteCallback) { }
 
         void drawContent() override {
             ImGui::TextUnformatted("hex.builtin.popup.safety_backup.desc"_lang);
-            ImGui::NewLine();
-
+            if (!this->m_logFilePath.empty()) {
+                ImGui::TextUnformatted("Log file: ");
+                if (ImGui::Hyperlink(this->m_logFilePath.filename().string().c_str())) {
+                    fs::openFolderWithSelectionExternal(this->m_logFilePath);
+                }
+                ImGui::NewLine();
+            }
+        
             auto width = ImGui::GetWindowWidth();
             ImGui::SetCursorPosX(width / 9);
             if (ImGui::Button("hex.builtin.popup.safety_backup.restore"_lang, ImVec2(width / 3, 0))) {
-                ProjectFile::load(s_safetyBackupPath);
-                ProjectFile::clearPath();
-
-                for (const auto &provider : ImHexApi::Provider::getProviders())
-                    provider->markDirty();
-
-                wolv::io::fs::remove(s_safetyBackupPath);
+                this->m_restoreCallback();
+                this->m_deleteCallback();
 
                 this->close();
             }
             ImGui::SameLine();
             ImGui::SetCursorPosX(width / 9 * 5);
             if (ImGui::Button("hex.builtin.popup.safety_backup.delete"_lang, ImVec2(width / 3, 0))) {
-                wolv::io::fs::remove(s_safetyBackupPath);
+                this->m_deleteCallback();
 
                 this->close();
             }
@@ -577,17 +586,54 @@ namespace hex::plugin::builtin {
         });
 
         // Check for crash backup
-        constexpr static auto CrashBackupFileName = "crash_backup.hexproj";
+        constexpr static auto CrashFileName = "crash.json";
+        constexpr static auto BackupFileName = "crash_backup.hexproj";
+        bool hasCrashed = false;
+
         for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Config)) {
-            if (auto filePath = std::fs::path(path) / CrashBackupFileName; wolv::io::fs::exists(filePath)) {
-                s_safetyBackupPath = filePath;
-                PopupRestoreBackup::open();
+            if (auto crashFilePath = std::fs::path(path) / CrashFileName; wolv::io::fs::exists(crashFilePath)) {
+                hasCrashed = true;
+                
+                log::info("Found crash.json file at {}", wolv::util::toUTF8String(crashFilePath));
+                wolv::io::File crashFile(crashFilePath, wolv::io::File::Mode::Read);
+                auto crashFileData = nlohmann::json::parse(crashFile.readString());
+                crashFile.close();
+                bool hasProject = !crashFileData.value("project", "").empty();
+
+                auto backupFilePath = path / BackupFileName;
+                bool hasBackupFile = wolv::io::fs::exists(backupFilePath);
+                
+                PopupRestoreBackup::open(
+                    // path of log file
+                    crashFileData.value("logFile", ""),
+                    // restore callback
+                    [=]{
+                        if(hasBackupFile){
+                            ProjectFile::load(backupFilePath);
+                            if(hasProject){
+                                ProjectFile::setPath(std::fs::path(crashFileData["project"]));
+                            }else{
+                                ProjectFile::setPath("");
+                            }
+                            EventManager::post<RequestUpdateWindowTitle>();
+                        }else{
+                            if(hasProject){
+                                ProjectFile::setPath(std::fs::path(crashFileData["project"]));
+                            }
+                        }
+                    },
+                    // delete callback (also executed after restore)
+                    [crashFilePath, backupFilePath]{
+                        wolv::io::fs::remove(crashFilePath);
+                        wolv::io::fs::remove(backupFilePath);
+                    }
+                );
             }
         }
 
         // Tip of the day
         auto tipsData = romfs::get("tips.json");
-        if(s_safetyBackupPath.empty() && tipsData.valid()){
+        if(!hasCrashed && tipsData.valid()){
             auto tipsCategories = nlohmann::json::parse(tipsData.string());
 
             auto now = std::chrono::system_clock::now();


### PR DESCRIPTION
- Add a new file 'crash.json' to store metadata about the crash, like the log file or project opened
- show the log file of the session that caused the crash to the user
- Correctly restore the project path