### PR TITLE
fix: Do not use custom repo gcc 13 for Ubuntu because it doesn't run on vanilla Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,11 +384,6 @@ jobs:
           apt update
           bash dist/get_deps_debian.sh
 
-          apt install software-properties-common -y
-          add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          apt update
-          apt install -y gcc-13 g++-13
-
       - name: ⬇️ Install .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -402,7 +397,7 @@ jobs:
           git config --global --add safe.directory '*'
           mkdir -p build
           cd build
-          CC=gcc-13 CXX=g++-13 cmake -G "Ninja"                       \
+          CC=gcc-12 CXX=g++-12 cmake -G "Ninja"                       \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}                    \
             -DCMAKE_INSTALL_PREFIX="/usr"                             \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache                        \


### PR DESCRIPTION
See https://discord.com/channels/789833418631675954/789838296376803358/1246523033884299284 and https://github.com/WerWolv/ImHex/pull/1720

The custom repo seems to pull a more recent glibc, that vanilla Ubuntu doesn't have

It also seems like the ICE I initially encountered (see #1720) doesn't show up anymore ?