### PR TITLE
Unobtainable achievement fix

### DIFF
--- a/plugins/builtin/source/content/main_menu_items.cpp
+++ b/plugins/builtin/source/content/main_menu_items.cpp
@@ -7,6 +7,7 @@
 #include <hex/api/keybinding.hpp>
 #include <hex/api/project_file_manager.hpp>
 #include <hex/api/layout_manager.hpp>
+#include <hex/api/achievement_manager.hpp>
 
 #include <hex/helpers/crypto.hpp>
 #include <hex/helpers/patches.hpp>
@@ -276,6 +277,8 @@ namespace hex::plugin::builtin {
                         else {
                             handleIPSError(data.error());
                         }
+
+                        AchievementManager::unlockAchievement("hex.builtin.achievement.hex_editor", "hex.builtin.achievement.hex_editor.create_patch.name");
                     });
                 });
             });
@@ -306,8 +309,11 @@ namespace hex::plugin::builtin {
 
                         if (data.has_value())
                             file.writeVector(data.value());
-                        else
+                        else {
                             handleIPSError(data.error());
+                        }
+
+                        AchievementManager::unlockAchievement("hex.builtin.achievement.hex_editor", "hex.builtin.achievement.hex_editor.create_patch.name");
                     });
                 });
             });


### PR DESCRIPTION
It turned out that the achievement "ROM hacks" wasn't actually unlockable.
I'm not sure if the IPS32 patch also has to trigger this achievement, but it seemed logical to me so I added the call to both methods.