### PR TITLE
impr: Restore native macOS title bar double click gesture in borderless mode

### DIFF
--- a/lib/libimhex/include/hex/helpers/utils_macos.hpp
+++ b/lib/libimhex/include/hex/helpers/utils_macos.hpp
@@ -15,6 +15,8 @@
         void setupMacosWindowStyle(GLFWwindow *window, bool borderlessWindowMode);
 
         void enumerateFontsMacos();
+    
+        void toggleWindowZoomMacos(GLFWwindow *window);
     }
 
 #endif

--- a/lib/libimhex/include/hex/helpers/utils_macos.hpp
+++ b/lib/libimhex/include/hex/helpers/utils_macos.hpp
@@ -17,6 +17,7 @@
         void enumerateFontsMacos();
     
         void macosHandleTitlebarDoubleClickGesture(GLFWwindow *window);
+        bool macosIsWindowBeingResizedByUser(GLFWwindow *window);
     }
 
 #endif

--- a/lib/libimhex/include/hex/helpers/utils_macos.hpp
+++ b/lib/libimhex/include/hex/helpers/utils_macos.hpp
@@ -16,7 +16,7 @@
 
         void enumerateFontsMacos();
     
-        void toggleWindowZoomMacos(GLFWwindow *window);
+        void macosHandleTitlebarDoubleClickGesture(GLFWwindow *window);
     }
 
 #endif

--- a/lib/libimhex/source/helpers/utils_macos.m
+++ b/lib/libimhex/source/helpers/utils_macos.m
@@ -102,7 +102,7 @@
             }
         } else if ([action isEqualToString:@"Maximize"]) {
             // `[NSWindow zoom:_ sender]` takes over pumping the main runloop for the duration of the resize,
-            // and would interfere with our renderer's frame logic. Shedule it for the next frame
+            // and would interfere with our renderer's frame logic. Schedule it for the next frame
             
             CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopCommonModes, ^{
                 if ([cocoaWindow isZoomable]) {

--- a/lib/libimhex/source/helpers/utils_macos.m
+++ b/lib/libimhex/source/helpers/utils_macos.m
@@ -88,6 +88,16 @@
         CFRelease(fontDescriptors);
     }
 
+    void toggleWindowZoomMacos(GLFWwindow *window) {
+        NSWindow* cocoaWindow = glfwGetCocoaWindow(window);
+
+        // `[NSWindow performZoom:_ sender]` takes over pumping the main runloop for the duration of the resize,
+        // and would interfere with our renderer's frame logic. Shedule it for the next frame
+        CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopCommonModes, ^{
+            [cocoaWindow performZoom:nil];
+        });
+    }
+
     @interface HexDocument : NSDocument
 
     @end

--- a/lib/libimhex/source/helpers/utils_macos.m
+++ b/lib/libimhex/source/helpers/utils_macos.m
@@ -112,6 +112,12 @@
         }
     }
 
+    bool macosIsWindowBeingResizedByUser(GLFWwindow *window) {
+        NSWindow* cocoaWindow = glfwGetCocoaWindow(window);
+        
+        return cocoaWindow.inLiveResize;
+    }
+
     @interface HexDocument : NSDocument
 
     @end

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -826,7 +826,12 @@ namespace hex {
             auto win = static_cast<Window *>(glfwGetWindowUserPointer(window));
             win->m_unlockFrameRate = true;
             
-            #if !defined(OS_MACOS)
+            #if defined(OS_MACOS)
+                // Stop widgets registering hover effects while the window is being resized
+                if (macosIsWindowBeingResizedByUser(window)) {
+                    ImGui::GetIO().MousePos = ImVec2();
+                }
+            #else
                 win->fullFrame();
             #endif
         });

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -683,14 +683,20 @@ namespace hex {
         glfwMakeContextCurrent(backupContext);
 
         if (shouldRender) {
-            int displayWidth, displayHeight;
-            glfwGetFramebufferSize(m_window, &displayWidth, &displayHeight);
-            glViewport(0, 0, displayWidth, displayHeight);
-            glClearColor(0.00F, 0.00F, 0.00F, 0.00F);
-            glClear(GL_COLOR_BUFFER_BIT);
-            ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+            auto* drawData = ImGui::GetDrawData();
+            
+            // Avoid accidentally clearing the viewport when the application is minimized,
+            // otherwise the OS will display an empty frame during deminimization on macOS
+            if (drawData->DisplaySize.x != 0 && drawData->DisplaySize.y != 0) {
+                int displayWidth, displayHeight;
+                glfwGetFramebufferSize(m_window, &displayWidth, &displayHeight);
+                glViewport(0, 0, displayWidth, displayHeight);
+                glClearColor(0.00F, 0.00F, 0.00F, 0.00F);
+                glClear(GL_COLOR_BUFFER_BIT);
+                ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-            glfwSwapBuffers(m_window);
+                glfwSwapBuffers(m_window);
+            }
 
             m_unlockFrameRate = true;
         }

--- a/plugins/builtin/source/content/window_decoration.cpp
+++ b/plugins/builtin/source/content/window_decoration.cpp
@@ -401,7 +401,7 @@ namespace hex::plugin::builtin {
                         
                         // Drawing this button late allows widgets rendered before it to grab click events, forming an "input underlay"
                         if (ImGui::InvisibleButton("##mainMenuUnderlay", menuUnderlaySize, ImGuiButtonFlags_PressedOnDoubleClick)) {
-                            toggleWindowZoomMacos(window);
+                            macosHandleTitlebarDoubleClickGesture(window);
                         }
                     }
                 #endif

--- a/plugins/builtin/source/content/window_decoration.cpp
+++ b/plugins/builtin/source/content/window_decoration.cpp
@@ -392,6 +392,20 @@ namespace hex::plugin::builtin {
                 drawMenu();
                 drawTitleBar();
 
+                #if defined(OS_MACOS)
+                    if (ImHexApi::System::isBorderlessWindowModeEnabled()) {
+                        const auto windowSize = ImHexApi::System::getMainWindowSize();
+                        const auto menuUnderlaySize = ImVec2(windowSize.x, ImGui::GetCurrentWindowRead()->MenuBarHeight() * 1.5F);
+                        
+                        ImGui::SetCursorPos(ImVec2());
+                        
+                        // Drawing this button late allows widgets rendered before it to grab click events, forming an "input underlay"
+                        if (ImGui::InvisibleButton("##mainMenuUnderlay", menuUnderlaySize, ImGuiButtonFlags_PressedOnDoubleClick)) {
+                            toggleWindowZoomMacos(window);
+                        }
+                    }
+                #endif
+                
                 ImGui::EndMainMenuBar();
             } else {
                 ImGui::PopStyleVar(2);


### PR DESCRIPTION
### Problem description

#### Problem 1
In borderless mode ImHex disables the standard macOS titlebar rendering and input processing. As a result double clicking the titlebar does not trigger the native macOS behavior set in `System Settings -> Desktop & Dock -> Double-click a window's title bar to [Zoom/Minimize/Do nothing]`.

#### Problem 2
The ImHex window shows up as blank/transparent when de-minimizing it from the dock.

#### Problem 3
Widgets experience ghost hover inputs from the past position of the cursor during live resizing.

### Implementation description
ImGui elements consume input events in the order they are drawn. As a result by "drawing" an `InvisibleButton` over the content area of the titlebar we can catch unprocessed clicks in the titlebar area. Connecting this button's double clicks to the native window is then a trivial endeavour.

The blank windows was caused by the rendering stack clearing the GL buffer, but proceeding to draw nothing in it. I have short circuited this path.

Ghost hover inputs were squelched by consistently moving the ImGui cursor to `0, 0` during a live resize. The OS will dispatch a cursor positioning event once the resizing ends, restoring normal behavior.

### Screenshots
N/A

### Additional things
N/A