### PR TITLE
fix: File dialogs on Linux causing a crash on systems where GTK uses Wayland but GLFW uses X11

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -80,6 +80,33 @@ else()
     target_compile_definitions(libimhex PRIVATE IMHEX_PROJECT_NAME="${PROJECT_NAME}")
 endif()
 
+if (UNIX AND NOT APPLE)
+    # For Linux, we need to figure out whether our GLFW is built for X11, Wayland, or both
+    INCLUDE(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES ${GLFW_INCLUDE_DIRS})
+    set(CMAKE_REQUIRED_LIBRARIES ${GLFW_LIBRARIES})
+    check_cxx_source_compiles("
+        #define GLFW_EXPOSE_NATIVE_X11
+        #include <GLFW/glfw3.h>
+        #include <GLFW/glfw3native.h>
+        Window test(GLFWwindow* w) { return glfwGetX11Window(w); }
+        int main() {}
+    " GLFW_HAS_X11)
+    check_cxx_source_compiles("
+        #define GLFW_EXPOSE_NATIVE_WAYLAND
+        #include <GLFW/glfw3.h>
+        #include <GLFW/glfw3native.h>
+        wl_surface* test(GLFWwindow* w) { return glfwGetWaylandWindow(w); }
+        int main() {}
+    " GLFW_HAS_WAYLAND)
+    if (GLFW_HAS_X11)
+        target_compile_definitions(libimhex PRIVATE GLFW_BACKEND_X11)
+    endif()
+    if (GLFW_HAS_WAYLAND)
+        target_compile_definitions(libimhex PRIVATE GLFW_BACKEND_WAYLAND)
+    endif()
+endif()
+
 
 if (DEFINED IMHEX_COMMIT_HASH_LONG AND DEFINED IMHEX_COMMIT_BRANCH)
     set(GIT_COMMIT_HASH_LONG "${IMHEX_COMMIT_HASH_LONG}")

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -35,17 +35,17 @@
         typedef void NSWindow;
         #define GLFW_EXPOSE_NATIVE_COCOA
     #endif
-    #if defined(OS_LINUX)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_X11)
         #define GLFW_EXPOSE_NATIVE_X11
     #endif
-    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_WAYLAND)
         #define GLFW_EXPOSE_NATIVE_WAYLAND
     #endif
     #include <nfd_glfw3.h>
-    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_WAYLAND)
         #undef GLFW_EXPOSE_NATIVE_WAYLAND
     #endif
-    #if defined(OS_LINUX)
+    #if defined(OS_LINUX) && defined(GLFW_BACKEND_X11)
         #undef GLFW_EXPOSE_NATIVE_X11
     #endif
     #if defined(OS_MACOS)

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -39,17 +39,18 @@
     #if defined(OS_LINUX)
         #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
             #define GLFW_EXPOSE_NATIVE_X11
+        #else
+            #define GLFW_EXPOSE_NATIVE_WAYLAND
         #endif
     #endif
 
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunused-parameter"
     #include <nfd_glfw3.h>
-    #pragma GCC diagnostic pop
 
     #if defined(OS_LINUX) && GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
         #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
             #undef GLFW_EXPOSE_NATIVE_X11
+        #else
+            #undef GLFW_EXPOSE_NATIVE_WAYLAND
         #endif
     #endif
     #if defined(OS_MACOS)

--- a/lib/libimhex/source/helpers/fs.cpp
+++ b/lib/libimhex/source/helpers/fs.cpp
@@ -23,7 +23,6 @@
 #if defined(OS_WEB)
     #include <emscripten.h>
 #else
-    #include <GLFW/glfw3.h>
     #include <nfd.hpp>
     #if defined(OS_WINDOWS)
         #define GLFW_EXPOSE_NATIVE_WIN32
@@ -37,21 +36,17 @@
         #define GLFW_EXPOSE_NATIVE_COCOA
     #endif
     #if defined(OS_LINUX)
-        #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-            #define GLFW_EXPOSE_NATIVE_X11
-        #else
-            #define GLFW_EXPOSE_NATIVE_WAYLAND
-        #endif
+        #define GLFW_EXPOSE_NATIVE_X11
     #endif
-
+    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+        #define GLFW_EXPOSE_NATIVE_WAYLAND
+    #endif
     #include <nfd_glfw3.h>
-
-    #if defined(OS_LINUX) && GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-        #if GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4
-            #undef GLFW_EXPOSE_NATIVE_X11
-        #else
-            #undef GLFW_EXPOSE_NATIVE_WAYLAND
-        #endif
+    #if defined(OS_LINUX) && defined(GLFW_WAYLAND_APP_ID)
+        #undef GLFW_EXPOSE_NATIVE_WAYLAND
+    #endif
+    #if defined(OS_LINUX)
+        #undef GLFW_EXPOSE_NATIVE_X11
     #endif
     #if defined(OS_MACOS)
         #undef GLFW_EXPOSE_NATIVE_COCOA


### PR DESCRIPTION
There has been reports of the file dialog crashing ImHex on Linux, including [this](https://github.com/WerWolv/ImHex/issues/1796#issuecomment-2229694812) and [this](https://github.com/WerWolv/ImHex/issues/1796#issuecomment-2248579290).  I think this occurs on systems where Wayland is the default compositor but the GLFW used in ImHex only supports X11.

The default Ubuntu 22.04 and Ubuntu 24.04 builds of ImHex use the GLFW from Ubuntu's default package repository, which supports only X11 but not Wayland.  GLFW is only built with Wayland support from Ubuntu 24.10 onwards.  This can be seen from the CI log https://github.com/WerWolv/ImHex/actions/runs/10167117281, which contain something like the lines below in the CMake configure step (they are added by #1833).
```
-- Performing Test GLFW_HAS_X11
-- Performing Test GLFW_HAS_X11 - Success
-- Performing Test GLFW_HAS_WAYLAND
-- Performing Test GLFW_HAS_WAYLAND - Failed
```
These tests detect if the GLFW package that ImHex is being built against supports X11 or Wayland (or both).

Using a build of ImHex like those above means that ImHex must use an X11 window, even when Wayland is available (e.g. with Sway).  However, the system GTK may support Wayland, and even default to Wayland with depending on the system configuration.  As the Ubuntu builds of ImHex use NFDe with the GTK backend and use the system GTK package, GTK may open a Wayland window.  An X11 window cannot be made the parent of a Wayland window, thereby causing the crash.

NFDe has been updated to force GTK to use the same compositor as the parent window, and this PR fixes ImHex by updating NFDe.