### PR TITLE
fix: bad entry in settings ends in .

### DIFF
--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -1254,7 +1254,7 @@ namespace hex {
             glfwGetWindowSize(this->m_window, &width, &height);
             maximized = glfwGetWindowAttrib(this->m_window, GLFW_MAXIMIZED);
 
-            ContentRegistry::Settings::write("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.", x);
+            ContentRegistry::Settings::write("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.x", x);
             ContentRegistry::Settings::write("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.y", y);
             ContentRegistry::Settings::write("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.width", width);
             ContentRegistry::Settings::write("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.height", height);


### PR DESCRIPTION
The entry is "hex.builtin.setting.interface.window." but I think it should be "hex.builtin.setting.interface.window.x"

