### PR TITLE
fix: segfault when starting with file arguments

### DIFF
--- a/lib/libimhex/source/api/plugin_manager.cpp
+++ b/lib/libimhex/source/api/plugin_manager.cpp
@@ -186,6 +186,8 @@ namespace hex {
     std::span<SubCommand> Plugin::getSubCommands() const {
         if (m_functions.getSubCommandsFunction != nullptr) {
             const auto result = m_functions.getSubCommandsFunction();
+            if (result == nullptr)
+                return { };
 
             return *static_cast<std::vector<SubCommand>*>(result);
         } else {


### PR DESCRIPTION
d511080814dc78ad39a63f2071003c07ee37673c introduced a regression where running imhex with arguments (i.e. `imhex blob1.bin blob2.bin`) will segfault due to a null pointer dereference.

### Implementation description
This patch updates `getSubCommands` to follow the same control flow as `getFeatures`, where if the function returns a null pointer, it will return gracefully rather than crash.