### PR TITLE
make ViewStore::remove() return true if the entry was removed

### DIFF
--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -284,8 +284,12 @@ namespace hex::plugin::builtin {
         return true;
     }
 
+    /**
+     * @brief Remove an entry from the content store from the filesystem
+     * @return true if the entry was removed, false if nothing was removed (not found)
+     */
     bool ViewStore::remove(fs::ImHexPath pathType, const std::string &fileName) {
-        bool removed = true;
+        bool removed = false;
         for (const auto &path : fs::getDefaultPaths(pathType)) {
             const auto filePath = path / fileName;
             const auto folderPath = (path / std::fs::path(fileName).stem());
@@ -293,7 +297,7 @@ namespace hex::plugin::builtin {
             wolv::io::fs::remove(filePath);
             wolv::io::fs::removeAll(folderPath);
 
-            removed = removed && !wolv::io::fs::exists(filePath) && !wolv::io::fs::exists(folderPath);
+            removed = removed || (!wolv::io::fs::exists(filePath) && !wolv::io::fs::exists(folderPath));
             EventManager::post<EventStoreContentRemoved>(filePath);
         }
 


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
When you remove an entry from the content store, the button keeps saying "removed" instead of "install"
This was because ViewStore::remove() only returned `true` if the entry was deleted from *every folder*.
I changed it to return true if the file was removed from at least one folder

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
