### PR TITLE
Fix off by one in "Export selection to file"

### DIFF
--- a/plugins/builtin/source/content/main_menu_items.cpp
+++ b/plugins/builtin/source/content/main_menu_items.cpp
@@ -200,7 +200,7 @@ namespace hex::plugin::builtin {
 
                     auto selection = ImHexApi::HexEditor::getSelection();
                     for (u64 address = selection->getStartAddress(); address <= selection->getEndAddress(); address += bytes.size()) {
-                        bytes.resize(std::min<u64>(bytes.size(), selection->getEndAddress() - address));
+                        bytes.resize(std::min<u64>(bytes.size(), selection->getEndAddress() - address + 1));
                         provider->read(address, bytes.data(), bytes.size());
 
                         outputFile.writeVector(bytes);


### PR DESCRIPTION
### Problem description
Export selection to file would never finish and wouldn't export the last byte.

### Implementation description
It was just a simple off by one when using the selection's end address to calculate the remaining data size. Add one to the remaining size calculation.

### Additional things
Fixes https://github.com/WerWolv/ImHex/issues/1733, https://github.com/WerWolv/ImHex/issues/1619 and https://github.com/WerWolv/ImHex/issues/1597.
