### PR TITLE
feat: Do not save memory providers as recent entries

### DIFF
--- a/lib/libimhex/include/hex/providers/provider.hpp
+++ b/lib/libimhex/include/hex/providers/provider.hpp
@@ -62,6 +62,12 @@ namespace hex::prv {
         [[nodiscard]] virtual bool isDumpable() const;
 
         /**
+         * @brief Controls whether this provider can be saved as a recent entry
+         *   Tipitcally used for providers that do not retain data, e.g. the memory provider
+         */
+        [[nodiscard]] virtual bool isSavableAsRecent() const { return true; }
+
+        /**
          * @brief Read data from this provider, applying overlays and patches
          * @param offset offset to start reading the data
          * @param buffer buffer to write read data

--- a/plugins/builtin/include/content/providers/memory_file_provider.hpp
+++ b/plugins/builtin/include/content/providers/memory_file_provider.hpp
@@ -15,6 +15,7 @@ namespace hex::plugin::builtin {
         [[nodiscard]] bool isWritable()  const override { return !this->m_readOnly; }
         [[nodiscard]] bool isResizable() const override { return !this->m_readOnly; }
         [[nodiscard]] bool isSavable()   const override { return this->m_name.empty(); }
+        [[nodiscard]] bool isSavableAsRecent() const override { return false; }
 
         [[nodiscard]] bool open() override;
         void close() override { }

--- a/plugins/builtin/source/content/recent.cpp
+++ b/plugins/builtin/source/content/recent.cpp
@@ -33,6 +33,9 @@ namespace hex::plugin::builtin::recent {
                 // do not save to recents if the provider is part of a project
                 if (ProjectFile::hasPath()) return;
 
+                // do not save to recents if the provider doesnt want it
+                if (!provider->isSavableAsRecent()) return;
+
                 // The recent provider is saved to every "recent" directory
                 for (const auto &recentPath : fs::getDefaultPaths(fs::ImHexPath::Recent)) {
                     wolv::io::File recentFile(recentPath / fileName, wolv::io::File::Mode::Create);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Memory providers were saved in recent entries, but they do not save any data, so we were essentially saving an empty provider as recent

### Implementation description
I added a `isSavableAsRecent()` property to the Provider class to control whether a provider should be saved as recent
