### PR TITLE
Try my modified cache action to overwrite caches

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  actions: write
+
 jobs:
   codeql:
     name: 🐛 CodeQL

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,11 +33,12 @@ jobs:
         max-size: 50M
 
     - name: 📜 Restore CMakeCache
-      uses: actions/cache@v3
+      uses: iTrooz/cache@v3
       with:
         path: |
           build/CMakeCache.txt
         key: ${{ runner.os }}-analysis-build-${{ hashFiles('**/CMakeLists.txt') }}
+        update: true
 
     - name: ⬇️ Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,12 @@ jobs:
         max-size: 1G
 
     - name: 📜 Restore CMakeCache
-      uses:  actions/cache@v3
+      uses:  iTrooz/cache@v3
       with:
         path: |
           build/CMakeCache.txt
         key: ${{ runner.os }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
+        update: true
 
     - name: 🟦 Install msys2
       uses: msys2/setup-msys2@v2
@@ -154,11 +155,12 @@ jobs:
         max-size: 1G
 
     - name: 📜 Restore CMakeCache
-      uses: actions/cache@v3
+      uses: iTrooz/cache@v3
       with:
         path: |
           build/CMakeCache.txt
         key: ${{ runner.os }}-${{ matrix.suffix }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
+        update: true
 
     - name: ⬇️ Install dependencies
       run: |
@@ -268,11 +270,12 @@ jobs:
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
+        uses: iTrooz/cache@v3
         with:
           path: |
             build/CMakeCache.txt
           key: Ubuntu-${{matrix.release_num}}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
+          update: true
 
       - name: ⬇️ Install dependencies
         run: |
@@ -346,11 +349,12 @@ jobs:
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
+        uses: iTrooz/cache@v3
         with:
           path: |
             build-appimage/CMakeCache.txt
           key: appimage-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
+          update: true
 
       - name: ⬇️ Install dependencies
         run: |
@@ -442,11 +446,12 @@ jobs:
           max-size: 1G
 
       - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
+        uses: iTrooz/cache@v3
         with:
           path: |
             build/CMakeCache.txt
           key: archlinux-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
+          update: true
 
       # ArchLinux cmake build
       - name: 🛠️ Build
@@ -544,12 +549,11 @@ jobs:
           submodules: recursive
 
       - name: 📜 Setup DNF Cache
-        uses: actions/cache@v3
+        uses: iTrooz/cache@v3
         with:
           path: /var/cache/dnf
-          key: ${{ matrix.mock_release }}-dnf-${{ github.run_id }}
-          restore-keys: |
-            ${{ matrix.mock_release }}-dnf-
+          key: ${{ matrix.mock_release }}-dnf
+          update: true
 
       - name: ⬇️ Update all packages and install dependencies
         run: |
@@ -605,12 +609,11 @@ jobs:
           EOT
 
       - name: 📜 Setup Mock Cache
-        uses: actions/cache@v3
+        uses: iTrooz/cache@v3
         with:
           path: /var/cache/mock
-          key: ${{ matrix.mock_release }}-mock-${{ github.run_id }}
-          restore-keys: |
-            ${{ matrix.mock_release }}-mock
+          key: ${{ matrix.mock_release }}-mock
+          update: true
 
       # Fedora cmake build (in imhex.spec)
       - name: 📦 Build RPM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
 
 env:
   BUILD_TYPE: RelWithDebInfo
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: read
+  actions: write
 
 jobs:
 

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -26,10 +26,11 @@ jobs:
         submodules: recursive
     
     - name: 📁 Restore docker /cache
-      uses: actions/cache@v3
+      uses: iTrooz/cache@v3
       with:
         path: cache
         key: build-web-cache
+        update: true
     
     - name: 🐳 Inject /cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v2.1.2

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -54,16 +54,6 @@ jobs:
       with:
         path: out/
 
-      # See https://github.com/actions/cache/issues/342#issuecomment-1711054115
-    - name: 🗑️ Delete old cache
-      continue-on-error: true
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete "build-web-cache" --confirm
-  
-
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   pages: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,13 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   tests:
     name: 🧪 Unit Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,13 @@ jobs:
         restore-keys: ${{ runner.os }}-tests-build
         max-size: 50M
 
-
     - name: 📜 Restore CMakeCache
-      uses: actions/cache@v3
+      uses: iTrooz/cache@v3
       with:
         path: |
           build/CMakeCache.txt
         key: ${{ runner.os }}-tests-build-${{ hashFiles('**/CMakeLists.txt') }}
+        update: true
 
     - name: ⬇️ Install dependencies
       run: |


### PR DESCRIPTION
This PR replaces the https://github.com/actions/cache/ action with my fork https://github.com/iTrooz/cache
In this fork, I added a `update` parameter that will delete and re-create the same cache key, instead of using unique cache keys by appending `${{ github.run_id }}`

This PR might be reverted since this was never tested in real-world conditions