### PR TITLE
fix: Unable to resize 3d-visualizer window in x-direction.

### DIFF
--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -493,6 +493,14 @@ namespace hex::plugin::visualizers {
             }
             ImGui::EndChild();
             ImGui::PopStyleVar();
+            {
+                ImGui::SameLine();
+                {
+                    ImGui::PushID(5);
+                    ImGui::Dummy(ImVec2(0, 0));
+                    ImGui::PopID();
+                }
+            }
 
             // Draw axis arrows toggle
             {
@@ -572,7 +580,7 @@ namespace hex::plugin::visualizers {
             ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
             ImGui::SameLine();
 
-            if (ImGuiExt::DimmedButton("hex.ui.common.reset"_lang, ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
+            if (ImGuiExt::DimmedButton("hex.ui.common.reset"_lang, ImVec2(renderingWindowSize.x-ImGui::GetCursorPosX(), 0))) {
                 s_translation      = { {  0.0F, 0.0F, -3.0F } };
                 s_rotation         = { {  0.0F, 0.0F,  0.0F } };
                 s_scaling            = 1.0F;


### PR DESCRIPTION
changes needed were:
1) add an extra dummy empty widget so that width of child and parent are not always the same. 2) Width of reset button needs to be adjusted when the width of the child is decreased so that the parent is decreased too.

<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

### Implementation description
<!-- Explain what you did to correct the problem -->

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
