### PR TITLE
Fixes for console scrolling

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -952,7 +952,7 @@ namespace hex::plugin::builtin {
                     }
 
                     this->m_console->emplace_back(line);
-                    this->m_consoleNeedsUpdate = true;
+                    //this->m_consoleNeedsUpdate = true;
                 }
             });
 


### PR DESCRIPTION
Since this function is evaluated every frame setting the draw console… to true here breaks the console scrolling. I'm not sure if the variable needs to be reset somewhere else so i am leaving it commented for now.


### Problem description
the console window cant be scrolled to the bottom

### Implementation description
line commented until told it is ok to delete


