### PR TITLE
Add support for the hex::group attribute and various fixes

### DIFF
--- a/lib/libimhex/include/hex/api/event.hpp
+++ b/lib/libimhex/include/hex/api/event.hpp
@@ -206,6 +206,7 @@ namespace hex {
     EVENT_DEF(EventWindowInitialized);
     EVENT_DEF(EventBookmarkCreated, ImHexApi::Bookmarks::Entry&);
     EVENT_DEF(EventPatchCreated, u64, u8, u8);
+    EVENT_DEF(EventPatternEvaluating);
     EVENT_DEF(EventPatternExecuted, const std::string&);
     EVENT_DEF(EventPatternEditorChanged, const std::string&);
     EVENT_DEF(EventStoreContentDownloaded, const std::fs::path&);

--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -66,6 +66,11 @@ namespace hex {
             }
 
             void store() {
+                // During a crash settings can be empty, causing them to be overwritten.
+                if(getSettingsData().empty()) {
+                    return;
+                }
+
                 for (const auto &dir : fs::getDefaultPaths(fs::ImHexPath::Config)) {
                     wolv::io::File file(dir / SettingsFile, wolv::io::File::Mode::Create);
 

--- a/plugins/builtin/include/content/views/view_pattern_data.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_data.hpp
@@ -20,8 +20,6 @@ namespace hex::plugin::builtin {
 
     private:
         ui::PatternDrawer m_patternDrawer;
-        bool m_shouldReset = false;
-        u64 m_lastRunId = 0;
     };
 
 }

--- a/plugins/builtin/include/ui/pattern_drawer.hpp
+++ b/plugins/builtin/include/ui/pattern_drawer.hpp
@@ -96,6 +96,7 @@ namespace hex::plugin::builtin::ui {
         std::vector<std::string> m_filter;
         std::vector<std::string> m_currPatternPath;
         std::map<std::vector<std::string>, std::unique_ptr<pl::ptrn::Pattern>> m_favorites;
+        std::map<std::string, std::vector<std::unique_ptr<pl::ptrn::Pattern>>> m_groups;
         bool m_showFavoriteStars = false;
         bool m_favoritesUpdated = false;
         bool m_showSpecName = false;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -923,6 +923,8 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::evaluatePattern(const std::string &code, prv::Provider *provider) {
+        EventManager::post<EventPatternEvaluating>();
+
         auto lock = std::scoped_lock(ContentRegistry::PatternLanguage::getRuntimeLock());
 
         this->m_runningEvaluators++;


### PR DESCRIPTION
As discussed (many times) on Discord, does the same as the new favorite tag, but instead allows you to add multiple groups.

Initially, this would cause some insane issues with draw/reset (apparantly) fighting eachother in the pattern drawer. After a lot of trial and error, I decided to rewrite the flow that is responsible for calling reset. Now evaluating patterns is the one to decide when the reset happens, not the core "game"-loop.

To make sure that draw and reset can never happen at the same time, the mutex originally used for the favorites has been repurposed. Due to the restructuring, the mutex in the favorite-task is no longer needed, as that will only ever kick-off after reset is called and if there are actually patterns, which can never line up to be accessed on different threads at the same time.

Last but not least, I noticed that hard crashes could result in your config file getting overridden. I added a check to prevent that.

Last I issue I can see is that if you use an excessive amount of favorites/groups, a crash can still happen, but it only happens when you close the program (occasionally, but unpredictable). Before, this would happen if you ran the evaluation a second time. I boiled the cause of the crash down to these lines of code in evaluator.cpp > patternDestroyed:

```cpp
if (pattern->isPatternLocal()) {
    if (auto it = this->m_patternLocalStorage.find(pattern->getHeapAddress()); it != this->m_patternLocalStorage.end()) {
        auto &[key, data] = *it;

        data.referenceCount--;
        if (data.referenceCount == 0)
            this->m_patternLocalStorage.erase(it);
    } else if (!this->m_evaluated) {
        err::E0001.throwError(fmt::format("Double free of variable named '{}'.", pattern->getVariableName()));
    }
}
```

Specifically, trying to access the `*it` is the reason for the crash (this was also the cause of the crashes before my fixes, but then during evaluation). 

I'm suspecting the root cause is somewhere in the `.clone` methods of the patterns. I'd say that for now a crash when closing the program is more acceptable than during evaluation (which can even happen if you use favorites).