### PR TITLE
fix `unsubscribe` bug

### DIFF
--- a/lib/libimhex/include/hex/api/event.hpp
+++ b/lib/libimhex/include/hex/api/event.hpp
@@ -161,7 +161,7 @@ namespace hex {
         }
 
     private:
-        static std::map<void *, EventList::iterator>& getTokenStore();
+        static std::multimap<void *, EventList::iterator>& getTokenStore();
         static EventList& getEvents();
     };
 

--- a/lib/libimhex/include/hex/api/event.hpp
+++ b/lib/libimhex/include/hex/api/event.hpp
@@ -103,6 +103,17 @@ namespace hex {
          */
         template<impl::EventType E>
         static void subscribe(void *token, typename E::Callback function) {
+            if (getTokenStore().contains(token)) {
+                auto&& [begin, end] = getTokenStore().equal_range(token);
+                auto eventRegistered = std::any_of(begin, end, [&](auto &item) {
+                    return item.second->first == E::Id;
+                });
+                if (eventRegistered) {
+                    log::fatal("The token '{}' has already registered the same event ('{}')", token, wolv::type::getTypeName<E>());
+                    return;
+                }
+            }
+
             getTokenStore().insert(std::make_pair(token, subscribe<E>(function)));
         }
 

--- a/lib/libimhex/source/api/event.cpp
+++ b/lib/libimhex/source/api/event.cpp
@@ -2,8 +2,8 @@
 
 namespace hex {
 
-    std::map<void *, EventManager::EventList::iterator>& EventManager::getTokenStore() {
-        static std::map<void *, EventManager::EventList::iterator> tokenStore;
+    std::multimap<void *, EventManager::EventList::iterator>& EventManager::getTokenStore() {
+        static std::multimap<void *, EventManager::EventList::iterator> tokenStore;
 
         return tokenStore;
     }


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

Fixed possible bug of  `EventManager::unsubscribe`

`std::map` only allows unique key, but the same token can subscribe to multiple events.
https://github.com/WerWolv/ImHex/blob/1a2a926b772f32d4f5e4c723c48e0e6e65a16b0a/lib/libimhex/include/hex/api/event.hpp#L104-L107

If the previous token has already subscribed to an event, then when subscribing again, `getTokenStore().insert` will not do anything (Because its type is `std::map`)

https://github.com/WerWolv/ImHex/blob/1a2a926b772f32d4f5e4c723c48e0e6e65a16b0a/lib/libimhex/include/hex/api/event.hpp#L122-L134

At this point in `unsubscribe`, the `iter` may not be able to find the correct event and erase it



### Implementation description
<!-- Explain what you did to correct the problem -->

Change `tokenStore` to `std::multimap` instead of `std::map`,  which cannot unsubscribe multiple events correctly

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
