### PR TITLE
fix: Updated wrong link to pattern language docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The Pattern Language is the completely custom programming language developed for
 It allows you to define structures and data types in a C-like syntax and then use them to parse and highlight a file's content.
 
 - Source Code: [Link](https://github.com/WerWolv/PatternLanguage/)
-- Documentation: [Link](https://imhex.werwolv.net/docs/)
+- Documentation: [Link](https://docs.werwolv.net/pattern-language/)
 
 ## Database
 


### PR DESCRIPTION
Just a very simple update to point to the right documentation URI