### PR TITLE
Fix missing window icon under wayland

### DIFF
--- a/main/gui/source/init/splash_window.cpp
+++ b/main/gui/source/init/splash_window.cpp
@@ -415,6 +415,10 @@ namespace hex::init {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         #endif
 
+	#if defined(OS_LINUX)
+	    glfwWindowHintString(GLFW_WAYLAND_APP_ID, "imhex");
+	#endif
+
         // Make splash screen non-resizable, undecorated and transparent
         glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -720,6 +720,10 @@ namespace hex {
             glfwWindowHint(GLFW_DECORATED, ImHexApi::System::isBorderlessWindowModeEnabled() ? GL_FALSE : GL_TRUE);
         #endif
 
+	#if defined(OS_LINUX)
+            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "imhex");
+	#endif
+
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
         glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
When running ImHex under Wayland, the window icon is missing.

### Implementation description
Setting [```GLFW_WAYLAND_APP_ID```](https://www.glfw.org/docs/latest/group__window.html#gafbf1ce7a4362c75e602a4df9e1bdecd3) to fix the issue.

### Screenshots
Before:
![Screenshot_20240420_162144](https://github.com/WerWolv/ImHex/assets/71180087/3318970f-6ed7-4161-b686-c2eaa28a0739)


After:
![Screenshot_20240420_161920](https://github.com/WerWolv/ImHex/assets/71180087/e9e35fb6-e3c1-44a8-b7a5-b145dfe225d9)


### Additional things
<!-- Anything else you would like to say -->
