### PR TITLE
git: build llvm ourselves in Fedora packages

### DIFF
--- a/dist/rpm/imhex.spec
+++ b/dist/rpm/imhex.spec
@@ -75,7 +75,6 @@ CXXFLAGS+=" -std=gnu++2b"
  -D IMHEX_OFFLINE_BUILD=ON               \
  -D USE_SYSTEM_NLOHMANN_JSON=ON          \
  -D USE_SYSTEM_FMT=ON                    \
- -D USE_SYSTEM_LLVM=ON                   \
  -D USE_SYSTEM_YARA=ON                   \
  -D USE_SYSTEM_NFD=ON                    \
  -D IMHEX_USE_GTK_FILE_PICKER=ON         \


### PR DESCRIPTION
### Problem description
Fedora rawhide build is currently failing, because its trying to use the system version is llvm, which is llvm 17
This PR makes Fedora packages use our bundled llvm