### PR TITLE
fix: Not being able to close certain modal popups with the close button on the title bar

### DIFF
--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -491,7 +491,7 @@ namespace hex {
                     ImGui::OpenPopup(name);
                 }
 
-                if (currPopup->shouldClose()) {
+                if (currPopup->shouldClose() || !open) {
                     log::debug("Closing popup '{}'", name);
                     positionSet = sizeSet = false;
 


### PR DESCRIPTION
### Problem description
When the close button is clicked, `ImGui::BeginPopupModal()` sets the bool passed into the second parameter (p_open) to false. However, the closing logic did not take this into account, making it difficult to actually close modal popups.

For example, closing the "Export pattern File" modal took several clicks on the "X" button, now it closes instantly.

### Implementation description
I added an additional check for the `open` variable being `false` in the logic that checks the closing condition.
