### PR TITLE
Make MacOS builds use MacOS 12 instead of 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
   # MacOS build
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
 
     strategy:
       matrix:
@@ -134,7 +134,7 @@ jobs:
           - suffix: ""
             custom_glfw: false
 
-    name: 🍎 macOS 11.0${{matrix.suffix}}
+    name: 🍎 macOS 12.0${{matrix.suffix}}
 
     steps:
     - name: 🧰 Checkout


### PR DESCRIPTION
Context: MacOS 11 (Big Sur) is EOL + llvm@17 has been released, and it has no binaries for Big Sur, making the CI hang
