### PR TITLE
git: Make CI faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
         shell: msys2 {0}
     env:
       CCACHE_DIR:      "${{ github.workspace }}/.ccache"
-      CCACHE_MAXSIZE:  "1000M"
-      CCACHE_COMPRESS: "true"
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build
-        max-size: 50M
+        max-size: 1G
 
     - name: 📜 Restore CMakeCache
       uses:  actions/cache@v3
@@ -153,7 +153,7 @@ jobs:
       with:
         key: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-build
-        max-size: 50M
+        max-size: 1G
 
     - name: 📜 Restore CMakeCache
       uses: actions/cache@v3
@@ -267,7 +267,7 @@ jobs:
         with:
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build
-          max-size: 50M
+          max-size: 1G
 
       - name: 📜 Restore CMakeCache
         uses: actions/cache@v3
@@ -342,7 +342,7 @@ jobs:
         with:
           key: ${{ runner.os }}-appimage-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-appimage-${{ secrets.CACHE_VERSION }}-build
-          max-size: 50M
+          max-size: 1G
 
       - name: 📜 Restore CMakeCache
         uses: actions/cache@v3
@@ -438,7 +438,7 @@ jobs:
         with:
           key: archlinux-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
           restore-keys: archlinux-${{ secrets.CACHE_VERSION }}-build
-          max-size: 50M
+          max-size: 1G
 
       - name: 📜 Restore CMakeCache
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       uses:  hendrikmuhs/ccache-action@v1.2
       id:    cache-ccache
       with:
-        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build
+        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-ccache-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-ccache
         max-size: 1G
 
     - name: 📜 Restore CMakeCache
@@ -41,7 +41,7 @@ jobs:
       with:
         path: |
           build/CMakeCache.txt
-        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: 🟦 Install msys2
       uses: msys2/setup-msys2@v2
@@ -151,8 +151,8 @@ jobs:
     - name: 📜 Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-build
+        key: ${{ runner.os }}${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-ccache-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-ccache
         max-size: 1G
 
     - name: 📜 Restore CMakeCache
@@ -160,7 +160,7 @@ jobs:
       with:
         path: |
           build/CMakeCache.txt
-        key: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-${{ matrix.suffix }}-${{ secrets.CACHE_VERSION }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: ⬇️ Install dependencies
       run: |
@@ -265,8 +265,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-          restore-keys: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build
+          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-ccache-${{ github.run_id }}
+          restore-keys: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-ccache
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
@@ -274,7 +274,7 @@ jobs:
         with:
           path: |
             build/CMakeCache.txt
-          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: ⬇️ Install dependencies
         run: |
@@ -340,8 +340,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-appimage-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-appimage-${{ secrets.CACHE_VERSION }}-build
+          key: appimage-${{ secrets.CACHE_VERSION }}-ccache-${{ github.run_id }}
+          restore-keys: appimage-${{ secrets.CACHE_VERSION }}-ccache
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
@@ -349,7 +349,7 @@ jobs:
         with:
           path: |
             build-appimage/CMakeCache.txt
-          key: ${{ runner.os }}-appimage-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+          key: appimage-${{ secrets.CACHE_VERSION }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: ⬇️ Install dependencies
         run: |
@@ -436,8 +436,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: archlinux-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-          restore-keys: archlinux-${{ secrets.CACHE_VERSION }}-build
+          key: archlinux-${{ secrets.CACHE_VERSION }}-ccache-${{ github.run_id }}
+          restore-keys: archlinux-${{ secrets.CACHE_VERSION }}-ccache
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
@@ -445,7 +445,7 @@ jobs:
         with:
           path: |
             build/CMakeCache.txt
-          key: archlinux-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+          key: archlinux-${{ secrets.CACHE_VERSION }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
       # ArchLinux cmake build
       - name: 🛠️ Build
@@ -565,8 +565,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2.5
         with:
-          key: rpm-${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-          restore-keys: rpm-${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-build
+          key: ${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-rpm-${{ github.run_id }}
+          restore-keys: ${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-rpm
           max-size: 1G
 
       - name: 📜 Set version variable
@@ -609,7 +609,7 @@ jobs:
           path: /var/cache/mock
           key: ${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-mock-${{ github.run_id }}
           restore-keys: |
-            ${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-mock-
+            ${{ matrix.mock_release }}-${{ secrets.CACHE_VERSION }}-mock
 
       # Fedora cmake build (in imhex.spec)
       - name: 📦 Build RPM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,8 +265,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build
+          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build-${{ github.run_id }}
+          restore-keys: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
@@ -274,7 +274,7 @@ jobs:
         with:
           path: |
             build/CMakeCache.txt
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+          key: Ubuntu-${{matrix.release_num}}-${{ secrets.CACHE_VERSION }}-build-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: ⬇️ Install dependencies
         run: |


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

This PR makes the CI go faster (yet again)

### What did you do ?
- The ArchLinux (and possibly other) jobs cache size was too small (50MiB), and was getting filled up in less than a run (400MiB). I put the cache size to 1GiB eveywhere to make sure it doesn't happen
	- This will need monitoring to make sure the cache doesn't fill up with old build caches (ccache has an option for that but I'm not sure how well it works by default)  
- The keys used for the Ubuntu build were the same fot both Ubuntu 22.04 and Ubuntu 23.04, which could cause only one of them to get a good cache

