### PR TITLE
fix: convert command line arguments to UTF-8 for windows builds

### DIFF
--- a/main/gui/source/main.cpp
+++ b/main/gui/source/main.cpp
@@ -227,13 +227,14 @@ int main(int argc, char **argv) {
 
 #if defined(OS_WINDOWS)
     // create UTF-8 argv
+    int wargc = 0;
     std::string argbuf;
     std::vector<char *> utf8_args;
-    WCHAR **wargv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+    WCHAR **wargv = ::CommandLineToArgvW(::GetCommandLineW(), &wargc);
     if (wargv) {
         // convert WCHAR arguments to UTF-8
         std::vector<size_t> offsets;
-        for (int i = 0; i < argc; i++) {
+        for (int i = 0; i < wargc; i++) {
             std::string arg = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>().to_bytes(wargv[i]);
             offsets.push_back(argbuf.size());
             argbuf.append(arg);


### PR DESCRIPTION
### Problem description
command line characters outside of the system's ANSI codepage are converted to '?'. Issue is seen in [Issue 1380](https://github.com/WerWolv/ImHex/issues/1380). This is a regression from 1.30.1 in [this commit](https://github.com/WerWolv/ImHex/commit/1ed658bcdc33207fe1da2c09d60c7769f9bf5f28), where the following got removed:
```
        std::optional<std::u8string> getProgramArgument(int index) {
            if (index >= impl::s_programArguments.argc) {
                return std::nullopt;
            }

            #if defined(OS_WINDOWS)
                std::wstring wideArg = ::CommandLineToArgvW(::GetCommandLineW(), &impl::s_programArguments.argc)[index];
                std::string byteArg = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>().to_bytes(wideArg);

                return std::u8string(byteArg.begin(), byteArg.end());
            #else
                return std::u8string(reinterpret_cast<const char8_t *>(impl::s_programArguments.argv[index]));
            #endif
        }
```

### Implementation description
replace main's argv with UTF-8 equivalent

### Screenshots
N/A

### Additional things
N/A
