### PR TITLE
fix: Fix detected wasm file size being wrong

### DIFF
--- a/dist/web/Dockerfile
+++ b/dist/web/Dockerfile
@@ -73,10 +73,15 @@ cp /imhex/dist/web/source/* /build
 ccache -s
 EOF
 
+# Create a file dedicated to store wasm size, because I know no way to get the wasm content length if the web server uses compression
+# See https://stackoverflow.com/questions/41701849/cannot-modify-accept-encoding-with-fetch https://github.com/AnthumChris/fetch-progress-indicators/issues/13
+RUN du -b /build/imhex.wasm | cut -f1 > imhex.wasm.size
+
 FROM scratch as raw
 COPY --from=build [             \
     # ImHex                     \
     "/build/imhex.wasm",        \
+    "/build/imhex.wasm.size",   \
     "/build/imhex.js",          \
     "/build/imhex.worker.js",   \
                                 \

--- a/dist/web/source/wasm-config.js
+++ b/dist/web/source/wasm-config.js
@@ -47,8 +47,11 @@ function monkeyPatch(progressFun) {
     }
 }
 monkeyPatch((file, done) =>  {
-    if (!wasmSize || done > wasmSize)
+    if (!wasmSize) return;
+    if (done > wasmSize) {
+        console.log(`Warning: downloaded size ${done} is larger than wasm size ${wasmSize}`);
         return;
+    };
 
     const percent  = ((done / wasmSize) * 100).toFixed(0);
     const mibNow   = (done / 1024**2).toFixed(1);


### PR DESCRIPTION
This PRs adds a new file to the deployed web version: `imhex.wasm.size`
This file is responsible for showing the size of `imhex.wasm`
