### PR TITLE
Added toggle for human-readable units in hex editor footer

### DIFF
--- a/plugins/builtin/include/ui/hex_editor.hpp
+++ b/plugins/builtin/include/ui/hex_editor.hpp
@@ -154,6 +154,10 @@ namespace hex::plugin::builtin::ui {
             this->m_showAscii = showAscii;
         }
 
+        void enableShowHumanReadableUnits(bool showHumanReadableUnits) {
+            this->m_showHumanReadableUnits = showHumanReadableUnits;
+        }
+
         void enableSyncScrolling(bool syncScrolling) {
             this->m_syncScrolling = syncScrolling;
         }
@@ -253,6 +257,7 @@ namespace hex::plugin::builtin::ui {
         bool m_grayOutZero = true;
         bool m_showAscii = true;
         bool m_showCustomEncoding = true;
+        bool m_showHumanReadableUnits = true;
         bool m_syncScrolling = false;
         u32 m_byteCellPadding = 0, m_characterCellPadding = 0;
 

--- a/plugins/builtin/romfs/lang/de_DE.json
+++ b/plugins/builtin/romfs/lang/de_DE.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "ASCII Spalte anzeigen",
         "hex.builtin.hex_editor.custom_encoding_view": "Erweiterte Dekodierungsspalte anzeigen",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "Datengrösse",
         "hex.builtin.hex_editor.gray_out_zero": "Nullen ausgrauen",
         "hex.builtin.hex_editor.no_bytes": "Keine Bytes verfügbar",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -153,6 +153,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "Display ASCII column",
         "hex.builtin.hex_editor.custom_encoding_view": "Display advanced decoding column",
+        "hex.builtin.hex_editor.human_readable_units_footer": "Convert sizes to human-readable units",
         "hex.builtin.hex_editor.data_size": "Data Size",
         "hex.builtin.hex_editor.gray_out_zero": "Grey out zeros",
         "hex.builtin.hex_editor.no_bytes": "No bytes available",

--- a/plugins/builtin/romfs/lang/es_ES.json
+++ b/plugins/builtin/romfs/lang/es_ES.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "Mostrar columna ASCII",
         "hex.builtin.hex_editor.custom_encoding_view": "Mostrar columna de decodificación avanzada",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "Tamaño de Datos",
         "hex.builtin.hex_editor.gray_out_zero": "Mostrar ceros en gris",
         "hex.builtin.hex_editor.no_bytes": "No hay bytes disponibles",

--- a/plugins/builtin/romfs/lang/it_IT.json
+++ b/plugins/builtin/romfs/lang/it_IT.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "Mostra la colonna ASCII",
         "hex.builtin.hex_editor.custom_encoding_view": "Mostra la colonna di decodifica avanzata",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "",
         "hex.builtin.hex_editor.gray_out_zero": "Taglia fuori gli zeri",
         "hex.builtin.hex_editor.no_bytes": "",

--- a/plugins/builtin/romfs/lang/ja_JP.json
+++ b/plugins/builtin/romfs/lang/ja_JP.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "ASCIIを表示",
         "hex.builtin.hex_editor.custom_encoding_view": "他のデコード列を表示",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "ファイルサイズ",
         "hex.builtin.hex_editor.gray_out_zero": "ゼロをグレーアウト",
         "hex.builtin.hex_editor.no_bytes": "",

--- a/plugins/builtin/romfs/lang/ko_KR.json
+++ b/plugins/builtin/romfs/lang/ko_KR.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "ASCII 열 표시",
         "hex.builtin.hex_editor.custom_encoding_view": "추가 디코딩 열 표시",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "데이터 크기",
         "hex.builtin.hex_editor.gray_out_zero": "00을 회색으로 표시",
         "hex.builtin.hex_editor.no_bytes": "바이트가 존재하지 않습니다",

--- a/plugins/builtin/romfs/lang/pt_BR.json
+++ b/plugins/builtin/romfs/lang/pt_BR.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "Exibir coluna ASCII",
         "hex.builtin.hex_editor.custom_encoding_view": "",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "Tamanho dos Dados",
         "hex.builtin.hex_editor.gray_out_zero": "",
         "hex.builtin.hex_editor.no_bytes": "Nenhum Byte Disponivel",

--- a/plugins/builtin/romfs/lang/zh_CN.json
+++ b/plugins/builtin/romfs/lang/zh_CN.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "显示 ASCII 栏",
         "hex.builtin.hex_editor.custom_encoding_view": "显示高级解码栏",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "总大小",
         "hex.builtin.hex_editor.gray_out_zero": "显示零字节为灰色",
         "hex.builtin.hex_editor.no_bytes": "没有可显示的字节",

--- a/plugins/builtin/romfs/lang/zh_TW.json
+++ b/plugins/builtin/romfs/lang/zh_TW.json
@@ -94,6 +94,7 @@
         "hex.builtin.hash.sha512": "SHA512",
         "hex.builtin.hex_editor.ascii_view": "顯示 ASCII 欄",
         "hex.builtin.hex_editor.custom_encoding_view": "顯示進階解碼欄",
+        "hex.builtin.hex_editor.human_readable_units_footer": "",
         "hex.builtin.hex_editor.data_size": "資料大小",
         "hex.builtin.hex_editor.gray_out_zero": "Grey out zeros",
         "hex.builtin.hex_editor.no_bytes": "無可用位元組",

--- a/plugins/builtin/source/ui/hex_editor.cpp
+++ b/plugins/builtin/source/ui/hex_editor.cpp
@@ -714,7 +714,9 @@ namespace hex::plugin::builtin::ui {
                                                 selection.getStartAddress(),
                                                 selection.getEndAddress(),
                                                 selection.getSize(),
-                                                hex::toByteString(selection.getSize())
+                                                this->m_showHumanReadableUnits
+                                                    ? hex::toByteString(selection.getSize())
+                                                    : hex::format("{}", selection.getSize())
                             );
                         }
                         else
@@ -733,7 +735,9 @@ namespace hex::plugin::builtin::ui {
                         ImGui::TextFormattedSelectable("0x{0:08X} (0x{1:X} | {2})",
                                                        this->m_provider->getActualSize(),
                                                        this->m_provider->getActualSize(),
-                                                       hex::toByteString(this->m_provider->getActualSize())
+                                                       this->m_showHumanReadableUnits
+                                                           ? hex::toByteString(this->m_provider->getActualSize())
+                                                           : hex::format("{}", this->m_provider->getActualSize())
                         );
                     }
 
@@ -765,6 +769,12 @@ namespace hex::plugin::builtin::ui {
                     ImGui::EndDisabled();
 
                     ImGui::InfoTooltip("hex.builtin.hex_editor.custom_encoding_view"_lang);
+
+                    ImGui::SameLine();
+
+                    // Human-readable units
+                    ImGui::DimmedIconToggle(ICON_VS_SYMBOL_NUMERIC, &this->m_showHumanReadableUnits);
+                    ImGui::InfoTooltip("hex.builtin.hex_editor.human_readable_units_footer"_lang);
 
                     ImGui::TableNextColumn();
 


### PR DESCRIPTION
Finalization of #1245 by adding a toggle to the hex editor itself, issue can be closed afterwards.