### PR TITLE
Added per provider cursor position for the Pattern editor.

### DIFF
--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -239,6 +239,7 @@ namespace hex::plugin::builtin {
 
         std::mutex m_logMutex;
 
+        PerProvider<TextEditor::Coordinates>  m_cursorPosition;
         PerProvider<std::optional<pl::core::err::PatternLanguageError>> m_lastEvaluationError;
         PerProvider<std::vector<pl::core::err::CompileError>> m_lastCompileError;
         PerProvider<std::map<std::string, pl::core::Token::Literal>> m_lastEvaluationOutVars;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -554,7 +554,7 @@ namespace hex::plugin::builtin {
             }
 
             if (m_hasUnevaluatedChanges && m_runningEvaluators == 0 && m_runningParsers == 0) {
-                if ((std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1)) {
+                if ((std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1ll)) {
                     m_hasUnevaluatedChanges = false;
 
                     auto code = m_textEditor.GetText();
@@ -1684,7 +1684,7 @@ namespace hex::plugin::builtin {
                 *m_breakpointHit = true;
                 m_resetDebuggerVariables = true;
                 while (*m_breakpointHit) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100ll));
                 }
             });
 
@@ -1707,7 +1707,7 @@ namespace hex::plugin::builtin {
                 m_dangerousFunctionCalled = true;
 
                 while (m_dangerousFunctionsAllowed == DangerousFunctionPerms::Ask) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100ll));
                 }
 
                 return m_dangerousFunctionsAllowed == DangerousFunctionPerms::Allow;
@@ -1800,15 +1800,19 @@ namespace hex::plugin::builtin {
             m_envVarEntries->emplace_back(0, "", i128(0), EnvVarType::Integer);
 
             m_debuggerDrawer.get(provider) = std::make_unique<ui::PatternDrawer>();
+            m_cursorPosition.get(provider) =  TextEditor::Coordinates(0, 0);
         });
 
         EventProviderChanged::subscribe(this, [this](prv::Provider *oldProvider, prv::Provider *newProvider) {
-            if (oldProvider != nullptr)
+            if (oldProvider != nullptr) {
                 m_sourceCode.set(oldProvider, m_textEditor.GetText());
+                m_cursorPosition.set(m_textEditor.GetCursorPosition(),oldProvider);
+            }
 
-            if (newProvider != nullptr)
+            if (newProvider != nullptr) {
                 m_textEditor.SetText(m_sourceCode.get(newProvider));
-            else
+                m_textEditor.SetCursorPosition(m_cursorPosition.get(newProvider));
+            } else
                 m_textEditor.SetText("");
         });
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -554,7 +554,7 @@ namespace hex::plugin::builtin {
             }
 
             if (m_hasUnevaluatedChanges && m_runningEvaluators == 0 && m_runningParsers == 0) {
-                if ((std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1ll)) {
+                if ((std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1LL)) {
                     m_hasUnevaluatedChanges = false;
 
                     auto code = m_textEditor.GetText();
@@ -1684,7 +1684,7 @@ namespace hex::plugin::builtin {
                 *m_breakpointHit = true;
                 m_resetDebuggerVariables = true;
                 while (*m_breakpointHit) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100ll));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100LL));
                 }
             });
 
@@ -1707,7 +1707,7 @@ namespace hex::plugin::builtin {
                 m_dangerousFunctionCalled = true;
 
                 while (m_dangerousFunctionsAllowed == DangerousFunctionPerms::Ask) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100ll));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100LL));
                 }
 
                 return m_dangerousFunctionsAllowed == DangerousFunctionPerms::Allow;


### PR DESCRIPTION

### Problem description
Currently, the pattern editor does not remember where the cursor is located in each provider. For example, suppose you have 2 providers in your project, and you scrolled down to line 200 in the first pattern to make some changes and remembered that the code you want to insert is in the second provider. Then you switch to the second provider, look for the code and find it in line 235. Switch back to the first one, and you are at the beginning of the file. So you again look for the line to edit paste it to realize that it needs code a few lines before the place you found it. You switch to the second provider, and you are at the top again. This gets annoying very fast.

### Implementation description

This PR ensures that, when you return to the pattern in the editor for any of the opened providers, the cursor will still be at the same place it was when you switched to a different one. Each provider pattern saves its cursor position and returns to it when you switch to that provider.  It does that by creating a PerProvider variable and using it when providers are first opened to set it to the origin and when switching providers it first saves the position of the old provider and then loads and sets  the saved position of the new provider.

