### PR TITLE
feat: move PerProvider data to new provider when saving memory provider into file provider

### DIFF
--- a/lib/libimhex/include/hex/api/event.hpp
+++ b/lib/libimhex/include/hex/api/event.hpp
@@ -245,4 +245,10 @@ namespace hex {
      * @brief Send an event to the main Imhex instance
      */
     EVENT_DEF(SendMessageToMainInstance, const std::string, const std::vector<u8>&);
+
+    /**
+     * Move the data from all PerProvider instances from one provider to another.
+     * The 'from' provider should not have any per provider data after this, and should be immediately deleted
+    */
+    EVENT_DEF(MovePerProviderData, prv::Provider *, prv::Provider *);
 }

--- a/lib/libimhex/include/hex/providers/provider_data.hpp
+++ b/lib/libimhex/include/hex/providers/provider_data.hpp
@@ -82,6 +82,22 @@ namespace hex {
             EventManager::subscribe<EventImHexClosing>(this, [this] {
                 this->m_data.clear();
             });
+
+            // moves the data of this PerProvider instance from one provider to another
+            EventManager::subscribe<MovePerProviderData>(this, [this](prv::Provider *from, prv::Provider *to) {
+                // get the value from the old provider, (removes it from the map)
+                auto node = m_data.extract(from);
+
+                // ensure the value existed
+                if (node.empty()) return;
+
+                // delete the value from the new provider, that we want to replace
+                this->m_data.erase(to);
+
+                // re-insert it with the key of the new provider
+                node.key() = to;
+                this->m_data.insert(std::move(node));
+            });
         }
 
         void onDestroy() {

--- a/plugins/builtin/source/content/providers/memory_file_provider.cpp
+++ b/plugins/builtin/source/content/providers/memory_file_provider.cpp
@@ -53,6 +53,8 @@ namespace hex::plugin::builtin {
                 if (!fileProvider->open())
                     ImHexApi::Provider::remove(newProvider);
                 else {
+                    EventManager::post<MovePerProviderData>(this, fileProvider);
+
                     fileProvider->markDirty(false);
                     EventManager::post<EventProviderOpened>(newProvider);
                     ImHexApi::Provider::remove(this, true);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
#1238 case B

### Implementation description
I added a function to move data in PerProvider members from a provider to another, and use that function when saving a memory provider

