### PR TITLE
feat: do not make splash screen wait for checkForUpdates task

### DIFF
--- a/main/gui/source/init/tasks.cpp
+++ b/main/gui/source/init/tasks.cpp
@@ -113,7 +113,7 @@ namespace hex::init {
     }
     
     static bool checkForUpdates() {
-        std::thread([]{ checkForUpdatesSync(); }).detach();
+        TaskManager::createBackgroundTask("Checking for updates", [](auto&) { checkForUpdatesSync(); });
         return true;
     }
 

--- a/main/gui/source/init/tasks.cpp
+++ b/main/gui/source/init/tasks.cpp
@@ -34,13 +34,12 @@ namespace hex::init {
 
     using namespace std::literals::string_literals;
 
-    static bool checkForUpdates() {
+    static bool checkForUpdatesSync() {
         int checkForUpdates = ContentRegistry::Settings::read("hex.builtin.setting.general", "hex.builtin.setting.general.server_contact", 2);
 
         // Check if we should check for updates
         if (checkForUpdates == 1){
             HttpRequest request("GET", GitHubApiURL + "/releases/latest"s);
-            request.setTimeout(500);
 
             // Query the GitHub API for the latest release version
             auto response = request.execute().get();
@@ -110,6 +109,11 @@ namespace hex::init {
                 telemetryRequest.execute();
             });
         }
+        return true;
+    }
+    
+    static bool checkForUpdates() {
+        std::thread([]{ checkForUpdatesSync(); }).detach();
         return true;
     }
 
@@ -608,7 +612,7 @@ namespace hex::init {
             { "Loading settings",        loadSettings,        false },
             { "Configuring UI scale",    configureUIScale,    false },
             { "Loading plugins",         loadPlugins,         true  },
-            { "Checking for updates",    checkForUpdates,     true  },
+            { "Checking for updates",    checkForUpdates,     false },
             { "Loading fonts",           loadFonts,           true  },
         };
     }


### PR DESCRIPTION
Running this task in a thread not related to the splash screen will allow us to make the request without a very small timeout