### PR TITLE
build: install pixmaps folder in ArchLinux package (to have the icon)

### DIFF
--- a/dist/Arch/PKGBUILD
+++ b/dist/Arch/PKGBUILD
@@ -25,5 +25,5 @@ package() {
 
     install -d "$pkgdir/usr/share/imhex"
     cp -r "$srcdir/usr/share/imhex/"{constants,encodings,includes,magic,patterns} "$pkgdir/usr/share/imhex"
-    cp -r "$srcdir/usr/share/"{applications,licenses} "$pkgdir/usr/share"
+    cp -r "$srcdir/usr/share/"{applications,licenses,pixmaps} "$pkgdir/usr/share"
 }


### PR DESCRIPTION
Right now imhex from the `imhex-bin` ArchLinux package do not have an icon, because the package do not bundle one

This PR fix that