### PR TITLE
WIP: Cap texture multisampling SampleCount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 .idea/
+.kdev4/
 
 cmake-build-*/
 build*/
@@ -7,6 +8,7 @@ local/
 venv/
 
 *.mgc
+*.kdev4
 imgui.ini
 .DS_Store
 ./CMakeUserPresets.json

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -105,8 +105,12 @@ namespace ImGuiExt {
             }
 
             #if defined(GL_TEXTURE_2D_MULTISAMPLE)
+                GLint MaxSamples;
+                static auto SampleCount = 8;
 
-                constexpr static auto SampleCount = 8;
+                glGetIntegerv(GL_MAX_SAMPLES, &MaxSamples);
+
+                if(MaxSamples < 8) SampleCount = MaxSamples;
 
                 // Generate renderbuffer
                 GLuint renderbuffer;


### PR DESCRIPTION
### Problem description
https://gitlab.freedesktop.org/mesa/mesa/-/issues/11135
It turns out LLVMpipe only supports 4x multisampling. Checking GL_MAX_SAMPLES seems like the right thing to do.

### Implementation description
Right now, I only check GL_MAX_SAMPLES. Depending on the format, we might need to check GL_MAX_INTEGER_SAMPLES. I don't know how likely it is that you might want to use a different format in the future, glGetInternalformativ might be a safer option to retrieve the max number of samples we can use.

### Additional things
I guess I could merge the ```if```s at lines 95, 99 and 103 in imgui_imhex_extensions.cpp while we're at it.
