### PR TITLE
Various fixes and an enhancement on the pattern editor 

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -175,7 +175,7 @@ public:
 		bool mCaseSensitive;
 
 		LanguageDefinition()
-			:  mGlobalDocComment("/*!"), mDocComment("/**"), mPreprocChar('#'), mAutoIndentation(true), mTokenize(nullptr), mCaseSensitive(true)
+			: mPreprocChar('#'), mAutoIndentation(true), mTokenize(nullptr), mCaseSensitive(true)
 		{
 		}
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -88,6 +88,9 @@ namespace hex::plugin::builtin {
             langDef.mAutoIndentation = true;
             langDef.mPreprocChar     = '#';
 
+            langDef.mGlobalDocComment = "/*!";
+            langDef.mDocComment      = "/**";
+
             langDef.mName = "Pattern Language";
 
             initialized = true;
@@ -675,6 +678,8 @@ namespace hex::plugin::builtin {
                     if (altCPressed)
                         matchCase = !matchCase;
                     findReplaceHandler->SetMatchCase(&m_textEditor,matchCase);
+                    position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
+                    count = findReplaceHandler->GetMatches().size();
                     updateCount = true;
                     requestFocusFind = true;
                 }


### PR DESCRIPTION
Fixed console error messages using doc comment syntax highlights. Fixed results of find not updating when march case was toggled. Fixed syntax highlights of nested ifdefs. Fixed editor cursor blinks if OS focus goes to another window. Fixed Highlights of "\\\"" was incorrectly handled.
