### PR TITLE
Various fixes for visualization functions.

### DIFF
--- a/plugins/builtin/source/content/pl_visualizers.cpp
+++ b/plugins/builtin/source/content/pl_visualizers.cpp
@@ -49,12 +49,11 @@ namespace hex::plugin::builtin {
 
             if (ImPlot::BeginPlot("##plot", ImVec2(400, 250), ImPlotFlags_NoChild | ImPlotFlags_CanvasOnly)) {
 
+                ImPlot::SetupAxes("X", "Y", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
                 if (shouldReset) {
                     values.clear();
                     values = sampleData(patternToArray<float>(dataPattern), ImPlot::GetPlotSize().x * 4);
                 }
-
-                ImPlot::SetupAxes("X", "Y", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
 
                 ImPlot::PlotLine("##line", values.data(), values.size());
 
@@ -70,13 +69,13 @@ namespace hex::plugin::builtin {
 
             if (ImPlot::BeginPlot("##plot", ImVec2(400, 250), ImPlotFlags_NoChild | ImPlotFlags_CanvasOnly)) {
 
+                ImPlot::SetupAxes("X", "Y", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
+
                 if (shouldReset) {
                     xValues.clear(); yValues.clear();
                     xValues = sampleData(patternToArray<float>(xPattern), ImPlot::GetPlotSize().x * 4);
                     yValues = sampleData(patternToArray<float>(yPattern), ImPlot::GetPlotSize().x * 4);
                 }
-
-                ImPlot::SetupAxes("X", "Y", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
 
                 ImPlot::PlotScatter("##scatter", xValues.data(), yValues.data(), xValues.size());
 

--- a/plugins/builtin/source/ui/pattern_drawer.cpp
+++ b/plugins/builtin/source/ui/pattern_drawer.cpp
@@ -228,6 +228,40 @@ namespace hex::plugin::builtin::ui {
         }
     }
 
+    void PatternDrawer::drawValueColumn(pl::ptrn::Pattern& pattern) {
+        const auto value = pattern.getFormattedValue();
+
+        const auto width = ImGui::GetColumnWidth();
+        if (const auto &arguments = pattern.getAttributeArguments("hex::visualize"); !arguments.empty()) {
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+            ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0.5F));
+            if (ImGui::Button(hex::format("{}  {}", ICON_VS_EYE_WATCH, value).c_str(), ImVec2(width, ImGui::GetTextLineHeight()))) {
+                this->m_currVisualizedPattern = &pattern;
+                this->m_lastVisualizerError.clear();
+
+                ImGui::OpenPopup("Visualizer");
+            }
+            ImGui::PopStyleVar(2);
+
+            ImGui::SameLine();
+
+            if (ImGui::BeginPopup("Visualizer")) {
+                if (this->m_currVisualizedPattern == &pattern) {
+                    drawVisualizer(arguments, pattern, dynamic_cast<pl::ptrn::IIterable&>(pattern), !this->m_visualizedPatterns.contains(&pattern));
+                    this->m_visualizedPatterns.insert(&pattern);
+                }
+
+                ImGui::EndPopup();
+            }
+        } else {
+            ImGui::TextFormatted("{}", value);
+        }
+
+        if (ImGui::CalcTextSize(value.c_str()).x > width) {
+            ImGui::InfoTooltip(value.c_str());
+        }
+    }
+
 
     void PatternDrawer::createLeafNode(const pl::ptrn::Pattern& pattern) {
         ImGui::TreeNodeEx(pattern.getDisplayName().c_str(), ImGuiTreeNodeFlags_Leaf |

--- a/plugins/builtin/source/ui/pattern_drawer.cpp
+++ b/plugins/builtin/source/ui/pattern_drawer.cpp
@@ -203,8 +203,12 @@ namespace hex::plugin::builtin::ui {
     void PatternDrawer::drawVisualizerButton(pl::ptrn::Pattern& pattern, pl::ptrn::IIterable &iteratable) {
         if (const auto &arguments = pattern.getAttributeArguments("hex::visualize"); !arguments.empty()) {
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+            auto shouldReset = false;
             if (ImGui::IconButton(ICON_VS_EYE, ImGui::GetStyleColorVec4(ImGuiCol_Text), ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeight()))) {
+                auto oldPattern = this->m_currVisualizedPattern;
                 this->m_currVisualizedPattern = &pattern;
+                if(this->m_currVisualizedPattern != oldPattern)
+                    shouldReset = true;
                 this->m_lastVisualizerError.clear();
 
                 ImGui::OpenPopup("Visualizer");
@@ -215,7 +219,7 @@ namespace hex::plugin::builtin::ui {
 
             if (ImGui::BeginPopup("Visualizer")) {
                 if (this->m_currVisualizedPattern == &pattern) {
-                    drawVisualizer(arguments, pattern, iteratable, !this->m_visualizedPatterns.contains(&pattern));
+                    drawVisualizer(arguments, pattern, iteratable, !this->m_visualizedPatterns.contains(&pattern) || shouldReset);
                     this->m_visualizedPatterns.insert(&pattern);
                 }
 


### PR DESCRIPTION
I created a data set and a small pattern to expose the problems this PR fixes. The input data are just the integers from zero to seven in floating point. 

```
00 00 00 00 00 00 80 BF 00 00 00 40 00 00 40 40 
00 00 80 40 00 00 A0 40 00 00 C0 40 00 00 E0 40
```

The pattern opens two line plots and two scatter plots that look different or at least they should. 

```cpp
struct Line {
 float value[4];
} [[hex::visualize("line_plot",value)]];

Line line1 @ 0;
Line line2 @ 0x10;

struct Plot {
   float x[4];
   float y[4];
} [[hex::visualize("scatter_plot",x,y)]];

struct SPlot {
    Plot p;
}[[hex::visualize("scatter_plot",p.y,p.x)]];

SPlot plot @ 0;
```

But before that try running ImHex in debug mode. In particular make sure that the ImGui assertions are not disabled. If you click on any of the visualizer icons then ImHex should crash. The reason is that functions like ImPlot::GetPlotSize() are Setup Locking functions (they call SetupLock() so that the setup functions cannot be called after them) and must be called after calling functions like ImPlot::SetupAxes that check if setup is locked and  fail the assert if it is locked. I think this affects only line plots and scatter plots based on a visual inspection of the code as I don't have the input data they need. The changes to fix the first two are in pl_visualizers.cpp and they need to be applied first if you are on a debug build.

For the second error run the pattern on the data and open both line plots or both scatter plots (the test is done in pairs of plots of the same kind). After the second one  is open, clicking on any of the two visualizer buttons shows always  the same result unless the pattern is evaluated again. The reason for this is that should_reset is only set to true when the pattern is evaluated or the visualized sub-pattern is displayed for the first time. 

After all of the displays of the same type have been opened should_reset remains false and the data doesn't change according to the button that is pressed. This problem occurs in every visualizer I have tested. I implemented a way to remember the previous sub-pattern that was clicked so that should_reset is only set to true when the new sub-pattern is not the same as the old sub-pattern. If there is only one pattern then no matter how many times is pressed nothing is updated  just like it did before. Also the data is reset if and only if it is absolutely necessary to do so. The fix applies to all visualizers equally because it is necessary to do so.
