### PR TITLE
fix: use `find_library()` instead of `find_file()` to find system yara library

### DIFF
--- a/cmake/modules/FindYara.cmake
+++ b/cmake/modules/FindYara.cmake
@@ -1,4 +1,4 @@
-find_file(libyara.a YARA_LIBRARIES)
+find_library(YARA_LIBRARIES NAMES yara)
 find_file(yara.h YARA_INCLUDE_DIRS)
 
 mark_as_advanced(YARA_LIBRARIES YARA_INCLUDE_DIRS)


### PR DESCRIPTION
Discord discussion: https://discord.com/channels/789833418631675954/789840633414025246/1213564050848485427