### PR TITLE
Update plugin_manager.cpp

### DIFF
--- a/lib/libimhex/source/api/plugin_manager.cpp
+++ b/lib/libimhex/source/api/plugin_manager.cpp
@@ -174,7 +174,7 @@ namespace hex {
         if (m_functions.isBuiltinPluginFunction != nullptr)
             return m_functions.isBuiltinPluginFunction();
         else
-            return false;
+            return getPluginName() == "Built-in";
     }
 
     const std::fs::path &Plugin::getPath() const {


### PR DESCRIPTION
Fix imhex with static non-web non-emscripten build.

Or else I have errors about missing "Built-in" plugin on start.

Actually, I think that this method can be implemented as plain 

```
isBuiltInPlugin() {
    return getPluginName() == "Built-in";
}
```

but obviously I missing some point :)