### PR TITLE
impr: Add a link to the "Find" view in the search popup

### DIFF
--- a/plugins/builtin/romfs/lang/de_DE.json
+++ b/plugins/builtin/romfs/lang/de_DE.json
@@ -799,6 +799,7 @@
         "hex.builtin.view.hex_editor.search.find": "Suchen",
         "hex.builtin.view.hex_editor.search.hex": "Hex",
         "hex.builtin.view.hex_editor.search.no_more_results": "Keine weiteren Ergebnisse",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "String",
         "hex.builtin.view.hex_editor.search.string.encoding": "Kodierung",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -805,6 +805,7 @@
         "hex.builtin.view.hex_editor.search.string.endianness.little": "Little",
         "hex.builtin.view.hex_editor.search.string.endianness.big": "Big",
         "hex.builtin.view.hex_editor.search.no_more_results": "No more results",
+        "hex.builtin.view.hex_editor.search.advanced": "Advanced Search...",
         "hex.builtin.view.hex_editor.select.offset.begin": "Begin",
         "hex.builtin.view.hex_editor.select.offset.end": "End",
         "hex.builtin.view.hex_editor.select.offset.region": "Region",

--- a/plugins/builtin/romfs/lang/es_ES.json
+++ b/plugins/builtin/romfs/lang/es_ES.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "Buscar",
         "hex.builtin.view.hex_editor.search.hex": "Hexadecimal",
         "hex.builtin.view.hex_editor.search.no_more_results": "No se encontraron más resultados",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "Cadena",
         "hex.builtin.view.hex_editor.search.string.encoding": "Codificación",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/it_IT.json
+++ b/plugins/builtin/romfs/lang/it_IT.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "Cerca",
         "hex.builtin.view.hex_editor.search.hex": "Hex",
         "hex.builtin.view.hex_editor.search.no_more_results": "Nessun risultato trovato",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "Stringa",
         "hex.builtin.view.hex_editor.search.string.encoding": "Codifica",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/ja_JP.json
+++ b/plugins/builtin/romfs/lang/ja_JP.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "検索",
         "hex.builtin.view.hex_editor.search.hex": "16進数",
         "hex.builtin.view.hex_editor.search.no_more_results": "結果がありません",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "文字列",
         "hex.builtin.view.hex_editor.search.string.encoding": "エンコード",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/ko_KR.json
+++ b/plugins/builtin/romfs/lang/ko_KR.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "찾기",
         "hex.builtin.view.hex_editor.search.hex": "헥스",
         "hex.builtin.view.hex_editor.search.no_more_results": "더이상 결과 없음",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "문자열",
         "hex.builtin.view.hex_editor.search.string.encoding": "エンコード",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/pt_BR.json
+++ b/plugins/builtin/romfs/lang/pt_BR.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "Buscar",
         "hex.builtin.view.hex_editor.search.hex": "Hex",
         "hex.builtin.view.hex_editor.search.no_more_results": "Não há mais resultados",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "String",
         "hex.builtin.view.hex_editor.search.string.encoding": "Codificação",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/zh_CN.json
+++ b/plugins/builtin/romfs/lang/zh_CN.json
@@ -839,6 +839,7 @@
         "hex.builtin.view.hex_editor.search.find": "查找",
         "hex.builtin.view.hex_editor.search.hex": "Hex",
         "hex.builtin.view.hex_editor.search.no_more_results": "没有更多结果",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "字符串",
         "hex.builtin.view.hex_editor.search.string.encoding": "编码",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/romfs/lang/zh_TW.json
+++ b/plugins/builtin/romfs/lang/zh_TW.json
@@ -795,6 +795,7 @@
         "hex.builtin.view.hex_editor.search.find": "尋找",
         "hex.builtin.view.hex_editor.search.hex": "十六進位",
         "hex.builtin.view.hex_editor.search.no_more_results": "沒有更多結果",
+        "hex.builtin.view.hex_editor.search.advanced": "",
         "hex.builtin.view.hex_editor.search.string": "字串",
         "hex.builtin.view.hex_editor.search.string.encoding": "編碼",
         "hex.builtin.view.hex_editor.search.string.encoding.utf16": "UTF-16",

--- a/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
+++ b/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
@@ -46,7 +46,7 @@ namespace hex::plugin::builtin {
             ImGui::EndTabBar();
         }
 
-        if(ImGuiExt::IconHyperlink(ICON_VS_SEARCH, "Advanced Search...")) {
+        if(ImGuiExt::IconHyperlink(ICON_VS_SEARCH, "hex.builtin.view.hex_editor.search.advanced"_lang)) {
             const auto& view = ContentRegistry::Views::getViewByName("hex.builtin.view.find.name");
             view->getWindowOpenState() = true;
             ImGui::SetWindowFocus(view->getName().c_str());

--- a/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
+++ b/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
@@ -50,6 +50,7 @@ namespace hex::plugin::builtin {
             const auto& view = ContentRegistry::Views::getViewByName("hex.builtin.view.find.name");
             view->getWindowOpenState() = true;
             ImGui::SetWindowFocus(view->getName().c_str());
+            editor->closePopup();
         }
 
         if (lastMode != *s_searchMode) {

--- a/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
+++ b/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_find.cpp
@@ -46,6 +46,12 @@ namespace hex::plugin::builtin {
             ImGui::EndTabBar();
         }
 
+        if(ImGuiExt::IconHyperlink(ICON_VS_SEARCH, "Advanced Search...")) {
+            const auto& view = ContentRegistry::Views::getViewByName("hex.builtin.view.find.name");
+            view->getWindowOpenState() = true;
+            ImGui::SetWindowFocus(view->getName().c_str());
+        }
+
         if (lastMode != *s_searchMode) {
             m_requestFocus = true;
             s_inputString->clear();


### PR DESCRIPTION
### Problem description
This PR adds a shortcut link on the Search (Ctrl+F) popup to the more advanced "Find" view that is normally accessible at the `View > Find` menu.

### Implementation description
I added a simple `ImGuiExt::IconHyperlink` link to the `draw()` function of the `PopupFind` class to display the hyperlink. Clicking the link will open the Find view, bring it into focus and close the current popup.

### Screenshots
Before:
![image](https://github.com/WerWolv/ImHex/assets/45818400/0961f594-0548-426a-8622-20093d4a165e)

After:
![image](https://github.com/WerWolv/ImHex/assets/45818400/d40d78f4-1a5d-4bf6-97a4-ff7ab40d0cef)


### Additional things
- Localization keys were added to all .json files, but only `en_US` is populated for now.
