### PR TITLE
feat: Adapt content store view for new API contents

### DIFF
--- a/plugins/builtin/include/content/views/view_store.hpp
+++ b/plugins/builtin/include/content/views/view_store.hpp
@@ -24,6 +24,7 @@ namespace hex::plugin::builtin {
     struct StoreEntry {
         std::string name;
         std::string description;
+        std::vector<std::string> authors;
         std::string fileName;
         std::string link;
         std::string hash;

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -962,6 +962,7 @@
         "hex.builtin.view.store.reload": "Reload",
         "hex.builtin.view.store.remove": "Remove",
         "hex.builtin.view.store.row.description": "Description",
+        "hex.builtin.view.store.row.authors": "Authors",
         "hex.builtin.view.store.row.name": "Name",
         "hex.builtin.view.store.tab.constants": "Constants",
         "hex.builtin.view.store.tab.encodings": "Encodings",

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -79,7 +79,8 @@ namespace hex::plugin::builtin {
                         ImGui::EndTooltip();
                     }
                     ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(wolv::util::combineStrings(entry.authors, ", ").c_str());
+                    // the space makes a padding in the UI
+                    ImGui::Text("%s ", wolv::util::combineStrings(entry.authors, ", ").c_str());
                     ImGui::TableNextColumn();
 
                     const auto buttonSize = ImVec2(100_scaled, ImGui::GetTextLineHeightWithSpacing());

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -79,9 +79,7 @@ namespace hex::plugin::builtin {
                         ImGui::EndTooltip();
                     }
                     ImGui::TableNextColumn();
-                    for (auto &author : entry.authors) {
-                        ImGui::TextUnformatted(author.c_str());
-                    }
+                    ImGui::TextUnformatted(wolv::util::combineStrings(entry.authors, ", ").c_str());
                     ImGui::TableNextColumn();
 
                     const auto buttonSize = ImVec2(100_scaled, ImGui::GetTextLineHeightWithSpacing());

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -59,7 +59,7 @@ namespace hex::plugin::builtin {
                 ImGui::TableSetupScrollFreeze(0, 1);
                 ImGui::TableSetupColumn("hex.builtin.view.store.row.name"_lang, ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("hex.builtin.view.store.row.description"_lang, ImGuiTableColumnFlags_None);
-                ImGui::TableSetupColumn("hex.builtin.view.store.row.authors"_lang, ImGuiTableColumnFlags_None);
+                ImGui::TableSetupColumn("hex.builtin.view.store.row.authors"_lang, ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
 
                 ImGui::TableHeadersRow();

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -55,10 +55,11 @@ namespace hex::plugin::builtin {
 
     void ViewStore::drawTab(hex::plugin::builtin::StoreCategory &category) {
         if (ImGui::BeginTabItem(LangEntry(category.unlocalizedName))) {
-            if (ImGui::BeginTable("##pattern_language", 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Borders | ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_RowBg)) {
+            if (ImGui::BeginTable("##pattern_language", 4, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Borders | ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_RowBg)) {
                 ImGui::TableSetupScrollFreeze(0, 1);
                 ImGui::TableSetupColumn("hex.builtin.view.store.row.name"_lang, ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("hex.builtin.view.store.row.description"_lang, ImGuiTableColumnFlags_None);
+                ImGui::TableSetupColumn("hex.builtin.view.store.row.authors"_lang, ImGuiTableColumnFlags_None);
                 ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
 
                 ImGui::TableHeadersRow();
@@ -70,6 +71,10 @@ namespace hex::plugin::builtin {
                     ImGui::TextUnformatted(entry.name.c_str());
                     ImGui::TableNextColumn();
                     ImGui::TextUnformatted(entry.description.c_str());
+                    ImGui::TableNextColumn();
+                    for (auto &author : entry.authors) {
+                        ImGui::TextUnformatted(author.c_str());
+                    }
                     ImGui::TableNextColumn();
 
                     const auto buttonSize = ImVec2(100_scaled, ImGui::GetTextLineHeightWithSpacing());
@@ -196,10 +201,10 @@ namespace hex::plugin::builtin {
                     for (auto &entry : storeJson[category.requestName]) {
 
                         // Check if entry is valid
-                        if (entry.contains("name") && entry.contains("desc") && entry.contains("file") && entry.contains("url") && entry.contains("hash") && entry.contains("folder")) {
+                        if (entry.contains("name") && entry.contains("desc") && entry.contains("authors") && entry.contains("file") && entry.contains("url") && entry.contains("hash") && entry.contains("folder")) {
 
                             // Parse entry
-                            StoreEntry storeEntry = { entry["name"], entry["desc"], entry["file"], entry["url"], entry["hash"], entry["folder"], false, false, false };
+                            StoreEntry storeEntry = { entry["name"], entry["desc"], entry["authors"], entry["file"], entry["url"], entry["hash"], entry["folder"], false, false, false };
 
                             // Check if file is installed already or has an update available
                             for (const auto &folder : fs::getDefaultPaths(category.path)) {

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -71,6 +71,13 @@ namespace hex::plugin::builtin {
                     ImGui::TextUnformatted(entry.name.c_str());
                     ImGui::TableNextColumn();
                     ImGui::TextUnformatted(entry.description.c_str());
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::BeginTooltip();
+                        ImGui::PushTextWrapPos(500);
+                        ImGui::TextUnformatted(entry.description.c_str());
+                        ImGui::PopTextWrapPos();
+                        ImGui::EndTooltip();
+                    }
                     ImGui::TableNextColumn();
                     for (auto &author : entry.authors) {
                         ImGui::TextUnformatted(author.c_str());


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Description
This PR modifies the content store view to accommodate for the new content the API will send, the pattern description and authors.
For that, I changed the "description" column to be wrapped (because the description might be so long it takes multiple lines) and added a "authors" column

### Screenshots
Before
![image](https://github.com/WerWolv/ImHex/assets/42669835/dbfdeb5b-7cbd-4935-9674-6e936ac58f19)

After
![image](https://github.com/WerWolv/ImHex/assets/42669835/45e56c04-6101-449b-b413-1cbe7952b1ef)
