### PR TITLE
explicitely convert std::fs::path to std::string

### DIFF
--- a/plugins/builtin/source/content/recent.cpp
+++ b/plugins/builtin/source/content/recent.cpp
@@ -68,7 +68,7 @@ namespace hex::plugin::builtin::recent {
                     nlohmann::json recentEntry {
                         {"type", "project"},
                         {"displayName", displayName},
-                        {"path", ProjectFile::getPath()}
+                        {"path", wolv::util::toUTF8String(ProjectFile::getPath())}
                     };
 
                     recentFile.writeString(recentEntry.dump(4));


### PR DESCRIPTION
This should fix the current crash when opening a project on Windows