### PR TITLE
feat: Support high-DPI rendering in a cross-platform way

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LIBIMHEX_SOURCES
         source/providers/memory_provider.cpp
         source/providers/undo/stack.cpp
 
+        source/ui/glfw_di.cpp
         source/ui/imgui_imhex_extensions.cpp
         source/ui/view.cpp
         source/ui/popup.cpp

--- a/lib/libimhex/include/hex/api/event_manager.hpp
+++ b/lib/libimhex/include/hex/api/event_manager.hpp
@@ -226,7 +226,7 @@ namespace hex {
     EVENT_DEF(EventAbnormalTermination, int);
     EVENT_DEF(EventThemeChanged);
     EVENT_DEF(EventOSThemeChanged);
-    EVENT_DEF(EventDPIChanged, float, float);
+    EVENT_DEF(EventDPIChanged, float);
     EVENT_DEF(EventWindowFocused, bool);
 
     /**

--- a/lib/libimhex/include/hex/api/event_manager.hpp
+++ b/lib/libimhex/include/hex/api/event_manager.hpp
@@ -226,7 +226,7 @@ namespace hex {
     EVENT_DEF(EventAbnormalTermination, int);
     EVENT_DEF(EventThemeChanged);
     EVENT_DEF(EventOSThemeChanged);
-    EVENT_DEF(EventDPIChanged, float);
+    EVENT_DEF(EventScaleChanged);
     EVENT_DEF(EventWindowFocused, bool);
 
     /**

--- a/lib/libimhex/include/hex/api/imhex_api.hpp
+++ b/lib/libimhex/include/hex/api/imhex_api.hpp
@@ -426,8 +426,8 @@ namespace hex {
                 void setMainDockSpaceId(ImGuiID id);
                 void setMainWindowHandle(GLFWwindow *window);
 
-                void setGlobalScale(float scale);
-                void setNativeScale(float scale);
+                void setContentScale(float scale);
+                void setUserScale(float scale);
 
                 void setBorderlessWindowMode(bool enabled);
                 void setMultiWindowMode(bool enabled);
@@ -481,17 +481,22 @@ namespace hex {
 
 
             /**
-             * @brief Gets the current global scale
-             * @return The current global scale
+             * @brief Gets the combined window content and user scale
+             * @return The combined window content and user scale
              */
             float getGlobalScale();
 
             /**
-             * @brief Gets the current native scale
-             * @return The current native scale
+             * @brief Gets the window content scale
+             * @return The window content scale
              */
-            float getNativeScale();
+            float getContentScale();
 
+            /**
+             * @brief Gets the user requested scale
+             * @return The user requested scale
+             */
+            float getUserScale();
 
             /**
              * @brief Gets the current main window position

--- a/lib/libimhex/include/hex/helpers/utils_macos.hpp
+++ b/lib/libimhex/include/hex/helpers/utils_macos.hpp
@@ -10,7 +10,6 @@
         void openWebpageMacos(const char *url);
         bool isMacosSystemDarkModeEnabled();
         bool isMacosFullScreenModeEnabled(GLFWwindow *window);
-        float getBackingScaleFactor();
 
         void setupMacosWindowStyle(GLFWwindow *window, bool borderlessWindowMode);
 

--- a/lib/libimhex/include/hex/ui/glfw_di.h
+++ b/lib/libimhex/include/hex/ui/glfw_di.h
@@ -1,0 +1,42 @@
+#pragma once
+
+struct GLFWwindow;
+struct GLFWmonitor;
+typedef void (* GLFWcursorposfun)(GLFWwindow* window, double diX, double diY);
+typedef void (* GLFWframebuffersizefun)(GLFWwindow* window, int width, int height);
+typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, float yscale);
+typedef void (* GLFWwindowposfun)(GLFWwindow* window, int diX, int diY);
+typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int diWidth, int diHeight);
+
+namespace hex {
+    /**
+     * These functions translate GLFW coordinates to/from a device-independent
+     * coordinate system so application code does not need to perform any
+     * platform-specific scaling transformations itself.
+     *
+     * This ought to be handled by GLFW, but GLFW <=3.4 leaks the platform’s
+     * coordinate system instead of abstracting it. Some platforms use a
+     * device-independent coordinate system (Wayland, macOS, Web) where others
+     * do not (X11, Win32), and this detail should not be leaking into
+     * application code.
+     */
+    namespace glfw {
+        GLFWwindow *CreateWindow(int diWidth, int diHeight, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
+        void DestroyWindow(GLFWwindow *window);
+        void *GetWindowUserPointer(GLFWwindow *window);
+        void *SetWindowUserPointer(GLFWwindow *window, void *pointer);
+        void GetMonitorPos(GLFWmonitor *monitor, int *diX, int *diY);
+        bool GetMonitorSize(GLFWmonitor *monitor, int *diWidth, int *diHeight);
+        void SetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int diXpos, int diYpos, int diWidth, int diHeight, int refreshRate);
+        void GetWindowPos(GLFWwindow *window, int *diX, int *diY);
+        void SetWindowPos(GLFWwindow *window, int diX, int diY);
+        void GetWindowSize(GLFWwindow *window, int *diWidth, int *diHeight);
+        void SetWindowSize(GLFWwindow *window, int diWidth, int diHeight);
+        void SetWindowSizeLimits(GLFWwindow *window, int diMinWidth, int diMinHeight, int diMaxWidth, int diMaxHeight);
+        GLFWcursorposfun SetCursorPosCallback(GLFWwindow *window, GLFWcursorposfun callback);
+        GLFWwindowposfun SetFramebufferSizeCallback(GLFWwindow *window, GLFWframebuffersizefun callback);
+        GLFWwindowcontentscalefun SetWindowContentScaleCallback(GLFWwindow *window, GLFWwindowcontentscalefun callback);
+        GLFWwindowposfun SetWindowPosCallback(GLFWwindow *window, GLFWwindowposfun callback);
+        GLFWwindowsizefun SetWindowSizeCallback(GLFWwindow *window, GLFWwindowsizefun callback);
+    }
+}

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -86,9 +86,9 @@ namespace ImGuiExt {
         static Texture fromGLTexture(unsigned int texture, int width, int height);
         static Texture fromBitmap(const ImU8 *buffer, int size, int width, int height, Filter filter = Filter::Nearest);
         static Texture fromBitmap(std::span<const std::byte> buffer, int width, int height, Filter filter = Filter::Nearest);
-        static Texture fromSVG(const char *path, int width = 0, int height = 0, Filter filter = Filter::Nearest);
-        static Texture fromSVG(const std::fs::path &path, int width = 0, int height = 0, Filter filter = Filter::Nearest);
-        static Texture fromSVG(std::span<const std::byte> buffer, int width = 0, int height = 0, Filter filter = Filter::Nearest);
+        static Texture fromSVG(const char *path, int width = 0, int height = 0, float scale = 1.0f, Filter filter = Filter::Nearest);
+        static Texture fromSVG(const std::fs::path &path, int width = 0, int height = 0, float scale = 1.0f, Filter filter = Filter::Nearest);
+        static Texture fromSVG(std::span<const std::byte> buffer, int width = 0, int height = 0, float scale = 1.0f, Filter filter = Filter::Nearest);
 
 
         ~Texture();
@@ -109,7 +109,7 @@ namespace ImGuiExt {
         }
 
         [[nodiscard]] auto getSize() const noexcept {
-            return ImVec2(m_width, m_height);
+            return ImVec2(float(m_width) / m_scale, float(m_height) / m_scale);
         }
 
         [[nodiscard]] constexpr auto getAspectRatio() const noexcept {
@@ -121,6 +121,7 @@ namespace ImGuiExt {
     private:
         ImTextureID m_textureId = nullptr;
         int m_width = 0, m_height = 0;
+        float m_scale = 1.0f;
     };
 
     float GetTextWrapPos();

--- a/lib/libimhex/source/api/imhex_api.cpp
+++ b/lib/libimhex/source/api/imhex_api.cpp
@@ -501,16 +501,15 @@ namespace hex {
             }
 
 
-            static float s_globalScale = 1.0;
-            void setGlobalScale(float scale) {
-                s_globalScale = scale;
+            static float s_contentScale = 1.0;
+            void setContentScale(float scale) {
+                s_contentScale = scale;
             }
 
-            static float s_nativeScale = 1.0;
-            void setNativeScale(float scale) {
-                s_nativeScale = scale;
+            static float s_userScale = 1.0;
+            void setUserScale(float scale) {
+                s_userScale = scale;
             }
-
 
             static bool s_borderlessWindowMode;
             void setBorderlessWindowMode(bool enabled) {
@@ -598,13 +597,16 @@ namespace hex {
         }
 
         float getGlobalScale() {
-            return impl::s_globalScale;
+            return getUserScale() * getContentScale();
         }
 
-        float getNativeScale() {
-            return impl::s_nativeScale;
+        float getContentScale() {
+            return impl::s_contentScale;
         }
 
+        float getUserScale() {
+            return impl::s_userScale;
+        }
 
         ImVec2 getMainWindowPosition() {
             if ((ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) != ImGuiConfigFlags_None)

--- a/lib/libimhex/source/helpers/utils.cpp
+++ b/lib/libimhex/source/helpers/utils.cpp
@@ -29,19 +29,19 @@
 namespace hex {
 
     float operator""_scaled(long double value) {
-        return value * ImHexApi::System::getGlobalScale();
+        return value * ImHexApi::System::getUserScale();
     }
 
     float operator""_scaled(unsigned long long value) {
-        return value * ImHexApi::System::getGlobalScale();
+        return value * ImHexApi::System::getUserScale();
     }
 
     ImVec2 scaled(const ImVec2 &vector) {
-        return vector * ImHexApi::System::getGlobalScale();
+        return vector * ImHexApi::System::getUserScale();
     }
 
     ImVec2 scaled(float x, float y) {
-        return ImVec2(x, y) * ImHexApi::System::getGlobalScale();
+        return ImVec2(x, y) * ImHexApi::System::getUserScale();
     }
 
     std::string to_string(u128 value) {

--- a/lib/libimhex/source/helpers/utils_macos.m
+++ b/lib/libimhex/source/helpers/utils_macos.m
@@ -42,10 +42,6 @@
         }
     }
 
-    float getBackingScaleFactor(void) {
-        return [[NSScreen mainScreen] backingScaleFactor];
-    }
-
     void setupMacosWindowStyle(GLFWwindow *window, bool borderlessWindowMode) {
         NSWindow* cocoaWindow = glfwGetCocoaWindow(window);
 

--- a/lib/libimhex/source/ui/glfw_di.cpp
+++ b/lib/libimhex/source/ui/glfw_di.cpp
@@ -1,0 +1,223 @@
+#include <hex/ui/glfw_di.h>
+
+#include <GLFW/glfw3.h>
+
+#include <new>
+#include <stdexcept>
+
+namespace hex::glfw {
+    struct GlfwData {
+        void *userPointer = nullptr;
+        GLFWcursorposfun userCursorPosFn = nullptr;
+        GLFWframebuffersizefun userFramebufferSizeFn = nullptr;
+        GLFWwindowcontentscalefun userWindowContentScaleFn = nullptr;
+        GLFWwindowposfun userWindowPosFn = nullptr;
+        GLFWwindowsizefun userWindowSizeFn = nullptr;
+        float scaleX = 1.0F;
+        float scaleY = 1.0F;
+    };
+
+    static void RecalculateScale(GLFWwindow *window, GlfwData *data) {
+        int width, height, framebufferWidth, framebufferHeight;
+        float scaleX, scaleY;
+        glfwGetWindowSize(window, &width, &height);
+        glfwGetFramebufferSize(window, &framebufferWidth, &framebufferHeight);
+        glfwGetWindowContentScale(window, &scaleX, &scaleY);
+        data->scaleX = scaleX / (float(framebufferWidth) / width);
+        data->scaleY = scaleY / (float(framebufferHeight) / height);
+    }
+
+    static GlfwData* GetWindowData(GLFWwindow *window) {
+        if (!window)
+            return nullptr;
+
+        return static_cast<GlfwData *>(glfwGetWindowUserPointer(window));
+    }
+
+    template <typename T>
+    void FromGLFW(GLFWwindow *window, T *x, T *y) {
+        auto data = GetWindowData(window);
+        if (!data)
+            throw std::runtime_error("Missing window data; did you use glfwCreateWindow directly instead of hex::glfw::CreateWindow?");
+        if (x)
+            *x /= data->scaleX;
+        if (y)
+            *y /= data->scaleY;
+    }
+
+    template <typename T>
+    static void FromGLFW(GLFWmonitor *monitor, T *x, T *y) {
+        float xScale, yScale;
+        glfwGetMonitorContentScale(monitor, &xScale, &yScale);
+        if (x)
+            *x /= xScale;
+        if (y)
+            *y /= yScale;
+    }
+
+    template <typename T>
+    void ToGLFW(GLFWwindow *window, T *x, T *y) {
+        auto data = GetWindowData(window);
+        if (!data)
+            throw std::runtime_error("Missing window data; did you use glfwCreateWindow directly instead of hex::glfw::CreateWindow?");
+        if (x)
+            *x *= data->scaleX;
+        if (y)
+            *y *= data->scaleY;
+    }
+
+    template <typename T>
+    static void ToGLFW(GLFWmonitor *monitor, T *x, T *y) {
+        float xScale, yScale;
+        glfwGetMonitorContentScale(monitor, &xScale, &yScale);
+        if (x)
+            *x *= xScale;
+        if (y)
+            *y *= yScale;
+    }
+
+    GLFWwindow* CreateWindow(int diWidth, int diHeight, const char* title, GLFWmonitor* monitor, GLFWwindow* share) {
+        auto window = glfwCreateWindow(1, 1, title, monitor, share);
+        if (!window)
+            return nullptr;
+
+        auto *data = new (std::nothrow) GlfwData;
+        if (!data) {
+            glfwDestroyWindow(window);
+            return nullptr;
+        }
+
+        glfwSetWindowUserPointer(window, data);
+        RecalculateScale(window, data);
+        glfwSetWindowSize(window, diWidth * data->scaleX, diHeight * data->scaleY);
+        glfwSetFramebufferSizeCallback(window, [](GLFWwindow *window, int width, int height) {
+            auto data = GetWindowData(window);
+            RecalculateScale(window, data);
+            if (data->userFramebufferSizeFn)
+                (data->userFramebufferSizeFn)(window, width, height);
+        });
+        glfwSetWindowContentScaleCallback(window, [](GLFWwindow *window, float scaleX, float scaleY) {
+            auto data = GetWindowData(window);
+            RecalculateScale(window, data);
+            if (data->userWindowContentScaleFn)
+                (data->userWindowContentScaleFn)(window, scaleX, scaleY);
+        });
+
+        return window;
+    }
+
+    void DestroyWindow(GLFWwindow *window) {
+        if (!window)
+            return;
+
+        delete GetWindowData(window);
+        glfwDestroyWindow(window);
+    }
+
+    void *GetWindowUserPointer(GLFWwindow *window) {
+        if (!window)
+            return nullptr;
+
+        return GetWindowData(window)->userPointer;
+    }
+
+    void *SetWindowUserPointer(GLFWwindow *window, void *pointer) {
+        if (!window)
+            return nullptr;
+
+        auto data = GetWindowData(window);
+        auto prev = data->userPointer;
+        data->userPointer = pointer;
+        return prev;
+    }
+
+    bool GetMonitorSize(GLFWmonitor *monitor, int *diWidth, int *diHeight) {
+        auto mode = glfwGetVideoMode(monitor);
+        if (!mode)
+            return false;
+
+        if (diWidth)
+            *diWidth = mode->width;
+        if (diHeight)
+            *diHeight = mode->height;
+        FromGLFW(monitor, diWidth, diHeight);
+
+        return true;
+    }
+
+    void GetMonitorPos(GLFWmonitor *monitor, int *diX, int *diY) {
+        glfwGetMonitorPos(monitor, diX, diY);
+        FromGLFW(monitor, diX, diY);
+    }
+
+    void SetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int diXpos, int diYpos, int diWidth, int diHeight, int refreshRate) {
+        if (monitor)
+            ToGLFW(monitor, &diXpos, &diYpos);
+        else
+            ToGLFW(window, &diXpos, &diYpos);
+
+        ToGLFW(window, &diWidth, &diHeight);
+        glfwSetWindowMonitor(window, monitor, diXpos, diYpos, diWidth, diHeight, refreshRate);
+    }
+
+    void GetWindowPos(GLFWwindow *window, int *diX, int *diY) {
+        glfwGetWindowPos(window, diX, diY);
+        FromGLFW(window, diX, diY);
+    }
+
+    void SetWindowPos(GLFWwindow *window, int diX, int diY) {
+        ToGLFW(window, &diX, &diY);
+        glfwSetWindowPos(window, diX, diY);
+    }
+
+    void GetWindowSize(GLFWwindow *window, int *diWidth, int *diHeight) {
+        glfwGetWindowSize(window, diWidth, diHeight);
+        FromGLFW(window, diWidth, diHeight);
+    }
+
+    void SetWindowSize(GLFWwindow *window, int diWidth, int diHeight) {
+        ToGLFW(window, &diWidth, &diHeight);
+        glfwSetWindowSize(window, diWidth, diHeight);
+    }
+
+    void SetWindowSizeLimits(GLFWwindow *window, int diMinWidth, int diMinHeight, int diMaxWidth, int diMaxHeight) {
+        ToGLFW(window,
+            diMinWidth == GLFW_DONT_CARE ? nullptr : &diMinWidth,
+            diMinHeight == GLFW_DONT_CARE ? nullptr : &diMinHeight);
+        ToGLFW(window,
+            diMaxWidth == GLFW_DONT_CARE ? nullptr : &diMaxWidth,
+            diMaxHeight == GLFW_DONT_CARE ? nullptr : &diMaxHeight);
+        glfwSetWindowSizeLimits(window, diMinWidth, diMinHeight, diMaxWidth, diMaxHeight);
+    }
+
+    #define IMHEX_WINDOW_CALLBACK_SCALE(fnName, cbType, paramType)              \
+    static void fnName##Wrapper(GLFWwindow *window, paramType x, paramType y) { \
+        FromGLFW(window, &x, &y);                                               \
+        (GetWindowData(window)->user##fnName##Fn)(window, x, y);                \
+    }                                                                           \
+                                                                                \
+    cbType Set##fnName##Callback(GLFWwindow *window, cbType callback) {         \
+        auto data = GetWindowData(window);                                      \
+        auto previous = data->user##fnName##Fn;                                 \
+        data->user##fnName##Fn = callback;                                      \
+        glfwSet##fnName##Callback(window, callback ? fnName##Wrapper : nullptr);\
+        return previous;                                                        \
+    }
+
+    IMHEX_WINDOW_CALLBACK_SCALE(CursorPos, GLFWcursorposfun, double)
+    IMHEX_WINDOW_CALLBACK_SCALE(WindowPos, GLFWwindowposfun, int)
+    IMHEX_WINDOW_CALLBACK_SCALE(WindowSize, GLFWwindowsizefun, int)
+    #undef IMHEX_WINDOW_CALLBACK_SCALE
+
+    #define IMHEX_WINDOW_CALLBACK_RECALC(fnName, cbType)                        \
+    cbType Set##fnName##Callback(GLFWwindow *window, cbType callback) {         \
+        auto data = GetWindowData(window);                                      \
+        auto previous = data->user##fnName##Fn;                                 \
+        data->user##fnName##Fn = callback;                                      \
+        return previous;                                                        \
+    }
+
+    IMHEX_WINDOW_CALLBACK_RECALC(FramebufferSize, GLFWframebuffersizefun)
+    IMHEX_WINDOW_CALLBACK_RECALC(WindowContentScale, GLFWwindowcontentscalefun)
+    #undef IMHEX_WINDOW_CALLBACK_RECALC
+}

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -33,7 +33,7 @@ namespace ImGuiExt {
 
     namespace {
 
-        void adjustSVGScale(const lunasvg::Document *document, int &width, int &height, int scale) {
+        void adjustSVGScale(const lunasvg::Document *document, int &width, int &height, float scale) {
             if (document->width() == 0 || document->height() == 0)
                 return;
 

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -23,11 +23,13 @@
 #include <hex/api/task_manager.hpp>
 #include <hex/api/theme_manager.hpp>
 #include <hex/helpers/logger.hpp>
+#include <hex/helpers/utils.hpp>
 
 
 namespace ImGuiExt {
 
     using namespace ImGui;
+    using hex::operator""_scaled;
 
     namespace {
 
@@ -500,8 +502,8 @@ namespace ImGuiExt {
         RenderTextClipped(bb.Min + style.FramePadding * 2 + ImVec2(style.FramePadding.x * 2, label_size.y), bb.Max - style.FramePadding, description, nullptr, &text_size, style.ButtonTextAlign, &clipBb);
         PopStyleColor();
 
-        RenderFrame(ImVec2(bb.Min.x, bb.Max.y - 5 * hex::ImHexApi::System::getGlobalScale()), bb.Max, GetColorU32(ImGuiCol_ScrollbarBg), false, style.FrameRounding);
-        RenderFrame(ImVec2(bb.Min.x, bb.Max.y - 5 * hex::ImHexApi::System::getGlobalScale()), ImVec2(bb.Min.x + fraction * bb.GetSize().x, bb.Max.y), GetColorU32(ImGuiCol_Button), false, style.FrameRounding);
+        RenderFrame(ImVec2(bb.Min.x, bb.Max.y - 5_scaled), bb.Max, GetColorU32(ImGuiCol_ScrollbarBg), false, style.FrameRounding);
+        RenderFrame(ImVec2(bb.Min.x, bb.Max.y - 5_scaled), ImVec2(bb.Min.x + fraction * bb.GetSize().x, bb.Max.y), GetColorU32(ImGuiCol_Button), false, style.FrameRounding);
         RenderFrame(bb.Min, bb.Max, 0x00, true, style.FrameRounding);
 
         PopStyleVar(2);
@@ -579,7 +581,7 @@ namespace ImGuiExt {
             if (!std::string_view(text).empty()) {
                 const auto textWidth = CalcTextSize(text).x;
 
-                const auto maxWidth = 300 * hex::ImHexApi::System::getGlobalScale();
+                const auto maxWidth = 300_scaled;
                 const bool wrapping = textWidth > maxWidth;
 
                 if (wrapping)
@@ -912,7 +914,7 @@ namespace ImGuiExt {
         const ImGuiStyle &style = g.Style;
 
         ImVec2 pos  = window->DC.CursorPos + ImVec2(0, yOffset);
-        ImVec2 size = CalcItemSize(ImVec2(100, 5) * hex::ImHexApi::System::getGlobalScale(), 100, g.FontSize + style.FramePadding.y * 2.0F);
+        ImVec2 size = CalcItemSize(ImVec2(100_scaled, 5_scaled), 100, g.FontSize + style.FramePadding.y * 2.0F);
         ImRect bb(pos, pos + size);
         ItemSize(size, 0);
         if (!ItemAdd(bb, 0))

--- a/main/gui/source/window/linux_window.cpp
+++ b/main/gui/source/window/linux_window.cpp
@@ -11,6 +11,8 @@
     #include <hex/helpers/logger.hpp>
     #include <hex/helpers/default_paths.hpp>
 
+    #include <hex/ui/glfw_di.h>
+
     #include <wolv/utils/core.hpp>
 
     #include <nlohmann/json.hpp>
@@ -18,7 +20,6 @@
     #include <sys/wait.h>
     #include <unistd.h>
 
-    #include <imgui_impl_glfw.h>
     #include <string.h>
     #include <ranges>
 
@@ -74,10 +75,6 @@ namespace hex {
     }
 
     void Window::configureGLFW() {
-        #if defined(GLFW_SCALE_FRAMEBUFFER)
-            glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
-        #endif
-
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_DECORATED, ImHexApi::System::isBorderlessWindowModeEnabled() ? GL_FALSE : GL_TRUE);
@@ -140,7 +137,7 @@ namespace hex {
         });
 
         glfwSetWindowRefreshCallback(m_window, [](GLFWwindow *window) {
-            auto win = static_cast<Window *>(glfwGetWindowUserPointer(window));
+            auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
             win->fullFrame();
         });
 

--- a/main/gui/source/window/macos_window.cpp
+++ b/main/gui/source/window/macos_window.cpp
@@ -11,10 +11,10 @@
     #include <hex/helpers/logger.hpp>
     #include <hex/helpers/default_paths.hpp>
 
+    #include <hex/ui/glfw_di.h>
+
     #include <cstdio>
     #include <unistd.h>
-
-    #include <imgui_impl_glfw.h>
 
 namespace hex {
 
@@ -27,7 +27,6 @@ namespace hex {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
         glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, GLFW_TRUE);
         glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
     }
@@ -99,7 +98,7 @@ namespace hex {
         setupMacosWindowStyle(m_window, ImHexApi::System::isBorderlessWindowModeEnabled());
 
         glfwSetWindowRefreshCallback(m_window, [](GLFWwindow *window) {
-            auto win = static_cast<Window *>(glfwGetWindowUserPointer(window));
+            auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
             win->fullFrame();
         });
     }

--- a/main/gui/source/window/web_window.cpp
+++ b/main/gui/source/window/web_window.cpp
@@ -6,6 +6,7 @@
 #include <emscripten/html5.h>
 
 #include <hex/api/event_manager.hpp>
+#include <hex/ui/glfw_di.h>
 
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -119,7 +120,7 @@ namespace hex {
         });
 
         glfwSetWindowRefreshCallback(m_window, [](GLFWwindow *window) {
-            auto win = static_cast<Window *>(glfwGetWindowUserPointer(window));
+            auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
             resizeCanvas();
             win->fullFrame();
         });

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -933,7 +933,7 @@ namespace hex {
                 return;
 
             ImHexApi::System::impl::setContentScale(newScale);
-            EventDPIChanged::post(newScale);
+            EventScaleChanged::post();
 
             auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
             win->fullFrame();
@@ -1040,7 +1040,7 @@ namespace hex {
             plugin.setImGuiContext(ImGui::GetCurrentContext());
 
         RequestInitThemeHandlers::post();
-        EventDPIChanged::post(ImHexApi::System::getContentScale());
+        EventScaleChanged::post();
     }
 
     void Window::exitGLFW() {

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -849,10 +849,8 @@ namespace hex {
             auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
             win->m_unlockFrameRate = true;
 
-            #if !defined(OS_WINDOWS)
-                if (!glfwGetWindowAttrib(window, GLFW_ICONIFIED))
-                    ImHexApi::System::impl::setMainWindowSize(width, height);
-            #endif
+            if (!glfwGetWindowAttrib(window, GLFW_ICONIFIED))
+                ImHexApi::System::impl::setMainWindowSize(width, height);
 
             #if defined(OS_MACOS)
                 // Stop widgets registering hover effects while the window is being resized
@@ -929,13 +927,16 @@ namespace hex {
             EventWindowClosing::post(window);
         });
 
-        hex::glfw::SetWindowContentScaleCallback(m_window, [](GLFWwindow *, float newScale, float) {
+        hex::glfw::SetWindowContentScaleCallback(m_window, [](GLFWwindow *window, float newScale, float) {
             auto oldScale = ImHexApi::System::getContentScale();
             if (newScale == 0 || oldScale == newScale)
                 return;
 
             ImHexApi::System::impl::setContentScale(newScale);
             EventDPIChanged::post(newScale);
+
+            auto win = static_cast<Window *>(hex::glfw::GetWindowUserPointer(window));
+            win->fullFrame();
         });
 
         hex::glfw::SetWindowSizeLimits(m_window, 480, 360, GLFW_DONT_CARE, GLFW_DONT_CARE);

--- a/plugins/builtin/romfs/lang/de_DE.json
+++ b/plugins/builtin/romfs/lang/de_DE.json
@@ -492,7 +492,6 @@
         "hex.builtin.setting.interface.multi_windows": "Multi-Window-Unterstützung aktivieren",
         "hex.builtin.setting.interface.pattern_data_row_bg": "Aktiviere farbige Patternhintergründe",
         "hex.builtin.setting.interface.restore_window_pos": "Fensterposition und Grösse wiederherstellen",
-        "hex.builtin.setting.interface.scaling.native": "Nativ",
         "hex.builtin.setting.interface.scaling_factor": "Skalierung",
         "hex.builtin.setting.interface.show_header_command_palette": "Befehlspalette in Titelbar anzeigen",
         "hex.builtin.setting.interface.style": "Stil",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -501,7 +501,6 @@
         "hex.builtin.setting.interface.language": "Language",
         "hex.builtin.setting.interface.multi_windows": "Enable Multi Window support",
         "hex.builtin.setting.interface.scaling_factor": "Scaling",
-        "hex.builtin.setting.interface.scaling.native": "Native",
         "hex.builtin.setting.interface.scaling.fractional_warning": "The default font does not support fractional scaling. For better results, select a custom font in the 'Font' tab.",
         "hex.builtin.setting.interface.show_header_command_palette": "Show Command Palette in Window Header",
         "hex.builtin.setting.interface.style": "Styling",

--- a/plugins/builtin/romfs/lang/es_ES.json
+++ b/plugins/builtin/romfs/lang/es_ES.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "Activar soporte de ventanas múltiples",
         "hex.builtin.setting.interface.pattern_data_row_bg": "",
         "hex.builtin.setting.interface.restore_window_pos": "",
-        "hex.builtin.setting.interface.scaling.native": "Nativo",
         "hex.builtin.setting.interface.scaling_factor": "Escalado",
         "hex.builtin.setting.interface.style": "",
         "hex.builtin.setting.interface.wiki_explain_language": "Idioma de Wikipedia",

--- a/plugins/builtin/romfs/lang/hu_HU.json
+++ b/plugins/builtin/romfs/lang/hu_HU.json
@@ -485,7 +485,6 @@
         "hex.builtin.setting.interface.language": "Nyelv",
         "hex.builtin.setting.interface.multi_windows": "Több ablakos mód engedélyezése",
         "hex.builtin.setting.interface.scaling_factor": "Méretezés",
-        "hex.builtin.setting.interface.scaling.native": "Natív",
         "hex.builtin.setting.interface.show_header_command_palette": "Parancspaletta mutatása az ablak fejlécben",
         "hex.builtin.setting.interface.style": "Stílusok",
         "hex.builtin.setting.interface.window": "Ablak",

--- a/plugins/builtin/romfs/lang/it_IT.json
+++ b/plugins/builtin/romfs/lang/it_IT.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "",
         "hex.builtin.setting.interface.pattern_data_row_bg": "",
         "hex.builtin.setting.interface.restore_window_pos": "",
-        "hex.builtin.setting.interface.scaling.native": "Nativo",
         "hex.builtin.setting.interface.scaling_factor": "Scale",
         "hex.builtin.setting.interface.style": "",
         "hex.builtin.setting.interface.wiki_explain_language": "",

--- a/plugins/builtin/romfs/lang/ja_JP.json
+++ b/plugins/builtin/romfs/lang/ja_JP.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "",
         "hex.builtin.setting.interface.pattern_data_row_bg": "",
         "hex.builtin.setting.interface.restore_window_pos": "",
-        "hex.builtin.setting.interface.scaling.native": "ネイティブ",
         "hex.builtin.setting.interface.scaling_factor": "スケーリング",
         "hex.builtin.setting.interface.style": "",
         "hex.builtin.setting.interface.wiki_explain_language": "",

--- a/plugins/builtin/romfs/lang/ko_KR.json
+++ b/plugins/builtin/romfs/lang/ko_KR.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "다중 창 지원 사용",
         "hex.builtin.setting.interface.pattern_data_row_bg": "색상 패턴 배경 사용",
         "hex.builtin.setting.interface.restore_window_pos": "창 위치 복원",
-        "hex.builtin.setting.interface.scaling.native": "기본",
         "hex.builtin.setting.interface.scaling_factor": "배율",
         "hex.builtin.setting.interface.style": "스타일",
         "hex.builtin.setting.interface.wiki_explain_language": "위키백과 언어",

--- a/plugins/builtin/romfs/lang/pt_BR.json
+++ b/plugins/builtin/romfs/lang/pt_BR.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "",
         "hex.builtin.setting.interface.pattern_data_row_bg": "",
         "hex.builtin.setting.interface.restore_window_pos": "",
-        "hex.builtin.setting.interface.scaling.native": "Nativo",
         "hex.builtin.setting.interface.scaling_factor": "Scaling",
         "hex.builtin.setting.interface.style": "",
         "hex.builtin.setting.interface.wiki_explain_language": "Idioma do Wikipedia",

--- a/plugins/builtin/romfs/lang/zh_CN.json
+++ b/plugins/builtin/romfs/lang/zh_CN.json
@@ -530,7 +530,6 @@
         "hex.builtin.setting.interface.native_window_decorations": "使用操作系统窗口装饰",
         "hex.builtin.setting.interface.pattern_data_row_bg": "启用彩色图案背景",
         "hex.builtin.setting.interface.restore_window_pos": "恢复窗口位置",
-        "hex.builtin.setting.interface.scaling.native": "本地默认",
         "hex.builtin.setting.interface.scaling_factor": "缩放",
         "hex.builtin.setting.interface.show_header_command_palette": "在窗口标题中显示命令面板",
         "hex.builtin.setting.interface.style": "风格",

--- a/plugins/builtin/romfs/lang/zh_TW.json
+++ b/plugins/builtin/romfs/lang/zh_TW.json
@@ -489,7 +489,6 @@
         "hex.builtin.setting.interface.multi_windows": "啟用多視窗支援",
         "hex.builtin.setting.interface.pattern_data_row_bg": "",
         "hex.builtin.setting.interface.restore_window_pos": "Restore window position",
-        "hex.builtin.setting.interface.scaling.native": "原生",
         "hex.builtin.setting.interface.scaling_factor": "縮放",
         "hex.builtin.setting.interface.style": "",
         "hex.builtin.setting.interface.wiki_explain_language": "維基百科語言",

--- a/plugins/builtin/source/content/events.cpp
+++ b/plugins/builtin/source/content/events.cpp
@@ -7,6 +7,7 @@
 #include <hex/api/workspace_manager.hpp>
 
 #include <hex/providers/provider.hpp>
+#include <hex/ui/glfw_di.h>
 #include <hex/ui/view.hpp>
 
 #include <imgui.h>
@@ -240,8 +241,8 @@ namespace hex::plugin::builtin {
 
             {
                 int x = 0, y = 0, width = 0, height = 0, maximized = 0;
-                glfwGetWindowPos(window, &x, &y);
-                glfwGetWindowSize(window, &width, &height);
+                hex::glfw::GetWindowPos(window, &x, &y);
+                hex::glfw::GetWindowSize(window, &width, &height);
                 maximized = glfwGetWindowAttrib(window, GLFW_MAXIMIZED);
 
                 ContentRegistry::Settings::write<int>("hex.builtin.setting.interface", "hex.builtin.setting.interface.window.x", x);

--- a/plugins/builtin/source/content/init_tasks.cpp
+++ b/plugins/builtin/source/content/init_tasks.cpp
@@ -99,20 +99,21 @@ namespace hex::plugin::builtin {
         }
 
         bool configureUIScale() {
-            EventDPIChanged::subscribe([](float, float newScaling) {
-                int interfaceScaleSetting = int(ContentRegistry::Settings::read<float>("hex.builtin.setting.interface", "hex.builtin.setting.interface.scaling_factor", 0.0F) * 10.0F);
+            int interfaceScaleSetting = int(ContentRegistry::Settings::read<float>("hex.builtin.setting.interface", "hex.builtin.setting.interface.scaling_factor", 1.0F) * 10.0F);
 
-                float interfaceScaling;
-                if (interfaceScaleSetting == 0)
-                    interfaceScaling = newScaling;
-                else
-                    interfaceScaling = interfaceScaleSetting / 10.0F;
+            float interfaceScaling;
+            // 0 used to mean 'native' but with DPI awareness in GLFW this just
+            // means no UI scaling
+            if (interfaceScaleSetting == 0) {
+                interfaceScaling = 1.0F;
+                ContentRegistry::Settings::write<float>("hex.builtin.setting.interface", "hex.builtin.setting.interface.scaling_factor", 1.0F);
+            } else
+                interfaceScaling = interfaceScaleSetting / 10.0F;
 
-                ImHexApi::System::impl::setGlobalScale(interfaceScaling);
-            });
-
-            const auto nativeScale = ImHexApi::System::getNativeScale();
-            EventDPIChanged::post(nativeScale, nativeScale);
+            // An `EventScaleChanged` event should be posted when the main
+            // window loads to communicate the content scale, so there should be
+            // no need to send one here too
+            ImHexApi::System::impl::setUserScale(interfaceScaling);
 
             return true;
         }

--- a/plugins/builtin/source/content/main_menu_items.cpp
+++ b/plugins/builtin/source/content/main_menu_items.cpp
@@ -3,6 +3,7 @@
 #include <imgui.h>
 #include <implot.h>
 
+#include <hex/ui/glfw_di.h>
 #include <hex/ui/view.hpp>
 #include <hex/api/shortcut_manager.hpp>
 #include <hex/api/project_file_manager.hpp>
@@ -536,11 +537,14 @@ namespace hex::plugin::builtin {
                     size     = ImHexApi::System::getMainWindowSize();
 
                     const auto monitor = glfwGetPrimaryMonitor();
-                    const auto videoMode = glfwGetVideoMode(monitor);
-
-                    glfwSetWindowMonitor(window, monitor, 0, 0, videoMode->width, videoMode->height, videoMode->refreshRate);
+                    auto videoMode = glfwGetVideoMode(monitor);
+                    if (videoMode) {
+                        int monitorWidth, monitorHeight;
+                        hex::glfw::GetMonitorSize(monitor, &monitorWidth, &monitorHeight);
+                        hex::glfw::SetWindowMonitor(window, monitor, 0, 0, monitorWidth, monitorHeight, videoMode->refreshRate);
+                    }
                 } else {
-                    glfwSetWindowMonitor(window, nullptr, position.x, position.y, size.x, size.y, 0);
+                    hex::glfw::SetWindowMonitor(window, nullptr, position.x, position.y, size.x, size.y, 0);
                 }
 
             }, []{ return true; }, []{ return glfwGetWindowMonitor(ImHexApi::System::getMainWindowHandle()) != nullptr; });

--- a/plugins/builtin/source/content/out_of_box_experience.cpp
+++ b/plugins/builtin/source/content/out_of_box_experience.cpp
@@ -442,8 +442,12 @@ namespace hex::plugin::builtin {
             ImHexApi::System::setWindowResizable(false);
 
             const auto imageTheme = ThemeManager::getImageTheme();
-            const auto scale = ImHexApi::System::getContentScale();
-            s_imhexBanner    = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>(), 300_scaled, 0, scale);
+            auto loadBanner = [=] {
+                const auto scale = ImHexApi::System::getContentScale();
+                s_imhexBanner = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>(), 300_scaled, 0, scale);
+            };
+            EventScaleChanged::subscribe(loadBanner);
+            loadBanner();
             s_compassTexture = ImGuiExt::Texture::fromImage(romfs::get("assets/common/compass.png").span<std::byte>());
             s_globeTexture   = ImGuiExt::Texture::fromImage(romfs::get("assets/common/globe.png").span<std::byte>());
             s_screenshotDescriptions = nlohmann::json::parse(romfs::get("assets/screenshot_descriptions.json").string());

--- a/plugins/builtin/source/content/out_of_box_experience.cpp
+++ b/plugins/builtin/source/content/out_of_box_experience.cpp
@@ -100,7 +100,7 @@ namespace hex::plugin::builtin {
                         ImGui::EndChild();
 
                         if (!s_screenshots.empty()) {
-                            const auto imageSize = s_screenshots.front().second.getSize() * ImHexApi::System::getGlobalScale();
+                            const auto imageSize = scaled(s_screenshots.front().second.getSize());
                             const auto padding = ImGui::GetStyle().CellPadding.x;
                             const auto stride = imageSize.x + padding * 2;
                             static bool imageHovered = false;
@@ -221,7 +221,7 @@ namespace hex::plugin::builtin {
                             currLanguage = languages.begin();
 
                         // Draw globe image
-                        const auto imageSize = s_compassTexture.getSize() / (1.5F * (1.0F / ImHexApi::System::getGlobalScale()));
+                        const auto imageSize = scaled(s_compassTexture.getSize() / 1.5F);
                         ImGui::SetCursorPos((ImGui::GetWindowSize() / 2 - imageSize / 2) - ImVec2(0, 50_scaled));
                         ImGui::Image(s_globeTexture, imageSize);
 
@@ -370,7 +370,7 @@ namespace hex::plugin::builtin {
                         ImGui::NewLine();
 
                         // Draw compass image
-                        const auto imageSize = s_compassTexture.getSize() / (1.5F * (1.0F / ImHexApi::System::getGlobalScale()));
+                        const auto imageSize = scaled(s_compassTexture.getSize() / 1.5F);
                         ImGui::SetCursorPos((ImGui::GetWindowSize() / 2 - imageSize / 2) - ImVec2(0, 50_scaled));
                         ImGui::Image(s_compassTexture, imageSize);
 

--- a/plugins/builtin/source/content/out_of_box_experience.cpp
+++ b/plugins/builtin/source/content/out_of_box_experience.cpp
@@ -76,7 +76,7 @@ namespace hex::plugin::builtin {
 
                 // Draw banner
                 ImGui::SetCursorPos(scaled({ 25 * bannerSlideIn, 25 }));
-                const auto bannerSize = s_imhexBanner.getSize() / (3.0F * (1.0F / ImHexApi::System::getGlobalScale()));
+                const auto bannerSize = s_imhexBanner.getSize();
                 ImGui::Image(
                     s_imhexBanner,
                     bannerSize,
@@ -443,7 +443,7 @@ namespace hex::plugin::builtin {
 
             const auto imageTheme = ThemeManager::getImageTheme();
             const auto scale = ImHexApi::System::getContentScale();
-            s_imhexBanner    = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>(), 0, 0, scale);
+            s_imhexBanner    = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>(), 300_scaled, 0, scale);
             s_compassTexture = ImGuiExt::Texture::fromImage(romfs::get("assets/common/compass.png").span<std::byte>());
             s_globeTexture   = ImGuiExt::Texture::fromImage(romfs::get("assets/common/globe.png").span<std::byte>());
             s_screenshotDescriptions = nlohmann::json::parse(romfs::get("assets/screenshot_descriptions.json").string());

--- a/plugins/builtin/source/content/out_of_box_experience.cpp
+++ b/plugins/builtin/source/content/out_of_box_experience.cpp
@@ -442,7 +442,8 @@ namespace hex::plugin::builtin {
             ImHexApi::System::setWindowResizable(false);
 
             const auto imageTheme = ThemeManager::getImageTheme();
-            s_imhexBanner    = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>());
+            const auto scale = ImHexApi::System::getContentScale();
+            s_imhexBanner    = ImGuiExt::Texture::fromSVG(romfs::get(hex::format("assets/{}/banner.svg", imageTheme)).span<std::byte>(), 0, 0, scale);
             s_compassTexture = ImGuiExt::Texture::fromImage(romfs::get("assets/common/compass.png").span<std::byte>());
             s_globeTexture   = ImGuiExt::Texture::fromImage(romfs::get("assets/common/globe.png").span<std::byte>());
             s_screenshotDescriptions = nlohmann::json::parse(romfs::get("assets/screenshot_descriptions.json").string());

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -172,19 +172,12 @@ namespace hex::plugin::builtin {
         class ScalingWidget : public ContentRegistry::Settings::Widgets::Widget {
         public:
             bool draw(const std::string &name) override {
-                auto format = [this] -> std::string {
-                    if (m_value == 0)
-                        return "hex.builtin.setting.interface.scaling.native"_lang + hex::format(" (x{:.1f})", ImHexApi::System::getNativeScale());
-                    else
-                        return "x%.1f";
-                }();
+                bool changed = ImGui::SliderFloat(name.data(), &m_value, 0.1, 4, "x%.1f");
 
-                bool changed = ImGui::SliderFloat(name.data(), &m_value, 0, 4, format.c_str());
-
-                if (m_value < 0)
-                    m_value = 0;
-                else if (m_value > 10)
-                    m_value = 10;
+                if (m_value < 0.1)
+                    m_value = 0.1;
+                else if (m_value > 4)
+                    m_value = 4;
 
                 if (s_showScalingWarning && (u32(m_value * 10) % 10) != 0) {
                     ImGui::SameLine();

--- a/plugins/builtin/source/content/themes.cpp
+++ b/plugins/builtin/source/content/themes.cpp
@@ -258,7 +258,8 @@ namespace hex::plugin::builtin {
         RequestInitThemeHandlers::subscribe([] {
             {
                 auto &style = ImGui::GetStyle();
-                const static ThemeManager::StyleMap ImGuiStyleMap = {
+                static ThemeManager::StyleMap ImGuiStyleMap;
+                ImGuiStyleMap = {
                     { "alpha",                  { &style.Alpha,                     0.1F,   1.0F,    false } },
                     { "disabled-alpha",         { &style.DisabledAlpha,             0.0F,   1.0F,    false } },
                     { "window-padding",         { &style.WindowPadding,             0.0F,   20.0F,   true  } },
@@ -294,7 +295,8 @@ namespace hex::plugin::builtin {
 
             {
                 auto &style = ImPlot::GetStyle();
-                const static ThemeManager::StyleMap ImPlotStyleMap = {
+                static ThemeManager::StyleMap ImPlotStyleMap;
+                ImPlotStyleMap = {
                         { "line-weight",            { &style.LineWeight,         0.0F, 5.0F,    true  } },
                         { "marker-size",            { &style.MarkerSize,         2.0F, 10.0F,   true  } },
                         { "marker-weight",          { &style.MarkerWeight,       0.0F, 5.0F,    true  } },
@@ -328,7 +330,8 @@ namespace hex::plugin::builtin {
 
             {
                 auto &style = ImNodes::GetStyle();
-                const static ThemeManager::StyleMap ImNodesStyleMap = {
+                static ThemeManager::StyleMap ImNodesStyleMap;
+                ImNodesStyleMap = {
                         { "grid-spacing",                  { &style.GridSpacing,               0.0F,    100.0F, true } },
                         { "node-corner-rounding",          { &style.NodeCornerRounding,        0.0F,    12.0F,  true } },
                         { "node-padding",                  { &style.NodePadding,               0.0F,    20.0F,  true } },
@@ -351,8 +354,9 @@ namespace hex::plugin::builtin {
 
             {
                 auto &style = ImGuiExt::GetCustomStyle();
-                const static ThemeManager::StyleMap ImHexStyleMap = {
-                        { "window-blur",    { &style.WindowBlur,    0.0F,   1.0F,   true } },
+                static ThemeManager::StyleMap ImHexStyleMap;
+                ImHexStyleMap = {
+                        { "window-blur",            { &style.WindowBlur,                0.0F,   1.0F,    true  } },
                         { "popup-alpha",            { &style.PopupWindowAlpha,          0.0F,   1.0F,    false } },
                 };
 

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -524,7 +524,9 @@ namespace hex::plugin::builtin {
             };
 
             auto changeTextureSvg = [&](const std::string &path, float width) {
-                return ImGuiExt::Texture::fromSVG(romfs::get(path).span(), width, 0, ImGuiExt::Texture::Filter::Linear);
+                // UI scaling is already baked into the width
+                const auto scale = ImHexApi::System::getContentScale();
+                return ImGuiExt::Texture::fromSVG(romfs::get(path).span(), width, 0, scale, ImGuiExt::Texture::Filter::Linear);
             };
 
             ThemeManager::changeTheme(theme);

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -557,7 +557,7 @@ namespace hex::plugin::builtin {
         for (const auto &path : paths::Config.read()) {
             if (auto crashFilePath = std::fs::path(path) / CrashFileName; wolv::io::fs::exists(crashFilePath)) {
                 hasCrashed = true;
-                
+
                 log::info("Found crash.json file at {}", wolv::util::toUTF8String(crashFilePath));
                 wolv::io::File crashFile(crashFilePath, wolv::io::File::Mode::Read);
                 nlohmann::json crashFileData;

--- a/plugins/fonts/source/font_loader.cpp
+++ b/plugins/fonts/source/font_loader.cpp
@@ -51,7 +51,7 @@ namespace hex::fonts {
                 m_config.SizePixels = ImHexApi::Fonts::DefaultFontSize;
                 m_config.MergeMode = false;
 
-                EventDPIChanged::subscribe(this, [this](float) {
+                EventScaleChanged::subscribe(this, [this]() {
                     if (scaleAndBuild()) {
                         ImGui_ImplOpenGL3_DestroyFontsTexture();
                         ImGui_ImplOpenGL3_CreateFontsTexture();
@@ -62,7 +62,7 @@ namespace hex::fonts {
 
             ~FontAtlas() {
                 IM_DELETE(m_fontAtlas);
-                EventDPIChanged::unsubscribe(this);
+                EventScaleChanged::unsubscribe(this);
             }
 
             bool scaleAndBuild() {


### PR DESCRIPTION
### Problem description

ImHex looks bad on high-DPI displays (at least Linux/Wayland) and the scaling slider doesn’t work right (it just makes everything bigger, but still blurry).

### Implementation description

GLFW 3.3 added support for DPI-aware scaling and so now does all the window manager work of making sure the window and framebuffer are sized appropriately. This patch hooks up the new GLFW 3.3 APIs to the recently added DPI event handling code, and gets rid of the platform-specific code that either appeared to reimplement what exists in GLFW (Windows) or tried to disable the automatic DPI-aware scaling (Linux/macOS).

The implementation distinguishes between the native scaling (physical/DPI scaling) and global scaling (logical/UI scaling) so removes the “Native” scaling option from the scaling control since now that just means the same thing as 1x global scaling. I did not see any place for settings migrations across versions so just detect and rewrite the setting if needed in the place where it is used to initialise the UI.

Textures are given scaling values so SVG are rendered at the correct resolution.

### Screenshots

Please forgive my custom font.

Before:

![image](https://github.com/user-attachments/assets/85418336-56e7-402c-9886-1eae571d2bd6)

After:

![image](https://github.com/user-attachments/assets/66d92cff-dd34-4df5-a68a-fb54839bb894)

### Additional things

I did test this against a multi-monitor setup with different per-screen DPI and the UI does adapt the scaling to each screen in the expected way. Code that was trying to resize the window on DPI changes is removed since that is already handled by GLFW and this just caused the window size to change incorrectly.

I did not test this against macOS, Windows, or X11, so maybe it is catastrophically broken there, but since this is not doing any platform-specific stuff, I would expect it to work OK. Please test and report back! (In particular, it’s possible some of the existing Windows mouse handling code in the `WM_NCHITTEST` window message is doing buggy stuff since it is calling `getGlobalScale`.)

This change needs GLFW 3.3 or later, so maybe things like DEBIAN/control.in and lib/third_party/imgui/custom/CMakeLists.txt should be updated to specify that, although even Ubuntu 20.04 includes GLFW 3.3, so probably it does not matter.

Fractional scaling does not look great; there are clearly some rounding errors somewhere that make the text glyphs look bad. I am not sure if this is something fixable in ImHex.

I am not sure that `OS_WEB` should be excluded from detecting native scaling since devicePixelRatio is certainly exposed in Web API but I left the code in the splash window functionally equivalent to before since I don’t have time to test that myself.