### PR TITLE
remove fedora 36 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,10 +482,6 @@ jobs:
             mock_release: f37
             release_num: 37
             mock_config: fedora-37
-          - name: Fedora
-            mock_release: f36
-            release_num: 36
-            mock_config: fedora-36
           - name: RHEL-AlmaLinux
             mock_release: epel9
             release_num: 9


### PR DESCRIPTION
Fedora 36 is EOL.

Build roots for it were taken offline this morning so builds against it will fail now.