### PR TITLE
fix building with capstone < 5

### DIFF
--- a/lib/libimhex/include/hex/helpers/disassembler.hpp
+++ b/lib/libimhex/include/hex/helpers/disassembler.hpp
@@ -28,9 +28,11 @@ namespace hex {
             BPF     = CS_ARCH_BPF,
             SH      = CS_ARCH_SH,
             TRICORE = CS_ARCH_TRICORE,
+            MAX   = TRICORE,
+        # else
+            MAX   = EVM,
         #endif
 
-        MAX         = TRICORE,
         MIN         = ARM
     };
 


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
This might fix building with capstone 4 as discussed in https://discord.com/channels/789833418631675954/1155669027306340393/1155669027306340393 

### Implementation description
<!-- Explain what you did to correct the problem -->
moves the max definition inside the if statement that checks for capstone 5
