### PR TITLE
fix: Textures draw correctly in 3D visualizer

### DIFF
--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -634,10 +634,13 @@ namespace hex::plugin::visualizers {
         if (s_renderingWindowSize.x <= 0 || s_renderingWindowSize.y <= 0)
             s_renderingWindowSize = { minSize, minSize };
 
-        if (!textureFile.empty())
+        if (!textureFile.empty()) {
             s_texturePath = textureFile;
-        else
+            s_drawTexture = true;
+        }
+        else {
             s_drawTexture = false;
+        }
 
         s_renderingWindowSize.x = std::max(s_renderingWindowSize.x, minSize);
         s_renderingWindowSize.y = std::max(s_renderingWindowSize.y, minSize);
@@ -795,6 +798,8 @@ namespace hex::plugin::visualizers {
                 if (s_shouldUpdateTexture) {
                     s_shouldUpdateTexture = false;
                     s_modelTexture = ImGuiExt::Texture::fromImage(s_texturePath, ImGuiExt::Texture::Filter::Nearest);
+                    if(s_modelTexture.isValid())
+                        s_drawTexture = true;
                 }
 
                 if (s_drawTexture)

--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -637,8 +637,7 @@ namespace hex::plugin::visualizers {
         if (!textureFile.empty()) {
             s_texturePath = textureFile;
             s_drawTexture = true;
-        }
-        else {
+        } else {
             s_drawTexture = false;
         }
 
@@ -798,8 +797,9 @@ namespace hex::plugin::visualizers {
                 if (s_shouldUpdateTexture) {
                     s_shouldUpdateTexture = false;
                     s_modelTexture = ImGuiExt::Texture::fromImage(s_texturePath, ImGuiExt::Texture::Filter::Nearest);
-                    if(s_modelTexture.isValid())
+                    if (s_modelTexture.isValid()) {
                         s_drawTexture = true;
+                    }
                 }
 
                 if (s_drawTexture)


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Because of `s_drawTexture` never being set to true, textures rarely or never drew in the 3D visualizer.

### Implementation description
Set `s_drawTexture` to true when correct (valid texture file/object).