### PR TITLE
fix: add _lang suffix to "Load into memory" localization string

### DIFF
--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -228,7 +228,7 @@ namespace hex::plugin::builtin {
         return {
             { "hex.builtin.provider.file.menu.open_folder"_lang, [this] { fs::openFolderWithSelectionExternal(this->m_path); } },
             { "hex.builtin.provider.file.menu.open_file"_lang,   [this] { fs::openFileExternal(this->m_path); } },
-            { "hex.builtin.provider.file.menu.into_memory",      [this] { this->convertToMemoryFile(); } }
+            { "hex.builtin.provider.file.menu.into_memory"_lang,      [this] { this->convertToMemoryFile(); } }
         };
     }
 


### PR DESCRIPTION
`hex.builtin.provider.file.menu.into_memory` didn't have a the `_lang` suffix, probably got forgotten