### PR TITLE
Fix compiling with Zstd (at least on *nix)

### DIFF
--- a/plugins/decompress/CMakeLists.txt
+++ b/plugins/decompress/CMakeLists.txt
@@ -32,11 +32,11 @@ add_imhex_plugin(
         ZSTD
 )
 
-find_package(zstd)
-if (TARGET zstd::libzstd_static)
-    addOptionalLibrary(zstd libzstd_static)
-elseif(TARGET zstd::libzstd_shared)
-    addOptionalLibrary(zstd libzstd_shared)
+find_package(ZSTD)
+if(ZSTD_FOUND)
+    set(LIBRARIES ${LIBRARIES} "${ZSTD_LIBRARY}")
+    message(STATUS "Enabling decompression support using ZSTD (${ZSTD_VERSION})")
+    enable_plugin_feature(ZSTD)
 endif()
 
 addOptionalLibrary(ZLIB ZLIB)


### PR DESCRIPTION
Prior to this, at least on Linux/MacOS/etc, I guess it was not possible to compile with Zstd included for `hex::dec::zstd_decompress()`:

![image](https://github.com/WerWolv/ImHex/assets/56618074/008dbb3d-eeaf-4f49-a918-4751ec69f00c)

Every other target lib for the decompression plugin would compile, **except for** Zstd. Additionally, the target name `zstd` caused CMake to not be able to find `Find(ZSTD).cmake` due to case-sensitivity differences between Windows and Unix-based file paths, of course.
With that said, I'm not too sure if this will break building w/ Zstd on Windows... Hopefully not :smile: 
