### PR TITLE
[Feature] Support DWM immersive dark mode on Windows.

### DIFF
--- a/main/gui/source/window/win_window.cpp
+++ b/main/gui/source/window/win_window.cpp
@@ -526,6 +526,14 @@ namespace hex {
                 }
             }
         });
+        RequestChangeTheme::subscribe([this](const std::string &theme) {
+            const int immersiveDarkMode = 20;
+            auto hwnd = glfwGetWin32Window(m_window);
+            BOOL value = theme == "Dark" ? TRUE : FALSE;
+
+            // Using the C++ "bool" type seems to not work correctly.
+            DwmSetWindowAttribute(hwnd, immersiveDarkMode, &value, sizeof(value));
+        });
 
         ImGui::GetIO().ConfigDebugIsDebuggerPresent = ::IsDebuggerPresent();
     }


### PR DESCRIPTION

### Problem description
Implements support for DWM immersive dark mode.  
Closes #1635.

### Implementation description
Uses the DwmSetWindowAttribute API to enable this feature.

Documentation can be found [here](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/apply-windows-themes#enable-a-dark-mode-title-bar-for-win32-applications).

### Screenshots
Before:
![image](https://github.com/WerWolv/ImHex/assets/51166756/a2be204f-aa2d-44d7-8628-643a903d6679)

After:
![image](https://github.com/WerWolv/ImHex/assets/51166756/f6c9ab41-c811-45f7-826f-401dd712674b)

### Additional things
Nothing.
