### PR TITLE
MacOS: Don't force using discrete graphics card

### DIFF
--- a/main/gui/source/init/splash_window.cpp
+++ b/main/gui/source/init/splash_window.cpp
@@ -320,6 +320,7 @@ namespace hex::init {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
             glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+            glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, GLFW_TRUE);
         #else
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -282,7 +282,7 @@ namespace hex {
             if (ImGui::TitleBarButton(ICON_VS_CHROME_MAXIMIZE, buttonSize))
                 glfwMaximizeWindow(this->m_window);
         }
-        
+
 
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, 0xFF7A70F1);
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, 0xFF2311E8);
@@ -298,7 +298,7 @@ namespace hex {
         ImGui::SetCursorPosX(std::max(startX, (ImGui::GetWindowWidth() - ImGui::CalcTextSize(this->m_windowTitle.c_str()).x) / 2));
         ImGui::TextUnformatted(this->m_windowTitle.c_str());
     }
-    
+
     void Window::drawTitleBarBorder() {
         auto titleBarHeight = ImGui::GetCurrentWindow()->MenuBarHeight();
         auto buttonSize = ImVec2(titleBarHeight * 1.5F, titleBarHeight - 1);
@@ -805,6 +805,7 @@ namespace hex {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
             glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+            glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, GLFW_TRUE);
         #else
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);

--- a/resources/dist/macos/Info.plist.in
+++ b/resources/dist/macos/Info.plist.in
@@ -43,6 +43,8 @@
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 </dict>


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
When starting ImHex on a MacBook model with both integrated and discrete graphics, it will force the computer to use the discrete graphics card. This causes increased power usage, meaning the fans will spin up, the battery will drain faster, etc. This program is not very graphics intensive, so using the discrete graphics card shouldn't be needed.

### Implementation description
<!-- Explain what you did to correct the problem -->
I changed the [`GLFW_COCOA_GRAPHICS_SWITCHING`](https://www.glfw.org/docs/latest/window_guide.html#window_hints_osx) setting in GLFW to not enforce using the discrete graphics.

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
My editor is configured to automatically remove trailing whitespace, so I hope that those whitespace changes are ok