### PR TITLE
fix: Add mingw-w64-x86_64-make to get_deps_msys2.sh

### DIFF
--- a/dist/get_deps_msys2.sh
+++ b/dist/get_deps_msys2.sh
@@ -4,6 +4,7 @@ pacman -S --needed --noconfirm  \
   mingw-w64-x86_64-gcc          \
   mingw-w64-x86_64-lld          \
   mingw-w64-x86_64-cmake        \
+  mingw-w64-x86_64-make         \
   mingw-w64-x86_64-ccache       \
   mingw-w64-x86_64-glfw         \
   mingw-w64-x86_64-file         \


### PR DESCRIPTION
### Problem description

When I worked according to the description on [ImHex/dist/compiling/windows.md](https://github.com/WerWolv/ImHex/blob/master/dist/compiling/windows.md), I got following error after executing `cmake` command.

```
CMake was unable to find a build program corresponding to "MinGW Makefiles"
```

This error seems to be caused because `mingw-w64-x86_64-make` is not installed.

### Implementation description

Add `mingw-w64-x86_64-make` to `get_deps_msys2.sh`.