### PR TITLE
Add dependency download script for OpenSUSE Tumbleweed

### DIFF
--- a/dist/get_deps_tumbleweed.sh
+++ b/dist/get_deps_tumbleweed.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+zypper install     \
+  cmake            \
+  ninja            \
+  gcc12            \
+  gcc12-c++        \
+  freetype2-devel  \
+  libcurl-devel    \
+  dbus-1-devel     \
+  file-devel       \
+  Mesa-libGL-devel \
+  libglfw-devel    \
+  mbedtls-devel    \
+  gtk3-devel       \
+  libzstd-devel    \
+  zlib-devel       \
+  bzip3-devel      \
+  xz-devel


### PR DESCRIPTION
## Add dependency download script for OpenSUSE Tumbleweed.

### Testing
After installing the dependencies, I have managed to successfully compile the project as described in the building instructions:
https://github.com/WerWolv/ImHex/blob/master/dist/compiling/linux.md

I have tested the script on a fresh installations of the OpenSUSE:
- Tumbleweed Server
- Tumbleweed Generic Desktop

### Note
Dependencies added in the script are based off of scripts for other Linux distributions.  
Because of that, some download dependencies might not be necessary (or could be already included by other packages), so it is very much possible that some of them could be removed. 
