### PR TITLE
build: Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+cmake-build-*/
+build*/
+
+local/
+**/Dockerfile


### PR DESCRIPTION
This only helps locally, to avoid copying local build folders to the build container
