### PR TITLE
fix: Missing --help output & other diagnostic messages in console

### DIFF
--- a/main/gui/source/window/linux_window.cpp
+++ b/main/gui/source/window/linux_window.cpp
@@ -14,7 +14,6 @@
     #include <wolv/utils/core.hpp>
 
     #include <nlohmann/json.hpp>
-    #include <cstdio>
     #include <sys/wait.h>
     #include <unistd.h>
 
@@ -96,11 +95,6 @@ namespace hex {
             if (std::fs::exists(path))
                 setenv("LD_LIBRARY_PATH", hex::format("{};{}", hex::getEnvironmentVariable("LD_LIBRARY_PATH").value_or(""), path.string().c_str()).c_str(), true);
         }
-
-        // Various libraries sadly directly print to stderr with no way to disable it
-        // We redirect stderr to /dev/null to prevent this
-        wolv::util::unused(freopen("/dev/null", "w", stderr));
-        setvbuf(stderr, nullptr, _IONBF, 0);
 
         // Redirect stdout to log file if we're not running in a terminal
         if (!isatty(STDOUT_FILENO)) {

--- a/main/gui/source/window/macos_window.cpp
+++ b/main/gui/source/window/macos_window.cpp
@@ -11,7 +11,6 @@
     #include <hex/helpers/logger.hpp>
     #include <hex/helpers/default_paths.hpp>
 
-    #include <cstdio>
     #include <unistd.h>
 
     #include <imgui_impl_glfw.h>
@@ -40,11 +39,6 @@ namespace hex {
             if (std::fs::exists(path))
                 setenv("LD_LIBRARY_PATH", hex::format("{};{}", hex::getEnvironmentVariable("LD_LIBRARY_PATH").value_or(""), path.string().c_str()).c_str(), true);
         }
-
-        // Various libraries sadly directly print to stderr with no way to disable it
-        // We redirect stderr to /dev/null to prevent this
-        freopen("/dev/null", "w", stderr);
-        setvbuf(stderr, nullptr, _IONBF, 0);
 
         // Redirect stdout to log file if we're not running in a terminal
         if (!isatty(STDOUT_FILENO)) {

--- a/main/gui/source/window/win_window.cpp
+++ b/main/gui/source/window/win_window.cpp
@@ -29,8 +29,6 @@
     #include <shellapi.h>
     #include <timeapi.h>
 
-    #include <cstdio>
-
 namespace hex {
 
     template<typename T>
@@ -415,12 +413,6 @@ namespace hex {
             // Reopen stdin, stdout and stderr to the console if not in debug mode
             reopenConsoleHandle(STD_INPUT_HANDLE,  STDIN_FILENO,  stdin);
             reopenConsoleHandle(STD_OUTPUT_HANDLE, STDOUT_FILENO, stdout);
-
-            // Explicitly don't forward stderr because some libraries like to write to it
-            // with no way to disable it (e.g., libmagic)
-            /*
-                reopenConsoleHandle(STD_ERROR_HANDLE,  STDERR_FILENO, stderr);
-            */
 
             // Enable ANSI colors in the console
             log::impl::enableColorPrinting();


### PR DESCRIPTION
### Problem description

Typing `--help` causes ImHex to exit without outputting anything. Diagnostic messages from glib, ASan, other libraries that might have something important to say, etc. are also suppressed.

### Implementation description

This effectively reverts 7c1e33dde6e55ef6347f3b10868a42f456c2ae6a, which was partially reverted only on Windows by code that was left commented out in f114239f51ba68c385e3d46721dd9d97ca4a6c21.

Allowing other libraries to print to stderr may make the output ‘ugly’, but lots of things print to stderr that are important for figuring out why something is bugged, like ASan and glib.

### Additional things

![image](https://github.com/user-attachments/assets/fa6771e2-da2e-45ea-93cd-06c3f6bfd3bf)
