### PR TITLE
fix: Re-enable window transparence on Linux

### DIFF
--- a/main/gui/source/init/splash_window.cpp
+++ b/main/gui/source/init/splash_window.cpp
@@ -332,7 +332,6 @@ namespace hex::init {
         glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
         glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
         glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
-        glfwWindowHint(GLFW_SAMPLES, 1);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
 
         // Create the splash screen window

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -828,7 +828,6 @@ namespace hex {
         glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-        glfwWindowHint(GLFW_SAMPLES, 1);
 
         if (restoreWindowPos) {
             int maximized = ContentRegistry::Settings::read("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.maximized", GLFW_FALSE);


### PR DESCRIPTION
This PR removes the `glfwWindowHint(GLFW_SAMPLES, 1);` line
It is removing the window transparence on Linux
![image](https://github.com/WerWolv/ImHex/assets/42669835/1b2c84fa-ccc2-4218-8715-6768c3327a36)