### PR TITLE
fix: Fixed spacing in bit labels so it works for any font and any size.

### DIFF
--- a/plugins/builtin/source/content/tools_entries.cpp
+++ b/plugins/builtin/source/content/tools_entries.cpp
@@ -1802,7 +1802,7 @@ namespace hex::plugin::builtin {
                 // The main problem is that from_chars will not process special numbers
                 // like inf and nan, so we handle them manually.
                 static std::string decimalFloatingPointNumberString;
-                static std::string_view decimalStrView;
+
                 // Use qnan for quiet NaN and snan for signaling NaN.
                 if (ieee754.numberType == NumberType::NaN) {
                     if (ieee754.valueType == ValueType::QuietNaN)


### PR DESCRIPTION
Testing various fonts and sizes I realized there were still problems with the layout of the bit labels. Also I reorganized the code so that lambdas are defined just before they are used. Comments needed punctuation too.

Part of the problem was that I had been assuming all along that the check boxes were ImGui's originals which are always square. In actuality the width is determined by the width of the character for '0'. Also ImGui table was adding spacing to separate cells which made the boxes not start at same place as column. Also for some reason using indent of zero didn't work as expected but using 0.1 pixels worked.  With those problems fixed it is fairly easy to make sure the labels are centered at the box except when the first mantissa checkbox gets a label which is wider that the box width. Before and after show results for different fonts.

Before:
![image](https://github.com/WerWolv/ImHex/assets/53811119/3778e6d5-6fbd-48e1-ac51-39a6636daea5)

After:
![image](https://github.com/WerWolv/ImHex/assets/53811119/79c0f027-3119-4762-a4e3-315e84505f3b)



