### PR TITLE
fix: Handle exceptions thrown by providers on loadSettings()

### DIFF
--- a/plugins/builtin/source/content/providers.cpp
+++ b/plugins/builtin/source/content/providers.cpp
@@ -69,11 +69,19 @@ namespace hex::plugin::builtin {
                     }
 
                     provider->setID(id);
-                    provider->loadSettings(providerSettings.at("settings"));
-                    if (!provider->open() || !provider->isAvailable() || !provider->isReadable()) {
-                        providerWarnings[provider] = provider->getErrorMessage();
-                    } else
-                        EventManager::post<EventProviderOpened>(provider);
+                    bool loaded = false;
+                    try {
+                        provider->loadSettings(providerSettings.at("settings"));
+                        loaded = true;
+                    } catch (const std::exception &e){
+                            providerWarnings[provider] = e.what();
+                    }
+                    if (loaded) {
+                        if (!provider->open() || !provider->isAvailable() || !provider->isReadable()) {
+                            providerWarnings[provider] = provider->getErrorMessage();
+                        } else
+                            EventManager::post<EventProviderOpened>(provider);
+                    }
                 }
 
                 std::string warningMsg;


### PR DESCRIPTION
### Problem description
When loading providers, the loadSettings() function can throw an error. In this case, we should treat this the same as if it failed to open the provider

Else, the project might entierely fail to load because one provider has thrown an exception