### PR TITLE
fix: Do not connect to network on startup when setting is disabled

### DIFF
--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -664,7 +664,9 @@ namespace hex::plugin::builtin {
                 }
             }
 
-            if (!s_infoBannerTexture.isValid()) {
+            auto allowNetworking = ContentRegistry::Settings::read<bool>("hex.builtin.setting.general", "hex.builtin.setting.general.network_interface", false)
+                && ContentRegistry::Settings::read<int>("hex.builtin.setting.general", "hex.builtin.setting.general.server_contact", 0) != 0;
+            if (!s_infoBannerTexture.isValid() && allowNetworking) {
                 TaskManager::createBackgroundTask("Load banner", [](auto&) {
                     HttpRequest request("GET",
                         ImHexApiURL + hex::format("/info/{}/image", hex::toLower(ImHexApi::System::getOSName())));


### PR DESCRIPTION
### Problem description

ImHex asks users whether they wish to opt-in to network connections on start (excellent!), then ignores that and tries to connect to the network anyway when the welcome screen loads (less excellent!).

### Implementation description

Also don’t connect to the network on the welcome screen if it is supposed to not do that.