### PR TITLE
Use execvp() instead of system() on Linux 

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBIMHEX_SOURCES
         source/data_processor/node.cpp
 
         source/helpers/utils.cpp
+        source/helpers/utils_linux.cpp
         source/helpers/fs.cpp
         source/helpers/magic.cpp
         source/helpers/crypto.cpp

--- a/lib/libimhex/include/hex/helpers/utils_linux.hpp
+++ b/lib/libimhex/include/hex/helpers/utils_linux.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(OS_LINUX)
+
+namespace hex {
+    void executeCmd(const std::vector<std::string> &argsVector);
+}
+
+#endif

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -4,6 +4,7 @@
 #include <hex/api/project_file_manager.hpp>
 #include <hex/helpers/logger.hpp>
 #include <hex/helpers/fmt.hpp>
+#include <hex/helpers/utils_linux.hpp>
 
 #include <xdg.hpp>
 
@@ -43,9 +44,7 @@ namespace hex::fs {
                 hex::format("open {}", wolv::util::toUTF8String(filePath)).c_str()
             ));
         #elif defined(OS_LINUX)
-            hex::unused(system(
-                hex::format("xdg-open {}", wolv::util::toUTF8String(filePath)).c_str()
-            ));
+            executeCmd({"xdg-open", wolv::util::toUTF8String(filePath)});
         #endif
     }
 
@@ -62,9 +61,7 @@ namespace hex::fs {
                 hex::format("open {}", wolv::util::toUTF8String(dirPath)).c_str()
             ));
         #elif defined(OS_LINUX)
-            hex::unused(system(
-                hex::format("xdg-open {}", wolv::util::toUTF8String(dirPath)).c_str()
-            ));
+            executeCmd({"xdg-open", wolv::util::toUTF8String(dirPath)});
         #endif
     }
 
@@ -87,9 +84,7 @@ namespace hex::fs {
         #elif defined(OS_LINUX)
             // fallback to only opening the folder for now
             // TODO actually select the file
-            hex::unused(system(
-                hex::format("xdg-open {}", wolv::util::toUTF8String(selectedFilePath.parent_path())).c_str()
-            ));
+            executeCmd({"xdg-open", wolv::util::toUTF8String(selectedFilePath.parent_path())});
         #endif
     }
 

--- a/lib/libimhex/source/helpers/utils.cpp
+++ b/lib/libimhex/source/helpers/utils.cpp
@@ -8,6 +8,7 @@
 
 #include <hex/helpers/fmt.hpp>
 #include <hex/helpers/crypto.hpp>
+#include <hex/helpers/utils_linux.hpp>
 
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -313,14 +314,12 @@ namespace hex {
     void runCommand(const std::string &command) {
 
         #if defined(OS_WINDOWS)
-            auto result = system(hex::format("start {0}", command).c_str());
+            hex::unused(system(hex::format("start {0}", command).c_str()));
         #elif defined(OS_MACOS)
-            auto result = system(hex::format("open {0}", command).c_str());
+            hex::unused(system(hex::format("open {0}", command).c_str()));
         #elif defined(OS_LINUX)
-            auto result = system(hex::format("xdg-open {0}", command).c_str());
+            executeCmd({"xdg-open", command});
         #endif
-
-        hex::unused(result);
     }
 
     void openWebpage(std::string url) {
@@ -332,8 +331,7 @@ namespace hex {
         #elif defined(OS_MACOS)
             openWebpageMacos(url.c_str());
         #elif defined(OS_LINUX)
-            auto result = system(hex::format("xdg-open {0}", url).c_str());
-            hex::unused(result);
+            executeCmd({"xdg-open", url});
         #else
             #warning "Unknown OS, can't open webpages"
         #endif

--- a/lib/libimhex/source/helpers/utils_linux.cpp
+++ b/lib/libimhex/source/helpers/utils_linux.cpp
@@ -1,0 +1,27 @@
+#if defined(OS_LINUX)
+
+#include<hex/helpers/logger.hpp>
+
+#include<vector>
+#include<string>
+#include<unistd.h>
+
+namespace hex {
+
+    void executeCmd(const std::vector<std::string> &argsVector) {
+        std::vector<char*> cArgsVector;
+        for (const auto &str : argsVector) {
+            cArgsVector.push_back(const_cast<char*>(str.c_str()));
+        }
+        cArgsVector.push_back(nullptr);
+        
+        if (fork() == 0) {
+            execvp(cArgsVector[0], &cArgsVector[0]);
+            log::error("execvp() failed: {}", strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+    }
+
+}
+
+#endif

--- a/main/source/window/linux_window.cpp
+++ b/main/source/window/linux_window.cpp
@@ -7,6 +7,7 @@
     #include <hex/api/event.hpp>
 
     #include <hex/helpers/utils.hpp>
+    #include <hex/helpers/utils_linux.hpp>
     #include <hex/helpers/logger.hpp>
 
     #include <wolv/utils/core.hpp>
@@ -35,20 +36,6 @@ namespace hex {
             }
         }
         return false;
-    }
-
-    void executeCmd(const std::vector<std::string> &argsVector) {
-        std::vector<char*> cArgsVector;
-        for (const auto &str : argsVector) {
-            cArgsVector.push_back(const_cast<char*>(str.c_str()));
-        }
-        cArgsVector.push_back(nullptr);
-        
-        if (fork() == 0) {
-            execvp(cArgsVector[0], &cArgsVector[0]);
-            log::error("execvp() failed: {}", strerror(errno));
-            exit(EXIT_FAILURE);
-        }
     }
 
     void nativeErrorMessage(const std::string &message) {


### PR DESCRIPTION
This PR it just a hack to fix #1160 , it doesn't solve the underlying problem.

It fixes the problem because by using execvp() directly, it avoids the call to `sh` done with `system()`, which has a bug on Ubuntu 22.04 which makes it i,compatibles with the glibc inside the AppImage.
It doesn't fix the underlying problem because the programs we call themselves still link to the AppImage's libraries instead of the system ones.