### PR TITLE
feat: log stacktrace implementation used

### DIFF
--- a/main/gui/include/stacktrace.hpp
+++ b/main/gui/include/stacktrace.hpp
@@ -15,6 +15,11 @@ namespace hex::stacktrace {
 
     void initialize();
 
-    std::vector<StackFrame> getStackTrace(); 
+    struct StackTraceResult {
+        std::vector<StackFrame> stackFrames;
+        std::string implementationName;
+    };
+
+    StackTraceResult getStackTrace(); 
 
 }

--- a/main/gui/source/crash_handlers.cpp
+++ b/main/gui/source/crash_handlers.cpp
@@ -63,7 +63,9 @@ namespace hex::crash {
     }
 
     static void printStackTrace() {
-        for (const auto &stackFrame : stacktrace::getStackTrace()) {
+        auto stackTraceResult = stacktrace::getStackTrace();
+        log::fatal("Stacktrace implementation used: {}", stackTraceResult.implementationName);
+        for (const auto &stackFrame : stackTraceResult.stackFrames) {
             if (stackFrame.line == 0)
                 log::fatal("  ({}) | {}", stackFrame.file, stackFrame.function);
             else

--- a/main/gui/source/crash_handlers.cpp
+++ b/main/gui/source/crash_handlers.cpp
@@ -64,7 +64,7 @@ namespace hex::crash {
 
     static void printStackTrace() {
         auto stackTraceResult = stacktrace::getStackTrace();
-        log::fatal("Stacktrace implementation used: {}", stackTraceResult.implementationName);
+        log::fatal("Printing stacktrace using implementation '{}'", stackTraceResult.implementationName);
         for (const auto &stackFrame : stackTraceResult.stackFrames) {
             if (stackFrame.line == 0)
                 log::fatal("  ({}) | {}", stackFrame.file, stackFrame.function);

--- a/main/gui/source/stacktrace.cpp
+++ b/main/gui/source/stacktrace.cpp
@@ -192,8 +192,12 @@ namespace {
     namespace hex::stacktrace {
 
         void initialize() { }
-        std::vector<StackFrame> getStackTrace() { return { StackFrame { "??", "Stacktrace collecting not available!", 0 } }; }
-
+        StackTraceResult getStackTrace() {
+            return StackTraceResult {
+                {StackFrame { "??", "Stacktrace collecting not available!", 0 }},
+                "none"
+            };
+        }
     }
     
 #endif

--- a/main/gui/source/stacktrace.cpp
+++ b/main/gui/source/stacktrace.cpp
@@ -100,7 +100,7 @@ namespace {
 
             SymCleanup(process);
 
-            return StackTraceResult{ stackTrace, "Windows" };
+            return StackTraceResult{ stackTrace, "StackWalk" };
         }
 
     }

--- a/main/gui/source/stacktrace.cpp
+++ b/main/gui/source/stacktrace.cpp
@@ -29,7 +29,7 @@ namespace {
 
         }
 
-        std::vector<StackFrame> getStackTrace() {
+        StackTraceResult getStackTrace() {
             std::vector<StackFrame> stackTrace;
 
             HANDLE process = GetCurrentProcess();
@@ -100,7 +100,7 @@ namespace {
 
             SymCleanup(process);
 
-            return stackTrace;
+            return StackTraceResult{ stackTrace, "Windows" };
         }
 
     }
@@ -119,7 +119,7 @@ namespace {
 
             }
 
-            std::vector<StackFrame> getStackTrace() {
+            StackTraceResult getStackTrace() {
                 static std::vector<StackFrame> result;
 
                 std::array<void*, 128> addresses = {};
@@ -135,7 +135,7 @@ namespace {
                     result.push_back(StackFrame { std::move(fileName), std::move(demangledName), 0 });
                 }
 
-                return result;
+                return StackTraceResult{ result, "execinfo" };
             }
 
         }
@@ -162,7 +162,7 @@ namespace {
                 }
             }
 
-            std::vector<StackFrame> getStackTrace() {
+            StackTraceResult getStackTrace() {
                 static std::vector<StackFrame> result;
 
                 result.clear();
@@ -180,7 +180,7 @@ namespace {
 
                 }
 
-                return result;
+                return StackTraceResult{ result, "backtrace" };
             }
 
         }


### PR DESCRIPTION
Related to #1768

This pull request introduces changes to enhance the logging functionality in ImHex by displaying the stacktrace implementation used when showing a stack trace. 

- **Stacktrace Implementation Logging**: Modifies `getStackTrace()` in `main/gui/source/stacktrace.cpp` to return a `StackTraceResult` struct, which includes both the stack frames and the name of the stacktrace implementation used (`Windows`, `execinfo`, or `backtrace` depending on the compilation flags). This allows for the identification of the stacktrace implementation in the logs.
- **Crash Handler Update**: Updates `printStackTrace()` in `main/gui/source/crash_handlers.cpp` to log the name of the stacktrace implementation used before printing the stack frames. This ensures that the implementation name is clearly logged whenever a stack trace is printed due to a crash.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WerWolv/ImHex/issues/1768?shareId=5aee5c60-349e-4742-956a-9771e70c57b5).