### PR TITLE
reset terminate handler directly when being called + some other crashes to crash handling

### DIFF
--- a/lib/libimhex/include/hex/api/project_file_manager.hpp
+++ b/lib/libimhex/include/hex/api/project_file_manager.hpp
@@ -47,7 +47,7 @@ namespace hex {
          */
         static void setProjectFunctions(
             const std::function<bool(const std::fs::path&)> &loadFun,
-            const std::function<bool(std::optional<std::fs::path>)> &storeFun
+            const std::function<bool(std::optional<std::fs::path>, bool)> &storeFun
         );
 
         /**
@@ -63,10 +63,11 @@ namespace hex {
          * @brief Store a project file
          *
          * @param filePath Path to the project file
+         * @param updateLocation update the project location so subssequent saves will save there
          * @return true if the project file was stored successfully
          * @return false if the project file was not stored successfully
          */
-        static bool store(std::optional<std::fs::path> filePath = std::nullopt);
+        static bool store(std::optional<std::fs::path> filePath = std::nullopt, bool updateLocation = true);
 
         /**
          * @brief Check if a project file is currently loaded
@@ -131,7 +132,7 @@ namespace hex {
         ProjectFile() = default;
 
         static std::function<bool(const std::fs::path&)> s_loadProjectFunction;
-        static std::function<bool(std::optional<std::fs::path>)> s_storeProjectFunction;
+        static std::function<bool(std::optional<std::fs::path>, bool)> s_storeProjectFunction;
 
         static std::fs::path s_currProjectPath;
         static std::vector<Handler> s_handlers;

--- a/lib/libimhex/source/api/project_file_manager.cpp
+++ b/lib/libimhex/source/api/project_file_manager.cpp
@@ -17,11 +17,11 @@ namespace hex {
     std::fs::path ProjectFile::s_currProjectPath;
 
     std::function<bool(const std::fs::path&)> ProjectFile::s_loadProjectFunction;
-    std::function<bool(std::optional<std::fs::path>)> ProjectFile::s_storeProjectFunction;
+    std::function<bool(std::optional<std::fs::path>, bool)> ProjectFile::s_storeProjectFunction;
 
     void ProjectFile::setProjectFunctions(
             const std::function<bool(const std::fs::path&)> &loadFun,
-            const std::function<bool(std::optional<std::fs::path>)> &storeFun
+            const std::function<bool(std::optional<std::fs::path>, bool)> &storeFun
     ) {
         ProjectFile::s_loadProjectFunction = loadFun;
         ProjectFile::s_storeProjectFunction = storeFun;
@@ -31,8 +31,8 @@ namespace hex {
       return s_loadProjectFunction(filePath);
     }
 
-    bool ProjectFile::store(std::optional<std::fs::path> filePath) {
-       return s_storeProjectFunction(filePath);
+    bool ProjectFile::store(std::optional<std::fs::path> filePath, bool updateLocation) {
+       return s_storeProjectFunction(filePath, updateLocation);
     }
 
     bool ProjectFile::hasPath() {

--- a/main/source/crash_handlers.cpp
+++ b/main/source/crash_handlers.cpp
@@ -72,8 +72,6 @@ namespace hex::crash {
         printStackTrace();
         
         // Trigger an event so that plugins can handle crashes
-        // It may affect things (like the project path),
-        // so we do this after saving the crash file
         EventManager::post<EventAbnormalTermination>(signalNumber);
     }
 
@@ -151,7 +149,7 @@ namespace hex::crash {
                     ImGui::SaveIniSettingsToDisk(wolv::util::toUTF8String(imguiSettingsPath).c_str());
 
                 for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Config)) {
-                    if (ProjectFile::store(path / CrashBackupFileName))
+                    if (ProjectFile::store(path / CrashBackupFileName, false))
                         break;
                 }
             });

--- a/main/source/crash_handlers.cpp
+++ b/main/source/crash_handlers.cpp
@@ -114,6 +114,9 @@ namespace hex::crash {
         }
 
         originalHandler = std::set_terminate([]{
+            // Restore the original handler of C++ std
+            std::set_terminate(originalHandler);
+
             try {
                 std::rethrow_exception(std::current_exception());
             } catch (std::exception &ex) {
@@ -129,9 +132,6 @@ namespace hex::crash {
 
                 // Reset signal handlers prior to calling the original handler, because it may raise a signal
                 for(auto signal : Signals) std::signal(signal, SIG_DFL);
-
-                // Restore the original handler of C++ std
-                std::set_terminate(originalHandler);
 
                 #if defined(DEBUG)
                     assert(!"Debug build, triggering breakpoint");

--- a/main/source/crash_handlers.cpp
+++ b/main/source/crash_handlers.cpp
@@ -131,7 +131,7 @@ namespace hex::crash {
                     handleCrash(hex::format("Uncaught exception: {}", exceptionStr), 0);
 
                     // Reset signal handlers prior to calling the original handler, because it may raise a signal
-                    for(auto signal : Signals) std::signal(signal, SIG_DFL);
+                    for (auto signal : Signals) std::signal(signal, SIG_DFL);
 
                     #if defined(DEBUG)
                         assert(!"Debug build, triggering breakpoint");

--- a/main/source/crash_handlers.cpp
+++ b/main/source/crash_handlers.cpp
@@ -143,15 +143,18 @@ namespace hex::crash {
         // We need to save the project no mater if it is dirty,
         // because this save is responsible for telling us which files
         // were opened in case there wasn't a project
-        EventManager::subscribe<EventAbnormalTermination>([](int) {
-            auto imguiSettingsPath = hex::getImGuiSettingsPath();
-            if (!imguiSettingsPath.empty())
-                ImGui::SaveIniSettingsToDisk(wolv::util::toUTF8String(imguiSettingsPath).c_str());
+        // Only do it when ImHex has finished its loading
+        EventManager::subscribe<EventImHexStartupFinished>([] {
+            EventManager::subscribe<EventAbnormalTermination>([](int) {
+                auto imguiSettingsPath = hex::getImGuiSettingsPath();
+                if (!imguiSettingsPath.empty())
+                    ImGui::SaveIniSettingsToDisk(wolv::util::toUTF8String(imguiSettingsPath).c_str());
 
-            for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Config)) {
-                if (ProjectFile::store(path / CrashBackupFileName))
-                    break;
-            }
+                for (const auto &path : fs::getDefaultPaths(fs::ImHexPath::Config)) {
+                    if (ProjectFile::store(path / CrashBackupFileName))
+                        break;
+                }
+            });
         });
 
         EventManager::subscribe<EventImHexStartupFinished>([]{

--- a/plugins/builtin/source/content/project.cpp
+++ b/plugins/builtin/source/content/project.cpp
@@ -107,7 +107,7 @@ namespace hex::plugin::builtin {
         return true;
     }
     
-    bool store(std::optional<std::fs::path> filePath = std::nullopt) {
+    bool store(std::optional<std::fs::path> filePath = std::nullopt, bool updateLocation = true) {
         auto originalPath = ProjectFile::getPath();
 
         if (!filePath.has_value())
@@ -155,7 +155,11 @@ namespace hex::plugin::builtin {
         }
 
         ImHexApi::Provider::resetDirty();
-        resetPath.release();
+
+        // if saveLocation is false, reset the project path (do not release the lock)
+        if(updateLocation) {
+            resetPath.release();
+        }
 
         return result;
     }

--- a/plugins/builtin/source/content/project.cpp
+++ b/plugins/builtin/source/content/project.cpp
@@ -157,7 +157,7 @@ namespace hex::plugin::builtin {
         ImHexApi::Provider::resetDirty();
 
         // if saveLocation is false, reset the project path (do not release the lock)
-        if(updateLocation) {
+        if (updateLocation) {
             resetPath.release();
         }
 


### PR DESCRIPTION
This PR fixes some things about crash handling:
- when the terminate handler is called, immediately set it back to the original one, so can't make a recursion if the crash-handling code fails
- Only save projects if the crash occured after Imhex finished startup
- do not update the project location when saving the crash backup file: this will remove problems when `EventAbnormalTermination` is called before `crashCallback()`

I also added a bit more documentation