### PR TITLE
fix: Program crash caused by missing ImGui::BeginDisabled()

### DIFF
--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -185,12 +185,19 @@ namespace hex::plugin::builtin {
                     ImGui::EndTabItem();
                 }
 
-                if (ImGui::Button("hex.builtin.view.hex_editor.select.select"_lang) || (ImGui::IsWindowFocused() && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter)))) {
-                    editor->setSelection(m_region.getStartAddress(), m_region.getEndAddress());
-                    editor->jumpToSelection();
+                const auto provider = ImHexApi::Provider::get();
+                bool isOffsetValid = m_region.getStartAddress() <= m_region.getEndAddress() &&
+                                     m_region.getEndAddress() < provider->getActualSize();
+                ImGui::BeginDisabled(!isOffsetValid);
+                {
+                    if (ImGui::Button("hex.builtin.view.hex_editor.select.select"_lang) ||
+                        (ImGui::IsWindowFocused() && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter)))) {
+                        editor->setSelection(m_region.getStartAddress(), m_region.getEndAddress());
+                        editor->jumpToSelection();
 
-                    if (!this->isPinned())
-                        editor->closePopup();
+                        if (!this->isPinned())
+                            editor->closePopup();
+                    }
                 }
                 ImGui::EndDisabled();
 


### PR DESCRIPTION
### Problem description
Merging my previous PRs, #1660 and #1658 has resulted in a conflict causing an application crash due to a missing `ImGui::BeginDisabled();` in the `PopupSelect` class. Specifically, none of the code related to offset validation made it into the final merge. This PR fixes the crash by reintroducing the deleted lines.

### Additional things
The nightly release build seems to be unaffected by the crash, most likely because ImGui's `DisabledStack` assertions are only enforced in Debug mode. The offset validation was still missing before this fix.
