### PR TITLE
allow one byte ranges edits

### DIFF
--- a/plugins/builtin/source/content/views/view_bookmarks.cpp
+++ b/plugins/builtin/source/content/views/view_bookmarks.cpp
@@ -435,7 +435,7 @@ namespace hex::plugin::builtin {
 
                             ImGui::PopItemWidth();
 
-                            if (updated && end > begin) {
+                            if (updated && end >= begin) {
                                 region = Region(begin, end - begin + 1);
                                 EventHighlightingChanged::post();
                             }


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
When entering for the end value the same value as the start it is not recorgnized as valid region, because end must be strictly greater than begin. Due to the +1 in the Region constructor this is not correct, because the end is included in the range.

### Implementation description
<!-- Explain what you did to correct the problem -->

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->
After:
![image](https://github.com/WerWolv/ImHex/assets/10099533/c45d2001-8790-430a-8f1a-4b65130f4d01)


### Additional things
<!-- Anything else you would like to say -->
