### PR TITLE
fix: Remove debug package created by makepkg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -540,6 +540,7 @@ jobs:
 
           # Replace the old file
           rm imhex-${{env.IMHEX_VERSION}}-ArchLinux-x86_64.pkg.tar.zst
+          rm *imhex-bin-debug* # rm debug package which is created for some reason
           mv *.pkg.tar.zst imhex-${{env.IMHEX_VERSION}}-ArchLinux-x86_64.pkg.tar.zst
 
       - name: ⬆️ Upload imhex-archlinux.pkg.tar.zst


### PR DESCRIPTION
For some reason, makepkg started creating a imhex-bin-debug package along the regular imhex-bin package, which made the build fail
This PR remove it after running makepkg