### PR TITLE
fix: disable web deployment on forks

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -70,7 +70,7 @@ jobs:
     name: 📃 Deploy to GitHub Pages
     runs-on: ubuntu-latest
 
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.ref == 'refs/heads/master' && github.event.repository.fork == false }}
     needs: build
 
     steps:


### PR DESCRIPTION
Web deployments currently run on forks when pushing on master, which fails because github pages are not enabled.

This PR disables web deployments on forks