### PR TITLE
fix: TextEditor line numbers were still partially rendered despite mShowLineNumbers being set to false

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -914,10 +914,12 @@ void TextEditor::Render() {
             }
 
             // Draw line number (right aligned)
-            snprintf(buf, 16, "%d  ", lineNo + 1);
+            if (mShowLineNumbers) {
+                snprintf(buf, 16, "%d  ", lineNo + 1);
 
-            auto lineNoWidth = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x;
-            drawList->AddText(ImVec2(lineStartScreenPos.x + mTextStart - lineNoWidth, lineStartScreenPos.y), mPalette[(int)PaletteIndex::LineNumber], buf);
+                auto lineNoWidth = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x;
+                drawList->AddText(ImVec2(lineStartScreenPos.x + mTextStart - lineNoWidth, lineStartScreenPos.y), mPalette[(int)PaletteIndex::LineNumber], buf);
+            }
 
             // Draw breakpoints
             if (mBreakpoints.count(lineNo + 1) != 0) {


### PR DESCRIPTION
### Problem description
TextEditor line numbers were still partially rendered despite mShowLineNumbers being set to false

### Implementation description
I wrapped the line no. rendering code in `if (mShowLineNumbers) { ... }`.

### Screenshots
Before:
![image](https://github.com/WerWolv/ImHex/assets/45818400/58a2cfdd-1ee0-484b-ba05-6e886ad4fd65)

After:
![image](https://github.com/WerWolv/ImHex/assets/45818400/5d204e2b-12a5-4fc9-bcfc-da6b8e6359e1)
