### PR TITLE
fix: gl.h for MacOS

### DIFF
--- a/lib/third_party/imgui/include/imgui_impl_opengl3_loader.h
+++ b/lib/third_party/imgui/include/imgui_impl_opengl3_loader.h
@@ -32,7 +32,11 @@
 #ifndef __gl3w_h_
 #define __gl3w_h_
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 #if __has_include(<KHR/khrplatform.h>)
     #include <KHR/khrplatform.h>
@@ -1159,7 +1163,9 @@ typedef khronos_uint16_t GLhalf;
 #define GL_TEXTURE_DEPTH_TYPE             0x8C16
 #define GL_UNSIGNED_NORMALIZED            0x8C17
 #define GL_FRAMEBUFFER_BINDING            0x8CA6
+#ifndef __APPLE__
 #define GL_DRAW_FRAMEBUFFER_BINDING       0x8CA6
+#endif
 #define GL_RENDERBUFFER_BINDING           0x8CA7
 #define GL_READ_FRAMEBUFFER               0x8CA8
 #define GL_DRAW_FRAMEBUFFER               0x8CA9


### PR DESCRIPTION
### Problem description
Commit  1249eb326112a8caa518151f0d82fbb7619938c0 added `#include <GL/gl.h>` in a file, but MacOS uses `<OpenGL/gl.h>`.

### Implementation description
If compiling on MacOS, use `<OpenGL/gl.h>`. Otherwise, use `<GL/gl.h>`.

### Additional things
There is a redefine, so I used the preprocessor to ignore it for MacOS. This feels a little awkward to me (but I don't know how to do it better).

I'm not particularly familiar with C++, so let me know if this is the right solution. This is also my first pull request, so feel free to roast me for anything else :)