### PR TITLE
fix: Calculate default CRC-32

### DIFF
--- a/plugins/builtin/source/content/hashes.cpp
+++ b/plugins/builtin/source/content/hashes.cpp
@@ -178,7 +178,7 @@ namespace hex::plugin::builtin {
 
         ContentRegistry::Hashes::add<HashCRC<u8>>("hex.builtin.hash.crc8",  crypt::crc8,  0x07,        0x0000,      0x0000);
         ContentRegistry::Hashes::add<HashCRC<u16>>("hex.builtin.hash.crc16", crypt::crc16, 0x8005,      0x0000,      0x0000);
-        ContentRegistry::Hashes::add<HashCRC<u32>>("hex.builtin.hash.crc32", crypt::crc32, 0x04C1'1DB7, 0xFFFF'FFFF, 0xFFFF'FFFF);
+        ContentRegistry::Hashes::add<HashCRC<u32>>("hex.builtin.hash.crc32", crypt::crc32, 0x04C1'1DB7, 0xFFFF'FFFF, 0xFFFF'FFFF, true, true);
         ContentRegistry::Hashes::add<HashCRC<u32>>("hex.builtin.hash.crc32mpeg",  crypt::crc32, 0x04C1'1DB7, 0xFFFF'FFFF, 0x0000'0000, false, false);
         ContentRegistry::Hashes::add<HashCRC<u32>>("hex.builtin.hash.crc32posix", crypt::crc32, 0x04C1'1DB7, 0x0000'0000, 0xFFFF'FFFF, false, false);
         ContentRegistry::Hashes::add<HashCRC<u32>>("hex.builtin.hash.crc32c",     crypt::crc32, 0x1EDC'6F41, 0xFFFF'FFFF, 0xFFFF'FFFF, true,  true);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
Before this PR, the CRC-32 value of ImHex is not like most of others.  

### Implementation description
<!-- Explain what you did to correct the problem -->
Just set m_reflectIn and m_reflectOut of CRC-32 true by default.  