### PR TITLE
fix: Segfault when hashing regions spanning multiple MiBs

### DIFF
--- a/plugins/hashes/source/content/hashes.cpp
+++ b/plugins/hashes/source/content/hashes.cpp
@@ -27,7 +27,7 @@ namespace hex::plugin::hashes {
                 u64 readSize = std::min<u64>(1_MiB, (region.getEndAddress() - address) + 1);
 
                 auto data = reader.read(address, readSize);
-                hashFunction->TransformBytes({ data.begin(), data.end() }, address - region.getStartAddress(), data.size());
+                hashFunction->TransformBytes({ data.begin(), data.end() }, 0, data.size());
             }
 
             auto result = hashFunction->TransformFinal();


### PR DESCRIPTION
### Problem description

Attempting to do an MD5 hash of a large region (e.g. 2 MiB, ``u8 data[0x200000]``) crashes with a segfault.

### Implementation description

In ``hex::plugin::hashes::hashProviderRegionWithHashLib()``, ``hashFunction->TransformBytes()`` is called with an offset of 0, because it iterates over ``data`` and not the entire region.