### PR TITLE
fix: the lzma decoder seems to always fail with a memory error

### DIFF
--- a/plugins/decompress/source/content/pl_functions.cpp
+++ b/plugins/decompress/source/content/pl_functions.cpp
@@ -174,6 +174,13 @@ namespace hex::plugin::decompress {
                         section.resize(section.size() - stream.avail_out);
                         break;
                     }
+
+                    if (res == LZMA_MEMLIMIT_ERROR ) {
+                        auto usage = lzma_memusage(&stream);
+                        lzma_memlimit_set(&stream, usage);
+                        res = lzma_code(&stream, LZMA_RUN);
+                    }
+
                     if (res != LZMA_OK)
                         return false;
 

--- a/plugins/decompress/source/content/pl_functions.cpp
+++ b/plugins/decompress/source/content/pl_functions.cpp
@@ -175,7 +175,7 @@ namespace hex::plugin::decompress {
                         break;
                     }
 
-                    if (res == LZMA_MEMLIMIT_ERROR ) {
+                    if (res == LZMA_MEMLIMIT_ERROR) {
                         auto usage = lzma_memusage(&stream);
                         lzma_memlimit_set(&stream, usage);
                         res = lzma_code(&stream, LZMA_RUN);


### PR DESCRIPTION




<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
I was unable to use the LZMA de-compressor even though 7zip was able to identify them as LZMA compressed and decompress them without a problem. Under the debugger the `lzma_code()` call was returning `LZMA_MEMLIMIT_ERROR`.
### Implementation description
I found online that the error can be fixed using `lzma_memlimit_set()` using a value obtained with `lzma_memusage()`. I tried to avoid having to call `lzma_code()` twice but if the functions are called before the first `lzma_code()`the values of memory obtained fall short and error occurs again.

I suspect that there are better ways to deal with this other than the code proposed in this PR, but I haven't been able to find any.
