### PR TITLE
fix: GLFW backend detection on Linux in fs.cpp

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -80,6 +80,33 @@ else()
     target_compile_definitions(libimhex PRIVATE IMHEX_PROJECT_NAME="${PROJECT_NAME}")
 endif()
 
+if (UNIX AND NOT APPLE)
+    # For Linux, we need to figure out whether our GLFW is built for X11, Wayland, or both
+    INCLUDE(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES ${GLFW_INCLUDE_DIRS})
+    set(CMAKE_REQUIRED_LIBRARIES ${GLFW_LIBRARIES})
+    check_cxx_source_compiles("
+        #define GLFW_EXPOSE_NATIVE_X11
+        #include <GLFW/glfw3.h>
+        #include <GLFW/glfw3native.h>
+        Window test(GLFWwindow* w) { return glfwGetX11Window(w); }
+        int main() {}
+    " GLFW_HAS_X11)
+    check_cxx_source_compiles("
+        #define GLFW_EXPOSE_NATIVE_WAYLAND
+        #include <GLFW/glfw3.h>
+        #include <GLFW/glfw3native.h>
+        wl_surface* test(GLFWwindow* w) { return glfwGetWaylandWindow(w); }
+        int main() {}
+    " GLFW_HAS_WAYLAND)
+    if (GLFW_HAS_X11)
+        target_compile_definitions(libimhex PRIVATE GLFW_BACKEND_X11)
+    endif()
+    if (GLFW_HAS_WAYLAND)
+        target_compile_definitions(libimhex PRIVATE GLFW_BACKEND_WAYLAND)
+    endif()
+endif()
+
 
 if (DEFINED IMHEX_COMMIT_HASH_LONG AND DEFINED IMHEX_COMMIT_BRANCH)
     set(GIT_COMMIT_HASH_LONG "${IMHEX_COMMIT_HASH_LONG}")

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -35,17 +35,17 @@
         typedef void NSWindow;
         #define GLFW_EXPOSE_NATIVE_COCOA
     #endif
-    #if defined(OS_LINUX)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_X11)
         #define GLFW_EXPOSE_NATIVE_X11
     #endif
-    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_WAYLAND)
         #define GLFW_EXPOSE_NATIVE_WAYLAND
     #endif
     #include <nfd_glfw3.h>
-    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_WAYLAND)
         #undef GLFW_EXPOSE_NATIVE_WAYLAND
     #endif
-    #if defined(OS_LINUX)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_X11)
         #undef GLFW_EXPOSE_NATIVE_X11
     #endif
     #if defined(OS_MACOS)

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -39,17 +39,18 @@
     #if defined(OS_LINUX)
         #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
             #define GLFW_EXPOSE_NATIVE_X11
+        #else
+            #define GLFW_EXPOSE_NATIVE_WAYLAND
         #endif
     #endif
 
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunused-parameter"
     #include <nfd_glfw3.h>
-    #pragma GCC diagnostic pop
 
     #if defined(OS_LINUX) && GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
         #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
             #undef GLFW_EXPOSE_NATIVE_X11
+        #else
+            #undef GLFW_EXPOSE_NATIVE_WAYLAND
         #endif
     #endif
     #if defined(OS_MACOS)

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -23,7 +23,6 @@
 #if defined(OS_WEB)
     #include <emscripten.h>
 #else
-    #include <GLFW/glfw3.h>
     #include <nfd.hpp>
     #if defined(OS_WINDOWS)
         #define GLFW_EXPOSE_NATIVE_WIN32
@@ -37,21 +36,17 @@
         #define GLFW_EXPOSE_NATIVE_COCOA
     #endif
     #if defined(OS_LINUX)
-        #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-            #define GLFW_EXPOSE_NATIVE_X11
-        #else
-            #define GLFW_EXPOSE_NATIVE_WAYLAND
-        #endif
+        #define GLFW_EXPOSE_NATIVE_X11
     #endif
-
+    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+        #define GLFW_EXPOSE_NATIVE_WAYLAND
+    #endif
     #include <nfd_glfw3.h>
-
-    #if defined(OS_LINUX) && GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-        #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-            #undef GLFW_EXPOSE_NATIVE_X11
-        #else
-            #undef GLFW_EXPOSE_NATIVE_WAYLAND
-        #endif
+    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+        #undef GLFW_EXPOSE_NATIVE_WAYLAND
+    #endif
+    #if defined(OS_LINUX)
+        #undef GLFW_EXPOSE_NATIVE_X11
     #endif
     #if defined(OS_MACOS)
         #undef GLFW_EXPOSE_NATIVE_COCOA


### PR DESCRIPTION
This is an attempt to fix the issue described in #1832, where file dialogs on Linux/X11 are no longer properly parented.

I don't really know the reason for 48fc1a7a1e90fb596662c4d59449aa011daefade and cf2e1890496773b46bef747fdce19c903d2e0d9f, but it seems I had wrongly assumed that all GLFW builds support X11 and all GLFW builds that define GLFW_WAYLAND_APP_ID support Wayland.  This is not true, and so some Wayland-only GLFW builds probably broke due to this.  There seems to be no way to determine the supported backends of the GLFW library by looking at its public headers, and so I've made the build script compile two small programs as a way to detect the supported backends of the available GLFW library.

### Problem description
This fixes #1832.

### Implementation description
Properly detect the supported backends of the available GLFW library by compiling two test C++ programs.
