### PR TITLE
Do not loop over 'END' ImHexPath

### DIFF
--- a/plugins/builtin/source/content/views/view_about.cpp
+++ b/plugins/builtin/source/content/views/view_about.cpp
@@ -148,7 +148,7 @@ namespace hex::plugin::builtin {
             ImGui::TableSetupColumn("Type");
             ImGui::TableSetupColumn("Paths");
 
-            constexpr static std::array<std::pair<const char *, fs::ImHexPath>, u32(fs::ImHexPath::END)> PathTypes = {
+            constexpr static std::array<std::pair<const char *, fs::ImHexPath>, u32(fs::ImHexPath::END)-1> PathTypes = {
                 {
                     { "Patterns", fs::ImHexPath::Patterns },
                     { "Patterns Includes", fs::ImHexPath::PatternsInclude },


### PR DESCRIPTION
Really small issue, in Help->About->Imhex directories, there would be an extra entry at the end because you seemed to loop over the fs::ImHexPath::END entry