### PR TITLE
Fix full recompilation when commit hash has changed

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -15,11 +15,6 @@ macro(addDefines)
     endif ()
 
     if (DEFINED GIT_COMMIT_HASH_LONG AND DEFINED GIT_COMMIT_HASH_SHORT AND DEFINED GIT_COMMIT_BRANCH)
-        add_compile_definitions(
-                GIT_COMMIT_HASH_LONG="${GIT_COMMIT_HASH_LONG}"
-                GIT_COMMIT_HASH_SHORT="${GIT_COMMIT_HASH_SHORT}"
-                GIT_BRANCH="${GIT_COMMIT_BRANCH}"
-        )
     else()
         # Get the current working branch
         execute_process(
@@ -46,13 +41,6 @@ macro(addDefines)
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 RESULT_VARIABLE RESULT_HASH_LONG
         )
-
-        if (RESULT_BRANCH EQUAL 0 AND RESULT_HASH_LONG EQUAL 0 AND RESULT_HASH_SHORT EQUAL 0)
-            add_compile_definitions(
-                    GIT_COMMIT_HASH_SHORT="${GIT_COMMIT_HASH_SHORT}"
-                    GIT_COMMIT_HASH_LONG="${GIT_COMMIT_HASH_LONG}"
-                    GIT_BRANCH="${GIT_BRANCH}")
-        endif ()
     endif ()
 
     set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -DPROJECT_VERSION_MAJOR=${PROJECT_VERSION_MAJOR} -DPROJECT_VERSION_MINOR=${PROJECT_VERSION_MINOR} -DPROJECT_VERSION_PATCH=${PROJECT_VERSION_PATCH} ")
@@ -78,6 +66,16 @@ macro(addDefines)
         add_compile_definitions(HEX_UPDATE_CHECK)
     endif()
 endmacro()
+
+function(addVersionMacrodefsToSources)
+    foreach(p GIT_BRANCH="${GIT_BRANCH}" GIT_COMMIT_HASH_LONG="${GIT_COMMIT_HASH_LONG}" GIT_COMMIT_HASH_SHORT="${GIT_COMMIT_HASH_SHORT}")
+        set_property(
+            SOURCE ${ARGN}
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS "${p}"
+        )
+    endforeach()
+endfunction()
 
 # Detect current OS / System
 macro(detectOS)

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -14,11 +14,11 @@ macro(addDefines)
         message(FATAL_ERROR "IMHEX_VERSION is not defined")
     endif ()
 
-    if (DEFINED IMHEX_COMMIT_HASH_LONG AND DEFINED IMHEX_COMMIT_HASH_SHORT AND DEFINED IMHEX_COMMIT_BRANCH)
+    if (DEFINED GIT_COMMIT_HASH_LONG AND DEFINED GIT_COMMIT_HASH_SHORT AND DEFINED GIT_COMMIT_BRANCH)
         add_compile_definitions(
-                GIT_COMMIT_HASH_LONG="${IMHEX_COMMIT_HASH_LONG}"
-                IMHEX_COMMIT_HASH_SHORT="${IMHEX_COMMIT_HASH_SHORT}"
-                GIT_BRANCH="${IMHEX_COMMIT_BRANCH}"
+                GIT_COMMIT_HASH_LONG="${GIT_COMMIT_HASH_LONG}"
+                GIT_COMMIT_HASH_SHORT="${GIT_COMMIT_HASH_SHORT}"
+                GIT_BRANCH="${GIT_COMMIT_BRANCH}"
         )
     else()
         # Get the current working branch

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(main ${APPLICATION_TYPE}
     ${IMHEX_ICON}
 )
 
+addVersionMacrodefsToSources(source/main.cpp source/init/splash_window.cpp)
+
 target_include_directories(main PUBLIC include)
 setupCompilerWarnings(main)
 

--- a/plugins/builtin/CMakeLists.txt
+++ b/plugins/builtin/CMakeLists.txt
@@ -65,6 +65,8 @@ add_library(${PROJECT_NAME} SHARED
         source/ui/pattern_drawer.cpp
 )
 
+addVersionMacrodefsToSources(source/content/communication_interface.cpp source/content/views/view_about.cpp)
+
 # Add additional include directories here #
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 


### PR DESCRIPTION
### Problem description
The current approach adds the macrodefs to the most of compilation calls. This causes full recompilation on change of commit hash and/or branch.

### Implementation description
This PR
1. fixes some mistakes in variable names discovered when implementing .2
2. adds the macrodefs only to the compilation calls of the files using them. Its allows `ninja` to bypass the recompilation when it is not really needed.

### Additional things
This can be optimized further by generating a `.c` file with the git-dependent constants only and having a header for them, and just linking the compiled object file. But it is a bigger refactoring, since it introduces a header file. I prefer not to do bigger refactorings myself, maintainers love to just reject them with the reasons like "I can live without that".
