### PR TITLE
build: use microsoft vcpkg repository for the web build

### DIFF
--- a/dist/web/Dockerfile
+++ b/dist/web/Dockerfile
@@ -9,10 +9,10 @@ RUN apt install -y git ccache autoconf automake libtool cmake pkg-config
 
 RUN <<EOF
 # Install vcpkg
-# Note: we are using my fork of the repository with a libmagic patch
+# Note: we are a patch on the libmagic port
 set -xe
 
-git clone https://github.com/iTrooz/vcpkg /vcpkg
+git clone https://github.com/microsoft/vcpkg /vcpkg
 /vcpkg/bootstrap-vcpkg.sh
 sed -i 's/vcpkg_install_make(${EXTRA_ARGS})/vcpkg_install_make(${EXTRA_ARGS} SUBPATH src)/g' /vcpkg/ports/libmagic/portfile.cmake
 EOF


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/34157 fixed the issue we had with brotli (freetype) so we can now use the microsoft vcpkg repository, instead of my fork which was frozen at a date before the brotli problem