### PR TITLE
Remove `m_grayZeroHighlighter` from `hex::plugin::builtin::ui::HexEditor` from `plugins/builtin/include/ui/hex_editor.hpp`

### DIFF
--- a/plugins/builtin/include/ui/hex_editor.hpp
+++ b/plugins/builtin/include/ui/hex_editor.hpp
@@ -193,7 +193,6 @@ namespace hex::plugin::builtin::ui {
 
         u16 m_bytesPerRow = 16;
         ContentRegistry::HexEditor::DataVisualizer *m_currDataVisualizer;
-        u32 m_grayZeroHighlighter = 0;
         char m_unknownDataCharacter = '?';
 
         bool m_shouldJumpToSelection = false;


### PR DESCRIPTION
Fixes `error: private field 'm_grayZeroHighlighter' is not used [-Werror,-Wunused-private-field]`