### PR TITLE
feat: separate cmake configure steps + remove CMakeCache cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         echo "IMHEX_VERSION=`cat VERSION`" >> $GITHUB_ENV
 
     # Windows cmake build
-    - name: 🛠️ Build
+    - name: 🛠️ Configure CMake
       run: |
         set -x
         mkdir -p build
@@ -79,6 +79,10 @@ jobs:
           -DUSE_SYSTEM_CAPSTONE=ON                      \
           -DDOTNET_EXECUTABLE="C:/Program Files/dotnet/dotnet.exe"  \
           ..
+    
+    - name: 🛠️ Build
+      run: |
+        cd build
         ninja install
         cpack
         mv ImHex-*.msi ../imhex-${{env.IMHEX_VERSION}}-Windows-x86_64.msi
@@ -203,7 +207,7 @@ jobs:
         ninja install
 
     # MacOS cmake build
-    - name: 🛠️ Build
+    - name: 🛠️ Configure CMake
       run: |
         set -x
         mkdir -p build
@@ -226,7 +230,9 @@ jobs:
           -DIMHEX_COMMIT_BRANCH="${GITHUB_REF##*/}"                                                 \
           -DCPACK_PACKAGE_FILE_NAME="imhex-${{env.IMHEX_VERSION}}-macOS${{matrix.suffix}}-x86_64"   \
           ..
-        ninja package
+      
+    - name: 🛠️ Build
+      run: cd build && ninja package
 
     - name: ⬆️ Upload DMG
       uses: actions/upload-artifact@v4
@@ -380,7 +386,7 @@ jobs:
           dotnet-version: '8.0.100'
 
       # Ubuntu cmake build
-      - name: 🛠️ Build
+      - name: 🛠️ Configure CMake
         shell: bash
         run: |
           set -x
@@ -400,7 +406,9 @@ jobs:
             -DIMHEX_USE_GTK_FILE_PICKER=ON                            \
             -DDOTNET_EXECUTABLE="dotnet"                              \
             ..
-          DESTDIR=DebDir ninja install 
+      
+      - name: 🛠️ Build
+        run: cd build && DESTDIR=DebDir ninja install 
 
       - name: 📜 Set version variable
         run: |
@@ -508,7 +516,7 @@ jobs:
           key: archlinux-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
       # ArchLinux cmake build
-      - name: 🛠️ Build
+      - name: 🛠️ Configure CMake
         run: |
           set -x
           mkdir -p build
@@ -529,7 +537,9 @@ jobs:
           -DIMHEX_ENABLE_LTO=ON                         \
           -DIMHEX_USE_GTK_FILE_PICKER=ON                \
           ..
-          DESTDIR=installDir ninja install 
+      
+      - name: 🛠️ Build
+        run: cd build && DESTDIR=installDir ninja install 
 
       - name: 📜 Set version variable
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,6 @@ jobs:
         restore-keys: ${{ runner.os }}-ccache
         max-size: 1G
 
-    - name: 📜 Restore CMakeCache
-      uses:  actions/cache@v3
-      with:
-        path: |
-          build/CMakeCache.txt
-        key: ${{ runner.os }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
-
     - name: 🟦 Install msys2
       uses: msys2/setup-msys2@v2
       with:
@@ -153,13 +146,6 @@ jobs:
         key: ${{ runner.os }}${{ matrix.suffix }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}${{ matrix.suffix }}-ccache
         max-size: 1G
-
-    - name: 📜 Restore CMakeCache
-      uses: actions/cache@v3
-      with:
-        path: |
-          build/CMakeCache.txt
-        key: ${{ runner.os }}-${{ matrix.suffix }}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: ⬇️ Install dependencies
       run: |
@@ -368,13 +354,6 @@ jobs:
           restore-keys: Ubuntu-${{matrix.release_num}}-ccache
           max-size: 1G
 
-      - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
-        with:
-          path: |
-            build/CMakeCache.txt
-          key: Ubuntu-${{matrix.release_num}}-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
-
       - name: ⬇️ Install dependencies
         run: |
           apt update
@@ -507,13 +486,6 @@ jobs:
           key: archlinux-ccache-${{ github.run_id }}
           restore-keys: archlinux-ccache
           max-size: 1G
-
-      - name: 📜 Restore CMakeCache
-        uses: actions/cache@v3
-        with:
-          path: |
-            build/CMakeCache.txt
-          key: archlinux-cmakecache-${{ hashFiles('**/CMakeLists.txt') }}
 
       # ArchLinux cmake build
       - name: 🛠️ Configure CMake


### PR DESCRIPTION
I introduced CMakeCache cache ~a year ago, mainly because curl was doing a bunch of tests that took time. curl is now removed, and this cache seems to add more problems than it solves, e.g:
- builds rely on a previous build configuration, so we can't make sure building from scratch work, and we could inherit flags from previous builds
- Errors like this on MacOS
```
/Users/runner/work/ImHex/ImHex/plugins/script_loader/source/loaders/dotnet/dotnet_loader.cpp:15:10: fatal error: nethost.h: No such file or directory
   15 | #include <nethost.h>
      |          ^~~~~~~~~~~
```