### PR TITLE
feat: Do not make memory providers dirty when creating them

### DIFF
--- a/plugins/builtin/source/content/providers/memory_file_provider.cpp
+++ b/plugins/builtin/source/content/providers/memory_file_provider.cpp
@@ -17,7 +17,6 @@ namespace hex::plugin::builtin {
     bool MemoryFileProvider::open() {
         if (m_data.empty()) {
             m_data.resize(1);
-            this->markDirty();
         }
 
         return true;


### PR DESCRIPTION
This is in an effort to avoid unnecessary popups