### PR TITLE
fix: a recent update to the 3d visualizer meant to validate index arrays breaks index base 3d rendering.

### DIFF
--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -285,13 +285,11 @@ namespace hex::plugin::visualizers {
             else
                 indicesForLines(lineVectors.indices32);
 
-            const auto isIndexInRange = [vertexCount](auto index) { return index >= vertexCount; };
+            const auto isIndexInRange = [vertexCount](auto index) { return index < (vertexCount /  3); };
 
-            if (
-                !std::ranges::all_of(lineVectors.indices8, isIndexInRange)  ||
-                !std::ranges::all_of(lineVectors.indices16, isIndexInRange) ||
-                !std::ranges::all_of(lineVectors.indices32, isIndexInRange)
-            ) {
+            if ((indexType == IndexType::U8 && !std::ranges::all_of(lineVectors.indices8, isIndexInRange)) ||
+                (indexType == IndexType::U16 && !std::ranges::all_of(lineVectors.indices16, isIndexInRange)) ||
+                (indexType == IndexType::U32 && !std::ranges::all_of(lineVectors.indices32, isIndexInRange))) {
                 throw std::logic_error("One or more indices point to out-of-range vertex");
             }
         }


### PR DESCRIPTION


### Problem description
The recently added `isIndexInRange` test function broke every working model that uses valid indices, and also broke line mode rendering for each and every model.

The function has two major problems and its usage has a minor problem that may not be a problem at all.

1) isIndexInRange was set to return true if indices were bigger than some  threshold and false if they are smaller. This is the opposite of what it should be valid indices are in the range [0..threshold-1]. Fixing it was trivial.

2) isIndexInRange uses vertexCount as the threshold to check if index is valid. Despite their name, Vertex arrays are not arrays of vertices, but arrays of vertex coordinates (x0,y0,z0,x1,y1,z1,...). In other words, each vertex takes three numbers from the array  so the correct threshold to use is vertexCount/3. This was also trivially fixed.

3) isIndexInRange is being applied to all three index types, but only one type is used in a model. The types that are not used should be empty, but it is probably better not to try to use them just in case. PR 1850 has code that removes the multiple index arrays and creates only one index array of the type passed in the parameters using templates. I may also create a separate PR for that code.

Further checks for valid input for the 3d visualizer will be extracted from the feature branch and made into a bug fix branch.

### Implementation description
The fixes were trivial. see description above.

