### PR TITLE
fix: for issue #1663 (3d visualizer becomes very slow without...)

### DIFF
--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -692,8 +692,9 @@ namespace hex {
                 auto drawData = viewPort->DrawData;
                 for (int n = 0; n < drawData->CmdListsCount; n++) {
                     const ImDrawList *cmdList = drawData->CmdLists[n];
+                    std::string ownerName = cmdList->_OwnerName;
 
-                    if (vtxDataSize == previousVtxDataSize) {
+                    if (vtxDataSize == previousVtxDataSize && (!ownerName.contains("##Popup") || !ownerName.contains("##image"))) {
                         shouldRender = shouldRender || std::memcmp(previousVtxData.data() + offset, cmdList->VtxBuffer.Data, cmdList->VtxBuffer.size() * sizeof(ImDrawVert)) != 0;
                     } else {
                         shouldRender = true;


### PR DESCRIPTION
 
### Problem description
The bug described  in #1663 was caused by an optimization of the display rendering that uses drawlists to detect changes. The changes in the 3-d visualizer don't contain drawlists when axes are turned off.

### Implementation description
The fix is to identify the 3d visualizer among the command lists of the main window and, if found, avoid skipping frames regardless of the result of the comparison of drawlists.
