### PR TITLE
Fix a bug that caused the file provider's monitor to trigger the change dialog multiple times in a row (#1645)

### DIFF
--- a/plugins/builtin/include/content/providers/file_provider.hpp
+++ b/plugins/builtin/include/content/providers/file_provider.hpp
@@ -68,6 +68,7 @@ namespace hex::plugin::builtin {
         std::vector<u8> m_data;
         bool m_loadedIntoMemory = false;
         bool m_ignoreNextChangeEvent = false;
+        bool m_changeEventAcknowledgementPending = false;
 
         std::optional<struct stat> m_fileStats;
 

--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -339,12 +339,21 @@ namespace hex::plugin::builtin {
             return;
         }
 
+        if(m_changeEventAcknowledgementPending) {
+            return;
+        }
+
+        m_changeEventAcknowledgementPending = true;
+
         ui::PopupQuestion::open("hex.builtin.provider.file.reload_changes"_lang, [this] {
             this->close();
             (void)this->open();
             getUndoStack().reapply();
+            m_changeEventAcknowledgementPending = false;
         },
-        []{});
+        [this]{
+            m_changeEventAcknowledgementPending = false;
+        });
     }
 
 


### PR DESCRIPTION

<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
This PR aims to address #1645 that caused the built in file provider's change monitor to trigger the notification popup dialog multiple times in a row after multiple external file changes.

### Implementation description
I added an additional boolean field `m_changeEventAcknowledgementPending` that tracks whether there are any pending or unacknowledged change notification dialogs to prevent further dialogs from being opened. The flag is only reset to its initial value once the user has acknowledged the first `PopupQuestion` dialog.

Since the file is reloaded only after the user clicks 'Yes', it is unnecessary to ensure that only the latest popup is acknowledged.
