### PR TITLE
do not create file if it doesn't exist when trying to open file provider

### DIFF
--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -205,6 +205,11 @@ namespace hex::plugin::builtin {
         this->m_readable = true;
         this->m_writable = true;
 
+        if (!std::fs::exists(this->m_path)) {
+            this->setErrorMessage(hex::format("hex.builtin.provider.file.error.open"_lang, this->m_path.string(), ::strerror(ENOENT)));
+            return false;
+        }
+
         wolv::io::File file(this->m_path, wolv::io::File::Mode::Write);
         if (!file.isValid()) {
             this->m_writable = false;


### PR DESCRIPTION
Draft until I also do it for project loading, just in case I change my mind about the strategy