### PR TITLE
feat: handle content store entries managed by the system (in a read-only folder)

### DIFF
--- a/plugins/builtin/include/content/views/view_store.hpp
+++ b/plugins/builtin/include/content/views/view_store.hpp
@@ -34,6 +34,7 @@ namespace hex::plugin::builtin {
         bool downloading;
         bool installed;
         bool hasUpdate;
+        bool system;
     };
 
     struct StoreCategory {

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -988,6 +988,8 @@
         "hex.builtin.view.store.tab.themes": "Themes",
         "hex.builtin.view.store.tab.yara": "Yara Rules",
         "hex.builtin.view.store.update": "Update",
+        "hex.builtin.view.store.system": "System",
+        "hex.builtin.view.store.system.explanation": "This entry is in a read-only directory, it is probably managed by the system",
         "hex.builtin.view.store.update_count": "Update all\nAvailable Updates: {}",
         "hex.builtin.view.theme_manager.name": "Theme Manager",
         "hex.builtin.view.theme_manager.colors": "Colors",


### PR DESCRIPTION
Currently ImHex does not handle well content store entries that are in a read-only folder (typically managed by an external, system-wide package manager)
This PR fix that
