### PR TITLE
Refactor Texteditor code to ImHex standards.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -51,104 +51,104 @@ public:
 
 	struct Breakpoint
 	{
-		int mLine;
-		bool mEnabled;
-		std::string mCondition;
+		int32_t m_line;
+		bool m_enabled;
+		std::string m_condition;
 
 		Breakpoint()
-			: mLine(-1)
-			, mEnabled(false)
+			: m_line(-1)
+			, m_enabled(false)
 		{}
 	};
 
 	// Represents a character coordinate from the user's point of view,
 	// i. e. consider an uniform grid (assuming fixed-width font) on the
 	// screen as it is rendered, and each cell has its own coordinate, starting from 0.
-	// Tabs are counted as [1..mTabSize] count empty spaces, depending on
+	// Tabs are counted as [1..m_tabSize] count empty spaces, depending on
 	// how many space is necessary to reach the next tab stop.
-	// For example, coordinate (1, 5) represents the character 'B' in a line "\tABC", when mTabSize = 4,
+	// For example, coordinate (1, 5) represents the character 'B' in a line "\tABC", when m_tabSize = 4,
 	// because it is rendered as "    ABC" on the screen.
 	struct Coordinates
 	{
-		int mLine, mColumn;
-		Coordinates() : mLine(0), mColumn(0) {}
-		Coordinates(int aLine, int aColumn) : mLine(aLine), mColumn(aColumn)
+		int32_t m_line, m_column;
+		Coordinates() : m_line(0), m_column(0) {}
+		Coordinates(int32_t aLine, int32_t aColumn) : m_line(aLine), m_column(aColumn)
 		{
 			assert(aLine >= 0);
 			assert(aColumn >= 0);
 		}
-		static Coordinates Invalid() { static Coordinates invalid(-1, -1); return invalid; }
+		static Coordinates invalid() { static Coordinates invalid(-1, -1); return invalid; }
 
 		bool operator ==(const Coordinates& o) const
 		{
 			return
-				mLine == o.mLine &&
-				mColumn == o.mColumn;
+                    m_line == o.m_line &&
+                    m_column == o.m_column;
 		}
 
 		bool operator !=(const Coordinates& o) const
 		{
 			return
-				mLine != o.mLine ||
-				mColumn != o.mColumn;
+                    m_line != o.m_line ||
+                    m_column != o.m_column;
 		}
 
 		bool operator <(const Coordinates& o) const
 		{
-			if (mLine != o.mLine)
-				return mLine < o.mLine;
-			return mColumn < o.mColumn;
+			if (m_line != o.m_line)
+				return m_line < o.m_line;
+			return m_column < o.m_column;
 		}
 
 		bool operator >(const Coordinates& o) const
 		{
-			if (mLine != o.mLine)
-				return mLine > o.mLine;
-			return mColumn > o.mColumn;
+			if (m_line != o.m_line)
+				return m_line > o.m_line;
+			return m_column > o.m_column;
 		}
 
 		bool operator <=(const Coordinates& o) const
 		{
-			if (mLine != o.mLine)
-				return mLine < o.mLine;
-			return mColumn <= o.mColumn;
+			if (m_line != o.m_line)
+				return m_line < o.m_line;
+			return m_column <= o.m_column;
 		}
 
 		bool operator >=(const Coordinates& o) const
 		{
-			if (mLine != o.mLine)
-				return mLine > o.mLine;
-			return mColumn >= o.mColumn;
+			if (m_line != o.m_line)
+				return m_line > o.m_line;
+			return m_column >= o.m_column;
 		}
 	};
 
 	struct Identifier
 	{
-		Coordinates mLocation;
-		std::string mDeclaration;
+		Coordinates m_location;
+		std::string m_declaration;
 	};
 
 	typedef std::string String;
 	typedef std::unordered_map<std::string, Identifier> Identifiers;
 	typedef std::unordered_set<std::string> Keywords;
-	typedef std::map<int, std::string> ErrorMarkers;
-	typedef std::unordered_set<int> Breakpoints;
-	typedef std::array<ImU32, (unsigned)PaletteIndex::Max> Palette;
+	typedef std::map<int32_t, std::string> ErrorMarkers;
+	typedef std::unordered_set<int32_t> Breakpoints;
+	typedef std::array<ImU32, (uint32_t)PaletteIndex::Max> Palette;
 	typedef uint8_t Char;
 
 	struct Glyph
 	{
-		Char mChar;
-		PaletteIndex mColorIndex = PaletteIndex::Default;
-		bool mComment : 1;
-		bool mMultiLineComment : 1;
-		bool mPreprocessor : 1;
-		bool mDocComment : 1;
-        bool mGlobalDocComment : 1;
-		bool mDeactivated : 1;
+		Char m_char;
+		PaletteIndex m_colorIndex = PaletteIndex::Default;
+		bool m_comment : 1;
+		bool m_multiLineComment : 1;
+		bool m_preprocessor : 1;
+		bool m_docComment : 1;
+        bool m_globalDocComment : 1;
+		bool m_deactivated : 1;
 
-		Glyph(Char aChar, PaletteIndex aColorIndex) : mChar(aChar), mColorIndex(aColorIndex), mComment(false),
-        mMultiLineComment(false), mPreprocessor(false), mDocComment(false), mGlobalDocComment(false), mDeactivated(false) {}
+		Glyph(Char aChar, PaletteIndex aColorIndex) : m_char(aChar), m_colorIndex(aColorIndex), m_comment(false),
+                                                      m_multiLineComment(false), m_preprocessor(false), m_docComment(false), m_globalDocComment(false), m_deactivated(false) {}
 	};
 
 	typedef std::vector<Glyph> Line;
@@ -160,22 +160,22 @@ public:
 		typedef std::vector<TokenRegexString> TokenRegexStrings;
 		typedef bool(*TokenizeCallback)(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex);
 
-		std::string mName;
-		Keywords mKeywords;
-		Identifiers mIdentifiers;
-		Identifiers mPreprocIdentifiers;
-		std::string mCommentStart, mCommentEnd, mSingleLineComment, mGlobalDocComment, mDocComment;
-		char mPreprocChar;
-		bool mAutoIndentation;
+		std::string m_name;
+		Keywords m_keywords;
+		Identifiers m_identifiers;
+		Identifiers m_preprocIdentifiers;
+		std::string m_commentStart, m_commentEnd, m_singleLineComment, m_globalDocComment, m_docComment;
+		char m_preprocChar;
+		bool m_autoIndentation;
 
-		TokenizeCallback mTokenize;
+		TokenizeCallback m_tokenize;
 
-		TokenRegexStrings mTokenRegexStrings;
+		TokenRegexStrings m_tokenRegexStrings;
 
-		bool mCaseSensitive;
+		bool m_caseSensitive;
 
 		LanguageDefinition()
-			: mPreprocChar('#'), mAutoIndentation(true), mTokenize(nullptr), mCaseSensitive(true)
+			: m_preprocChar('#'), m_autoIndentation(true), m_tokenize(nullptr), m_caseSensitive(true)
 		{
 		}
 
@@ -191,103 +191,103 @@ public:
 	TextEditor();
 	~TextEditor();
 
-	void SetLanguageDefinition(const LanguageDefinition& aLanguageDef);
-	const LanguageDefinition& GetLanguageDefinition() const { return mLanguageDefinition; }
+	void setLanguageDefinition(const LanguageDefinition& aLanguageDef);
+	const LanguageDefinition& getLanguageDefinition() const { return mL_languageDefinition; }
 
-	static const Palette& GetPalette() { return sPaletteBase; }
-	static void SetPalette(const Palette& aValue);
+	static const Palette& getPalette() { return s_paletteBase; }
+	static void setPalette(const Palette& aValue);
 
-	void SetErrorMarkers(const ErrorMarkers& aMarkers) { mErrorMarkers = aMarkers; }
-	void SetBreakpoints(const Breakpoints& aMarkers) { mBreakpoints = aMarkers; }
+	void setErrorMarkers(const ErrorMarkers& aMarkers) { m_errorMarkers = aMarkers; }
+	void setBreakpoints(const Breakpoints& aMarkers) { m_breakpoints = aMarkers; }
 
-	void Render(const char* aTitle, const ImVec2& aSize = ImVec2(), bool aBorder = false);
-	void SetText(const std::string& aText);
-	std::string GetText() const;
+	void render(const char* aTitle, const ImVec2& aSize = ImVec2(), bool aBorder = false);
+	void setText(const std::string& aText);
+	std::string getText() const;
 
-	void SetTextLines(const std::vector<std::string>& aLines);
-	std::vector<std::string> GetTextLines() const;
+	void setTextLines(const std::vector<std::string>& aLines);
+	std::vector<std::string> getTextLines() const;
 
-	std::string GetSelectedText() const;
-	std::string GetCurrentLineText()const;
+	std::string getSelectedText() const;
+	std::string getCurrentLineText()const;
     class FindReplaceHandler;
 
 public:
-    FindReplaceHandler *GetFindReplaceHandler() { return &mFindReplaceHandler; }
-	int GetTotalLines() const { return (int)mLines.size(); }
-	bool IsOverwrite() const { return mOverwrite; }
+    FindReplaceHandler *getFindReplaceHandler() { return &m_findReplaceHandler; }
+	int32_t getTotalLines() const { return (int32_t)m_lines.size(); }
+	bool isOverwrite() const { return m_overwrite; }
 
-	void SetReadOnly(bool aValue);
-	bool IsReadOnly() const { return mReadOnly; }
-	bool IsTextChanged() const { return mTextChanged; }
-	bool IsCursorPositionChanged() const { return mCursorPositionChanged; }
+	void setReadOnly(bool aValue);
+	bool isReadOnly() const { return m_readOnly; }
+	bool isTextChanged() const { return m_textChanged; }
+	bool isCursorPositionChanged() const { return m_cursorPositionChanged; }
 
-    void SetShowCursor(bool aValue) { mShowCursor = aValue; }
-    void SetShowLineNumbers(bool aValue) { mShowLineNumbers = aValue; }
+    void setShowCursor(bool aValue) { m_showCursor = aValue; }
+    void setShowLineNumbers(bool aValue) { m_showLineNumbers = aValue; }
 
-	bool IsColorizerEnabled() const { return mColorizerEnabled; }
-	void SetColorizerEnable(bool aValue);
+	bool isColorizerEnabled() const { return m_colorizerEnabled; }
+	void setColorizerEnable(bool aValue);
 
-	Coordinates GetCursorPosition() const { return GetActualCursorCoordinates(); }
-	void SetCursorPosition(const Coordinates& aPosition);
+	Coordinates getCursorPosition() const { return getActualCursorCoordinates(); }
+	void setCursorPosition(const Coordinates& aPosition);
 
-	inline void SetHandleMouseInputs    (bool aValue){ mHandleMouseInputs    = aValue;}
-	inline bool IsHandleMouseInputsEnabled() const { return mHandleKeyboardInputs; }
+	inline void setHandleMouseInputs    (bool aValue){ m_handleMouseInputs    = aValue;}
+	inline bool isHandleMouseInputsEnabled() const { return m_handleKeyboardInputs; }
 
-	inline void SetHandleKeyboardInputs (bool aValue){ mHandleKeyboardInputs = aValue;}
-	inline bool IsHandleKeyboardInputsEnabled() const { return mHandleKeyboardInputs; }
+	inline void setHandleKeyboardInputs (bool aValue){ m_handleKeyboardInputs = aValue;}
+	inline bool isHandleKeyboardInputsEnabled() const { return m_handleKeyboardInputs; }
 
-	inline void SetImGuiChildIgnored    (bool aValue){ mIgnoreImGuiChild     = aValue;}
-	inline bool IsImGuiChildIgnored() const { return mIgnoreImGuiChild; }
+	inline void setImGuiChildIgnored    (bool aValue){ m_ignoreImGuiChild     = aValue;}
+	inline bool isImGuiChildIgnored() const { return m_ignoreImGuiChild; }
 
-	inline void SetShowWhitespaces(bool aValue) { mShowWhitespaces = aValue; }
-	inline bool IsShowingWhitespaces() const { return mShowWhitespaces; }
+	inline void setShowWhitespaces(bool aValue) { m_showWhitespaces = aValue; }
+	inline bool isShowingWhitespaces() const { return m_showWhitespaces; }
 
-	void SetTabSize(int aValue);
-	inline int GetTabSize() const { return mTabSize; }
+	void setTabSize(int32_t aValue);
+	inline int32_t getTabSize() const { return m_tabSize; }
 
-	void InsertText(const std::string& aValue);
-	void InsertText(const char* aValue);
+	void insertText(const std::string& aValue);
+	void insertText(const char* aValue);
 
-	void MoveUp(int aAmount = 1, bool aSelect = false);
-	void MoveDown(int aAmount = 1, bool aSelect = false);
-	void MoveLeft(int aAmount = 1, bool aSelect = false, bool aWordMode = false);
-	void MoveRight(int aAmount = 1, bool aSelect = false, bool aWordMode = false);
-	void MoveTop(bool aSelect = false);
-	void MoveBottom(bool aSelect = false);
-	void MoveHome(bool aSelect = false);
-	void MoveEnd(bool aSelect = false);
+	void moveUp(int32_t aAmount = 1, bool aSelect = false);
+	void moveDown(int32_t aAmount = 1, bool aSelect = false);
+	void moveLeft(int32_t aAmount = 1, bool aSelect = false, bool aWordMode = false);
+	void moveRight(int32_t aAmount = 1, bool aSelect = false, bool aWordMode = false);
+	void moveTop(bool aSelect = false);
+	void moveBottom(bool aSelect = false);
+	void moveHome(bool aSelect = false);
+	void moveEnd(bool aSelect = false);
 
-	void SetSelectionStart(const Coordinates& aPosition);
-	void SetSelectionEnd(const Coordinates& aPosition);
-	void SetSelection(const Coordinates& aStart, const Coordinates& aEnd, SelectionMode aMode = SelectionMode::Normal);
-	void SelectWordUnderCursor();
-	void SelectAll();
-	bool HasSelection() const;
+	void setSelectionStart(const Coordinates& aPosition);
+	void setSelectionEnd(const Coordinates& aPosition);
+	void setSelection(const Coordinates& aStart, const Coordinates& aEnd, SelectionMode aMode = SelectionMode::Normal);
+	void selectWordUnderCursor();
+	void selectAll();
+	bool hasSelection() const;
 
-	void Copy();
-	void Cut();
-	void Paste();
-	void Delete();
+	void copy();
+	void cut();
+	void paste();
+	void doDelete();
 
-	ImVec2 &GetCharAdvance() { return mCharAdvance; }
+	ImVec2 &getCharAdvance() { return m_charAdvance; }
 
-	bool CanUndo() const;
-	bool CanRedo() const;
-	void Undo(int aSteps = 1);
-	void Redo(int aSteps = 1);
+	bool canUndo() const;
+	bool canRedo() const;
+	void undo(int32_t aSteps = 1);
+	void redo(int32_t aSteps = 1);
 
-	static const Palette& GetDarkPalette();
-	static const Palette& GetLightPalette();
-	static const Palette& GetRetroBluePalette();
+	static const Palette& getDarkPalette();
+	static const Palette& getLightPalette();
+	static const Palette& getRetroBluePalette();
 
 private:
 	typedef std::vector<std::pair<std::regex, PaletteIndex>> RegexList;
 
 	struct EditorState
 	{
-		Coordinates mSelectionStart;
-		Coordinates mSelectionEnd;
-		Coordinates mCursorPosition;
+		Coordinates m_selectionStart;
+		Coordinates m_selectionEnd;
+		Coordinates m_cursorPosition;
 	};
 
 
@@ -296,68 +296,68 @@ public:
     public:
         FindReplaceHandler();
         typedef std::vector<EditorState> Matches;
-        Matches &GetMatches() { return mMatches; }
-        bool FindNext(TextEditor *editor,bool wrapAround);
-        unsigned FindMatch(TextEditor *editor,bool isNex);
-        bool Replace(TextEditor *editor,bool right);
-        bool ReplaceAll(TextEditor *editor);
-        std::string &GetFindWord()  { return mFindWord; }
-        void SetFindWord(TextEditor *editor, const std::string &aFindWord) {
-            if (aFindWord != mFindWord) {
-                FindAllMatches(editor, aFindWord);
-                mFindWord = aFindWord;
+        Matches &getMatches() { return m_matches; }
+        bool findNext(TextEditor *editor, bool wrapAround);
+        uint32_t findMatch(TextEditor *editor, bool isNex);
+        bool replace(TextEditor *editor,bool right);
+        bool replaceAll(TextEditor *editor);
+        std::string &getFindWord()  { return m_findWord; }
+        void setFindWord(TextEditor *editor, const std::string &aFindWord) {
+            if (aFindWord != m_findWord) {
+                findAllMatches(editor, aFindWord);
+                m_findWord = aFindWord;
             }
         }
-        std::string &GetReplaceWord()  { return mReplaceWord; }
-        void SetReplaceWord(const std::string &aReplaceWord) { mReplaceWord = aReplaceWord; }
-        void SelectFound(TextEditor *editor, int found);
-        void FindAllMatches(TextEditor *editor,std::string findWord);
-        unsigned FindPosition( TextEditor *editor, Coordinates pos, bool isNext);
-        bool GetMatchCase() const { return mMatchCase; }
-        void SetMatchCase(TextEditor *editor, bool matchCase)  {
-            if (matchCase != mMatchCase) {
-                mMatchCase = matchCase;
-                mOptionsChanged = true;
-                FindAllMatches(editor, mFindWord);
+        std::string &getReplaceWord()  { return m_replaceWord; }
+        void setReplaceWord(const std::string &aReplaceWord) { m_replaceWord = aReplaceWord; }
+        void selectFound(TextEditor *editor, int32_t found);
+        void findAllMatches(TextEditor *editor, std::string findWord);
+        uint32_t findPosition(TextEditor *editor, Coordinates pos, bool isNext);
+        bool getMatchCase() const { return m_matchCase; }
+        void setMatchCase(TextEditor *editor, bool matchCase)  {
+            if (matchCase != m_matchCase) {
+                m_matchCase = matchCase;
+                m_optionsChanged = true;
+                findAllMatches(editor, m_findWord);
             }
         }
-        bool GetWholeWord()  const { return mWholeWord; }
-        void SetWholeWord(TextEditor *editor, bool wholeWord)  {
-            if (wholeWord != mWholeWord) {
-                mWholeWord = wholeWord;
-                mOptionsChanged = true;
-                FindAllMatches(editor, mFindWord);
+        bool getWholeWord()  const { return m_wholeWord; }
+        void setWholeWord(TextEditor *editor, bool wholeWord)  {
+            if (wholeWord != m_wholeWord) {
+                m_wholeWord = wholeWord;
+                m_optionsChanged = true;
+                findAllMatches(editor, m_findWord);
             }
         }
-        bool GetFindRegEx()  const { return mFindRegEx; }
-        void SetFindRegEx(TextEditor *editor, bool findRegEx)  {
-            if (findRegEx != mFindRegEx) {
-                mFindRegEx = findRegEx;
-                mOptionsChanged = true;
-                FindAllMatches(editor, mFindWord);
+        bool getFindRegEx()  const { return m_findRegEx; }
+        void setFindRegEx(TextEditor *editor, bool findRegEx)  {
+            if (findRegEx != m_findRegEx) {
+                m_findRegEx = findRegEx;
+                m_optionsChanged = true;
+                findAllMatches(editor, m_findWord);
             }
         }
         void resetMatches() {
-            mMatches.clear();
-            mFindWord = "";
+            m_matches.clear();
+            m_findWord = "";
         }
 
-        void SetFindWindowPos(const ImVec2 &pos) { mFindWindowPos = pos; }
-        void SetFindWindowSize(const ImVec2 &size) { mFindWindowSize = size; }
-        ImVec2 GetFindWindowPos() const { return mFindWindowPos; }
-        ImVec2 GetFindWindowSize() const { return mFindWindowSize; }
+        void setFindWindowPos(const ImVec2 &pos) { m_findWindowPos = pos; }
+        void setFindWindowSize(const ImVec2 &size) { m_findWindowSize = size; }
+        ImVec2 getFindWindowPos() const { return m_findWindowPos; }
+        ImVec2 getFindWindowSize() const { return m_findWindowSize; }
     private:
-        std::string mFindWord;
-        std::string mReplaceWord;
-        bool mMatchCase;
-        bool mWholeWord;
-        bool mFindRegEx;
-        bool mOptionsChanged;
-        Matches mMatches;
-        ImVec2 mFindWindowPos;
-        ImVec2 mFindWindowSize;
+        std::string m_findWord;
+        std::string m_replaceWord;
+        bool m_matchCase;
+        bool m_wholeWord;
+        bool m_findRegEx;
+        bool m_optionsChanged;
+        Matches m_matches;
+        ImVec2 m_findWindowPos;
+        ImVec2 m_findWindowSize;
     };
-    FindReplaceHandler mFindReplaceHandler;
+    FindReplaceHandler m_findReplaceHandler;
 private:
 	class UndoRecord
 	{
@@ -377,112 +377,112 @@ private:
 			TextEditor::EditorState& aBefore,
 			TextEditor::EditorState& aAfter);
 
-		void Undo(TextEditor* aEditor);
-		void Redo(TextEditor* aEditor);
+		void undo(TextEditor* aEditor);
+		void redo(TextEditor* aEditor);
 
-		std::string mAdded;
-		Coordinates mAddedStart;
-		Coordinates mAddedEnd;
+		std::string m_added;
+		Coordinates m_addedStart;
+		Coordinates m_addedEnd;
 
-		std::string mRemoved;
-		Coordinates mRemovedStart;
-		Coordinates mRemovedEnd;
+		std::string m_removed;
+		Coordinates m_removedStart;
+		Coordinates m_removedEnd;
 
-		EditorState mBefore;
-		EditorState mAfter;
+		EditorState m_before;
+		EditorState m_after;
 	};
 
 	typedef std::vector<UndoRecord> UndoBuffer;
 
-	void ProcessInputs();
-	void Colorize(int aFromLine = 0, int aCount = -1);
-	void ColorizeRange(int aFromLine = 0, int aToLine = 0);
-	void ColorizeInternal();
-	float TextDistanceToLineStart(const Coordinates& aFrom) const;
-	void EnsureCursorVisible();
-	int GetPageSize() const;
-	std::string GetText(const Coordinates& aStart, const Coordinates& aEnd) const;
-	Coordinates GetActualCursorCoordinates() const;
-	Coordinates SanitizeCoordinates(const Coordinates& aValue) const;
-	void Advance(Coordinates& aCoordinates) const;
-	void DeleteRange(const Coordinates& aStart, const Coordinates& aEnd);
-	int InsertTextAt(Coordinates& aWhere, const char* aValue);
-	void AddUndo(UndoRecord& aValue);
-	Coordinates ScreenPosToCoordinates(const ImVec2& aPosition) const;
-	Coordinates FindWordStart(const Coordinates& aFrom) const;
-	Coordinates FindWordEnd(const Coordinates& aFrom) const;
-	Coordinates FindNextWord(const Coordinates& aFrom) const;
-	int GetCharacterIndex(const Coordinates& aCoordinates) const;
-	int GetCharacterColumn(int aLine, int aIndex) const;
-	int GetLineCharacterCount(int aLine) const;
-	unsigned long long GetLineByteCount(int aLine) const;
-	int GetStringCharacterCount(std::string str) const;
-	int GetLineMaxColumn(int aLine) const;
-	bool IsOnWordBoundary(const Coordinates& aAt) const;
-	void RemoveLine(int aStart, int aEnd);
-	void RemoveLine(int aIndex);
-	Line& InsertLine(int aIndex);
-	void EnterCharacter(ImWchar aChar, bool aShift);
-	void Backspace();
-	void DeleteSelection();
-	std::string GetWordUnderCursor() const;
-	std::string GetWordAt(const Coordinates& aCoords) const;
-	ImU32 GetGlyphColor(const Glyph& aGlyph) const;
-    void ResetCursorBlinkTime();
+	void processInputs();
+	void colorize(int32_t aFromLine = 0, int32_t aCount = -1);
+	void colorizeRange(int32_t aFromLine = 0, int32_t aToLine = 0);
+	void colorizeInternal();
+	float textDistanceToLineStart(const Coordinates& aFrom) const;
+	void ensureCursorVisible();
+	int32_t getPageSize() const;
+	std::string getText(const Coordinates& aStart, const Coordinates& aEnd) const;
+	Coordinates getActualCursorCoordinates() const;
+	Coordinates sanitizeCoordinates(const Coordinates& aValue) const;
+	void advance(Coordinates& aCoordinates) const;
+	void deleteRange(const Coordinates& aStart, const Coordinates& aEnd);
+	int32_t insertTextAt(Coordinates &aWhere, const char* aValue);
+	void addUndo(UndoRecord& aValue);
+	Coordinates screenPosToCoordinates(const ImVec2& aPosition) const;
+	Coordinates findWordStart(const Coordinates& aFrom) const;
+	Coordinates findWordEnd(const Coordinates& aFrom) const;
+	Coordinates findNextWord(const Coordinates& aFrom) const;
+	int32_t getCharacterIndex(const Coordinates& aCoordinates) const;
+	int32_t getCharacterColumn(int32_t aLine, int32_t aIndex) const;
+	int32_t getLineCharacterCount(int32_t aLine) const;
+	uint64_t getLineByteCount(int32_t aLine) const;
+	int32_t getStringCharacterCount(std::string str) const;
+	int32_t getLineMaxColumn(int32_t aLine) const;
+	bool isOnWordBoundary(const Coordinates& aAt) const;
+	void removeLine(int32_t aStart, int32_t aEnd);
+	void removeLine(int32_t aIndex);
+	Line& insertLine(int32_t aIndex);
+	void enterCharacter(ImWchar aChar, bool aShift);
+	void backspace();
+	void deleteSelection();
+	std::string getWordUnderCursor() const;
+	std::string getWordAt(const Coordinates& aCoords) const;
+	ImU32 getGlyphColor(const Glyph& aGlyph) const;
+    void resetCursorBlinkTime();
 
-	void HandleKeyboardInputs();
-	void HandleMouseInputs();
+	void handleKeyboardInputs();
+	void handleMouseInputs();
 	void Render();
 
-	float mLineSpacing;
-	Lines mLines;
-	EditorState mState;
-	UndoBuffer mUndoBuffer;
-	int mUndoIndex;
-    bool mScrollToBottom;
-    float mTopMargin;
+	float m_lineSpacing;
+	Lines m_lines;
+	EditorState m_state;
+	UndoBuffer m_undoBuffer;
+	int32_t m_undoIndex;
+    bool m_scrollToBottom;
+    float m_topMargin;
 
-	int mTabSize;
-	bool mOverwrite;
-	bool mReadOnly;
-	bool mWithinRender;
-	bool mScrollToCursor;
-	bool mScrollToTop;
-	bool mTextChanged;
-	bool mColorizerEnabled;
-	float mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
-	int  mLeftMargin;
-	bool mCursorPositionChanged;
-	int mColorRangeMin, mColorRangeMax;
-	SelectionMode mSelectionMode;
-	bool mHandleKeyboardInputs;
-	bool mHandleMouseInputs;
-	bool mIgnoreImGuiChild;
-	bool mShowWhitespaces;
+	int32_t m_tabSize;
+	bool m_overwrite;
+	bool m_readOnly;
+	bool m_withinRender;
+	bool m_scrollToCursor;
+	bool m_scrollToTop;
+	bool m_textChanged;
+	bool m_colorizerEnabled;
+	float m_textStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
+	int32_t  m_leftMargin;
+	bool m_cursorPositionChanged;
+	int32_t m_colorRangeMin, m_colorRangeMax;
+	SelectionMode m_selectionMode;
+	bool m_handleKeyboardInputs;
+	bool m_handleMouseInputs;
+	bool m_ignoreImGuiChild;
+	bool m_showWhitespaces;
 
-	static Palette sPaletteBase;
-	Palette mPalette;
-	LanguageDefinition mLanguageDefinition;
-	RegexList mRegexList;
-    bool mCheckComments;
-	Breakpoints mBreakpoints;
-	ErrorMarkers mErrorMarkers;
-	ImVec2 mCharAdvance;
-	Coordinates mInteractiveStart, mInteractiveEnd;
-	std::string mLineBuffer;
-	uint64_t mStartTime;
-	std::vector<std::string> mDefines;
+	static Palette s_paletteBase;
+	Palette m_palette;
+	LanguageDefinition mL_languageDefinition;
+	RegexList m_regexList;
+    bool m_checkComments;
+	Breakpoints m_breakpoints;
+	ErrorMarkers m_errorMarkers;
+	ImVec2 m_charAdvance;
+	Coordinates m_interactiveStart, m_interactiveEnd;
+	std::string m_lineBuffer;
+	uint64_t m_startTime;
+	std::vector<std::string> m_defines;
 
-	float mLastClick;
-    bool mShowCursor;
-    bool mShowLineNumbers;
+	float m_lastClick;
+    bool m_showCursor;
+    bool m_showLineNumbers;
 
-    static const int sCursorBlinkInterval;
-    static const int sCursorBlinkOnTime;
+    static const int32_t s_cursorBlinkInterval;
+    static const int32_t s_cursorBlinkOnTime;
 };
 
-bool TokenizeCStyleString(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
-bool TokenizeCStyleCharacterLiteral(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
-bool TokenizeCStyleIdentifier(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
-bool TokenizeCStyleNumber(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
-bool TokenizeCStylePunctuation(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
+bool tokenizeCStyleString(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
+bool tokenizeCStyleCharacterLiteral(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
+bool tokenizeCStyleIdentifier(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
+bool tokenizeCStyleNumber(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);
+bool tokenizeCStylePunctuation(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end);

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -22,61 +22,61 @@ bool equals(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Bi
     return first1 == last1 && first2 == last2;
 }
 
-const int TextEditor::sCursorBlinkInterval = 1200;
-const int TextEditor::sCursorBlinkOnTime = 800;
+const int32_t TextEditor::s_cursorBlinkInterval = 1200;
+const int32_t TextEditor::s_cursorBlinkOnTime = 800;
 
-TextEditor::Palette TextEditor::sPaletteBase = TextEditor::GetDarkPalette();
+TextEditor::Palette TextEditor::s_paletteBase = TextEditor::getDarkPalette();
 
-TextEditor::FindReplaceHandler::FindReplaceHandler() : mWholeWord(false),mFindRegEx(false),mMatchCase(false)  {}
+TextEditor::FindReplaceHandler::FindReplaceHandler() : m_wholeWord(false), m_findRegEx(false), m_matchCase(false)  {}
 
 TextEditor::TextEditor()
-    : mLineSpacing(1.0f), mUndoIndex(0), mTabSize(4), mOverwrite(false), mReadOnly(false), mWithinRender(false), mScrollToCursor(false), mScrollToTop(false), mScrollToBottom(false), mTextChanged(false), mColorizerEnabled(true), mTextStart(20.0f), mLeftMargin(10), mTopMargin(0), mCursorPositionChanged(false), mColorRangeMin(0), mColorRangeMax(0), mSelectionMode(SelectionMode::Normal), mCheckComments(true), mLastClick(-1.0f), mHandleKeyboardInputs(true), mHandleMouseInputs(true), mIgnoreImGuiChild(false), mShowWhitespaces(true), mShowCursor(true), mShowLineNumbers(true),mStartTime(ImGui::GetTime() * 1000) {
-    SetLanguageDefinition(LanguageDefinition::HLSL());
-    mLines.push_back(Line());
+    : m_lineSpacing(1.0f), m_undoIndex(0), m_tabSize(4), m_overwrite(false), m_readOnly(false), m_withinRender(false), m_scrollToCursor(false), m_scrollToTop(false), m_scrollToBottom(false), m_textChanged(false), m_colorizerEnabled(true), m_textStart(20.0f), m_leftMargin(10), m_topMargin(0), m_cursorPositionChanged(false), m_colorRangeMin(0), m_colorRangeMax(0), m_selectionMode(SelectionMode::Normal), m_checkComments(true), m_lastClick(-1.0f), m_handleKeyboardInputs(true), m_handleMouseInputs(true), m_ignoreImGuiChild(false), m_showWhitespaces(true), m_showCursor(true), m_showLineNumbers(true), m_startTime(ImGui::GetTime() * 1000) {
+    setLanguageDefinition(LanguageDefinition::HLSL());
+    m_lines.push_back(Line());
 }
 
 TextEditor::~TextEditor() {
 }
 
-void TextEditor::SetLanguageDefinition(const LanguageDefinition &aLanguageDef) {
-    mLanguageDefinition = aLanguageDef;
-    mRegexList.clear();
+void TextEditor::setLanguageDefinition(const LanguageDefinition &aLanguageDef) {
+    mL_languageDefinition = aLanguageDef;
+    m_regexList.clear();
 
-    for (auto &r : mLanguageDefinition.mTokenRegexStrings)
-        mRegexList.push_back(std::make_pair(std::regex(r.first, std::regex_constants::optimize), r.second));
+    for (auto &r : mL_languageDefinition.m_tokenRegexStrings)
+        m_regexList.push_back(std::make_pair(std::regex(r.first, std::regex_constants::optimize), r.second));
 
-    Colorize();
+    colorize();
 }
 
-void TextEditor::SetPalette(const Palette &aValue) {
-    sPaletteBase = aValue;
+void TextEditor::setPalette(const Palette &aValue) {
+    s_paletteBase = aValue;
 }
 
-std::string TextEditor::GetText(const Coordinates &aStart, const Coordinates &aEnd) const {
+std::string TextEditor::getText(const Coordinates &aStart, const Coordinates &aEnd) const {
     std::string result;
 
-    auto lstart = aStart.mLine;
-    auto lend   = aEnd.mLine;
-    auto istart = GetCharacterIndex(aStart);
-    auto iend   = GetCharacterIndex(aEnd);
+    auto line_start = aStart.m_line;
+    auto line_end   = aEnd.m_line;
+    auto index_start = getCharacterIndex(aStart);
+    auto index_end   = getCharacterIndex(aEnd);
     size_t s    = 0;
 
-    for (size_t i = lstart; i < lend; i++)
-        s += mLines[i].size();
+    for (size_t i = line_start; i < line_end; i++)
+        s += m_lines[i].size();
 
     result.reserve(s + s / 8);
 
-    while (istart < iend || lstart < lend) {
-        if (lstart >= (int)mLines.size())
+    while (index_start < index_end || line_start < line_end) {
+        if (line_start >= (int32_t)m_lines.size())
             break;
 
-        auto &line = mLines[lstart];
-        if (istart < (int)line.size()) {
-            result += line[istart].mChar;
-            istart++;
+        auto &line = m_lines[line_start];
+        if (index_start < (int32_t)line.size()) {
+            result += line[index_start].m_char;
+            index_start++;
         } else {
-            istart = 0;
-            ++lstart;
+            index_start = 0;
+            ++line_start;
             result += '\n';
         }
     }
@@ -84,31 +84,31 @@ std::string TextEditor::GetText(const Coordinates &aStart, const Coordinates &aE
     return result;
 }
 
-TextEditor::Coordinates TextEditor::GetActualCursorCoordinates() const {
-    return SanitizeCoordinates(mState.mCursorPosition);
+TextEditor::Coordinates TextEditor::getActualCursorCoordinates() const {
+    return sanitizeCoordinates(m_state.m_cursorPosition);
 }
 
-TextEditor::Coordinates TextEditor::SanitizeCoordinates(const Coordinates &aValue) const {
-    auto line   = aValue.mLine;
-    auto column = aValue.mColumn;
-    if (line >= (int)mLines.size()) {
-        if (mLines.empty()) {
+TextEditor::Coordinates TextEditor::sanitizeCoordinates(const Coordinates &aValue) const {
+    auto line   = aValue.m_line;
+    auto column = aValue.m_column;
+    if (line >= (int32_t)m_lines.size()) {
+        if (m_lines.empty()) {
             line   = 0;
             column = 0;
         } else {
-            line   = (int)mLines.size() - 1;
-            column = GetLineMaxColumn(line);
+            line   = (int32_t)m_lines.size() - 1;
+            column = getLineMaxColumn(line);
         }
         return Coordinates(line, column);
     } else {
-        column = mLines.empty() ? 0 : std::min(column, GetLineMaxColumn(line));
+        column = m_lines.empty() ? 0 : std::min(column, getLineMaxColumn(line));
         return Coordinates(line, column);
     }
 }
 
 // https://en.wikipedia.org/wiki/UTF-8
 // We assume that the char is a standalone character (<128) or a leading byte of an UTF-8 code sequence (non-10xxxxxx code)
-static int UTF8CharLength(TextEditor::Char c) {
+static int32_t UTF8CharLength(TextEditor::Char c) {
     if ((c & 0xFE) == 0xFC)
         return 6;
     if ((c & 0xFC) == 0xF8)
@@ -123,177 +123,177 @@ static int UTF8CharLength(TextEditor::Char c) {
 }
 
 // "Borrowed" from ImGui source
-static inline int ImTextCharToUtf8(char *buf, int buf_size, unsigned int c) {
+static inline int32_t ImTextCharToUtf8(char *buffer, int32_t buffer_size, uint32_t c) {
     if (c < 0x80) {
-        buf[0] = (char)c;
+        buffer[0] = (char)c;
         return 1;
     }
     if (c < 0x800) {
-        if (buf_size < 2) return 0;
-        buf[0] = (char)(0xc0 + (c >> 6));
-        buf[1] = (char)(0x80 + (c & 0x3f));
+        if (buffer_size < 2) return 0;
+        buffer[0] = (char)(0xc0 + (c >> 6));
+        buffer[1] = (char)(0x80 + (c & 0x3f));
         return 2;
     }
     if (c >= 0xdc00 && c < 0xe000) {
         return 0;
     }
     if (c >= 0xd800 && c < 0xdc00) {
-        if (buf_size < 4) return 0;
-        buf[0] = (char)(0xf0 + (c >> 18));
-        buf[1] = (char)(0x80 + ((c >> 12) & 0x3f));
-        buf[2] = (char)(0x80 + ((c >> 6) & 0x3f));
-        buf[3] = (char)(0x80 + ((c)&0x3f));
+        if (buffer_size < 4) return 0;
+        buffer[0] = (char)(0xf0 + (c >> 18));
+        buffer[1] = (char)(0x80 + ((c >> 12) & 0x3f));
+        buffer[2] = (char)(0x80 + ((c >> 6) & 0x3f));
+        buffer[3] = (char)(0x80 + ((c) & 0x3f));
         return 4;
     }
     // else if (c < 0x10000)
     {
-        if (buf_size < 3) return 0;
-        buf[0] = (char)(0xe0 + (c >> 12));
-        buf[1] = (char)(0x80 + ((c >> 6) & 0x3f));
-        buf[2] = (char)(0x80 + ((c)&0x3f));
+        if (buffer_size < 3) return 0;
+        buffer[0] = (char)(0xe0 + (c >> 12));
+        buffer[1] = (char)(0x80 + ((c >> 6) & 0x3f));
+        buffer[2] = (char)(0x80 + ((c) & 0x3f));
         return 3;
     }
 }
 
-void TextEditor::Advance(Coordinates &aCoordinates) const {
-    if (aCoordinates.mLine < (int)mLines.size()) {
-        auto &line  = mLines[aCoordinates.mLine];
-        auto cindex = GetCharacterIndex(aCoordinates);
+void TextEditor::advance(Coordinates &aCoordinates) const {
+    if (aCoordinates.m_line < (int32_t)m_lines.size()) {
+        auto &line  = m_lines[aCoordinates.m_line];
+        auto charIndex = getCharacterIndex(aCoordinates);
 
-        if (cindex + 1 < (int)line.size()) {
-            auto delta = UTF8CharLength(line[cindex].mChar);
-            cindex     = std::min(cindex + delta, (int)line.size() - 1);
+        if (charIndex + 1 < (int32_t)line.size()) {
+            auto delta = UTF8CharLength(line[charIndex].m_char);
+            charIndex     = std::min(charIndex + delta, (int32_t)line.size() - 1);
         } else {
-            ++aCoordinates.mLine;
-            cindex = 0;
+            ++aCoordinates.m_line;
+            charIndex = 0;
         }
-        aCoordinates.mColumn = GetCharacterColumn(aCoordinates.mLine, cindex);
+        aCoordinates.m_column = getCharacterColumn(aCoordinates.m_line, charIndex);
     }
 }
 
-void TextEditor::DeleteRange(const Coordinates &aStart, const Coordinates &aEnd) {
+void TextEditor::deleteRange(const Coordinates &aStart, const Coordinates &aEnd) {
     assert(aEnd >= aStart);
-    assert(!mReadOnly);
+    assert(!m_readOnly);
 
-    // printf("D(%d.%d)-(%d.%d)\n", aStart.mLine, aStart.mColumn, aEnd.mLine, aEnd.mColumn);
+    // printf("D(%d.%d)-(%d.%d)\n", aStart.m_line, aStart.m_column, aEnd.m_line, aEnd.m_column);
 
     if (aEnd == aStart)
         return;
 
-    auto start = GetCharacterIndex(aStart);
-    auto end   = GetCharacterIndex(aEnd);
+    auto start = getCharacterIndex(aStart);
+    auto end   = getCharacterIndex(aEnd);
 
-    if (aStart.mLine == aEnd.mLine) {
-        auto &line = mLines[aStart.mLine];
-        auto n     = GetLineMaxColumn(aStart.mLine);
-        if (aEnd.mColumn >= n)
+    if (aStart.m_line == aEnd.m_line) {
+        auto &line = m_lines[aStart.m_line];
+        auto n     = getLineMaxColumn(aStart.m_line);
+        if (aEnd.m_column >= n)
             line.erase(line.begin() + start, line.end());
         else
             line.erase(line.begin() + start, line.begin() + end);
     } else {
-        auto &firstLine = mLines[aStart.mLine];
-        auto &lastLine  = mLines[aEnd.mLine];
+        auto &firstLine = m_lines[aStart.m_line];
+        auto &lastLine  = m_lines[aEnd.m_line];
 
         firstLine.erase(firstLine.begin() + start, firstLine.end());
         lastLine.erase(lastLine.begin(), lastLine.begin() + end);
 
-        if (aStart.mLine < aEnd.mLine)
+        if (aStart.m_line < aEnd.m_line)
             firstLine.insert(firstLine.end(), lastLine.begin(), lastLine.end());
 
-        if (aStart.mLine < aEnd.mLine)
-            RemoveLine(aStart.mLine + 1, aEnd.mLine + 1);
+        if (aStart.m_line < aEnd.m_line)
+            removeLine(aStart.m_line + 1, aEnd.m_line + 1);
     }
 
-    mTextChanged = true;
+    m_textChanged = true;
 }
 
-int TextEditor::InsertTextAt(Coordinates & /* inout */ aWhere, const char *aValue) {
-    int cindex     = GetCharacterIndex(aWhere);
-    int totalLines = 0;
+int32_t TextEditor::insertTextAt(Coordinates /* inout */ &aWhere, const char *aValue) {
+    int32_t charIndex     = getCharacterIndex(aWhere);
+    int32_t totalLines = 0;
     while (*aValue != '\0') {
-        assert(!mLines.empty());
+        assert(!m_lines.empty());
 
         if (*aValue == '\r') {
             // skip
             ++aValue;
         } else if (*aValue == '\n') {
-            if (cindex < (int)mLines[aWhere.mLine].size()) {
-                auto &newLine = InsertLine(aWhere.mLine + 1);
-                auto &line    = mLines[aWhere.mLine];
-                newLine.insert(newLine.begin(), line.begin() + cindex, line.end());
-                line.erase(line.begin() + cindex, line.end());
+            if (charIndex < (int32_t)m_lines[aWhere.m_line].size()) {
+                auto &newLine = insertLine(aWhere.m_line + 1);
+                auto &line    = m_lines[aWhere.m_line];
+                newLine.insert(newLine.begin(), line.begin() + charIndex, line.end());
+                line.erase(line.begin() + charIndex, line.end());
             } else {
-                InsertLine(aWhere.mLine + 1);
+                insertLine(aWhere.m_line + 1);
             }
-            ++aWhere.mLine;
-            aWhere.mColumn = 0;
-            cindex         = 0;
+            ++aWhere.m_line;
+            aWhere.m_column = 0;
+            charIndex         = 0;
             ++totalLines;
             ++aValue;
         } else {
-            auto &line = mLines[aWhere.mLine];
+            auto &line = m_lines[aWhere.m_line];
             auto d     = UTF8CharLength(*aValue);
             while (d-- > 0 && *aValue != '\0')
-                line.insert(line.begin() + cindex++, Glyph(*aValue++, PaletteIndex::Default));
-            ++aWhere.mColumn;
+                line.insert(line.begin() + charIndex++, Glyph(*aValue++, PaletteIndex::Default));
+            ++aWhere.m_column;
         }
 
-        mTextChanged = true;
+        m_textChanged = true;
     }
 
     return totalLines;
 }
 
-void TextEditor::AddUndo(UndoRecord &aValue) {
-    assert(!mReadOnly);
-    // printf("AddUndo: (@%d.%d) +\'%s' [%d.%d .. %d.%d], -\'%s', [%d.%d .. %d.%d] (@%d.%d)\n",
-    //	aValue.mBefore.mCursorPosition.mLine, aValue.mBefore.mCursorPosition.mColumn,
-    //	aValue.mAdded.c_str(), aValue.mAddedStart.mLine, aValue.mAddedStart.mColumn, aValue.mAddedEnd.mLine, aValue.mAddedEnd.mColumn,
-    //	aValue.mRemoved.c_str(), aValue.mRemovedStart.mLine, aValue.mRemovedStart.mColumn, aValue.mRemovedEnd.mLine, aValue.mRemovedEnd.mColumn,
-    //	aValue.mAfter.mCursorPosition.mLine, aValue.mAfter.mCursorPosition.mColumn
+void TextEditor::addUndo(UndoRecord &aValue) {
+    assert(!m_readOnly);
+    // printf("addUndo: (@%d.%d) +\'%s' [%d.%d .. %d.%d], -\'%s', [%d.%d .. %d.%d] (@%d.%d)\n",
+    //	aValue.m_before.m_cursorPosition.m_line, aValue.m_before.m_cursorPosition.m_column,
+    //	aValue.m_added.c_str(), aValue.m_addedStart.m_line, aValue.m_addedStart.m_column, aValue.m_addedEnd.m_line, aValue.m_addedEnd.m_column,
+    //	aValue.m_removed.c_str(), aValue.m_removedStart.m_line, aValue.m_removedStart.m_column, aValue.m_removedEnd.m_line, aValue.m_removedEnd.m_column,
+    //	aValue.m_after.m_cursorPosition.m_line, aValue.m_after.m_cursorPosition.m_column
     //	);
 
-    mUndoBuffer.resize((size_t)(mUndoIndex + 1));
-    mUndoBuffer.back() = aValue;
-    ++mUndoIndex;
+    m_undoBuffer.resize((size_t)(m_undoIndex + 1));
+    m_undoBuffer.back() = aValue;
+    ++m_undoIndex;
 }
 
-TextEditor::Coordinates TextEditor::ScreenPosToCoordinates(const ImVec2 &aPosition) const {
+TextEditor::Coordinates TextEditor::screenPosToCoordinates(const ImVec2 &aPosition) const {
     ImVec2 origin = ImGui::GetCursorScreenPos();
     ImVec2 local(aPosition.x - origin.x, aPosition.y - origin.y);
 
-    int lineNo = std::max(0, (int)floor(local.y / mCharAdvance.y));
+    int32_t lineNo = std::max(0, (int32_t)floor(local.y / m_charAdvance.y));
 
-    int columnCoord = 0;
+    int32_t columnCoord = 0;
 
-    if (lineNo >= 0 && lineNo < (int)mLines.size()) {
-        auto &line = mLines.at(lineNo);
+    if (lineNo >= 0 && lineNo < (int32_t)m_lines.size()) {
+        auto &line = m_lines.at(lineNo);
 
-        int columnIndex = 0;
+        int32_t columnIndex = 0;
         float columnX   = 0.0f;
 
         while ((size_t)columnIndex < line.size()) {
             float columnWidth = 0.0f;
 
-            if (line[columnIndex].mChar == '\t') {
+            if (line[columnIndex].m_char == '\t') {
                 float spaceSize  = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, " ").x;
                 float oldX       = columnX;
-                float newColumnX = (1.0f + std::floor((1.0f + columnX) / (float(mTabSize) * spaceSize))) * (float(mTabSize) * spaceSize);
+                float newColumnX = (1.0f + std::floor((1.0f + columnX) / (float(m_tabSize) * spaceSize))) * (float(m_tabSize) * spaceSize);
                 columnWidth      = newColumnX - oldX;
-                if (mTextStart + columnX + columnWidth * 0.5f > local.x)
+                if (m_textStart + columnX + columnWidth * 0.5f > local.x)
                     break;
                 columnX     = newColumnX;
-                columnCoord = (columnCoord / mTabSize) * mTabSize + mTabSize;
+                columnCoord = (columnCoord / m_tabSize) * m_tabSize + m_tabSize;
                 columnIndex++;
             } else {
                 char buf[7];
-                auto d = UTF8CharLength(line[columnIndex].mChar);
-                int i  = 0;
+                auto d = UTF8CharLength(line[columnIndex].m_char);
+                int32_t i  = 0;
                 while (i < 6 && d-- > 0)
-                    buf[i++] = line[columnIndex++].mChar;
+                    buf[i++] = line[columnIndex++].m_char;
                 buf[i]      = '\0';
                 columnWidth = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf).x;
-                if (mTextStart + columnX + columnWidth * 0.5f > local.x)
+                if (m_textStart + columnX + columnWidth * 0.5f > local.x)
                     break;
                 columnX += columnWidth;
                 columnCoord++;
@@ -301,112 +301,112 @@ TextEditor::Coordinates TextEditor::ScreenPosToCoordinates(const ImVec2 &aPositi
         }
     }
 
-    return SanitizeCoordinates(Coordinates(lineNo, columnCoord));
+    return sanitizeCoordinates(Coordinates(lineNo, columnCoord));
 }
 
-TextEditor::Coordinates TextEditor::FindWordStart(const Coordinates &aFrom) const {
+TextEditor::Coordinates TextEditor::findWordStart(const Coordinates &aFrom) const {
     Coordinates at = aFrom;
-    if (at.mLine >= (int)mLines.size())
+    if (at.m_line >= (int32_t)m_lines.size())
         return at;
 
-    auto &line  = mLines[at.mLine];
-    auto cindex = GetCharacterIndex(at);
+    auto &line  = m_lines[at.m_line];
+    auto charIndex = getCharacterIndex(at);
 
-    if (cindex >= (int)line.size())
+    if (charIndex >= (int32_t)line.size())
         return at;
 
-    while (cindex > 0 && isspace(line[cindex].mChar))
-        --cindex;
+    while (charIndex > 0 && isspace(line[charIndex].m_char))
+        --charIndex;
 
-    auto cstart = line[cindex].mChar;
-    while (cindex > 0) {
-        auto c = line[cindex].mChar;
+    auto charStart = line[charIndex].m_char;
+    while (charIndex > 0) {
+        auto c = line[charIndex].m_char;
         if ((c & 0xC0) != 0x80)    // not UTF code sequence 10xxxxxx
         {
             if (c <= 32 && isspace(c)) {
-                cindex++;
+                charIndex++;
                 break;
             }
 
-            if (isalnum(cstart) || cstart == '_') {
+            if (isalnum(charStart) || charStart == '_') {
                 if (!isalnum(c) && c != '_') {
-                    cindex++;
+                    charIndex++;
                     break;
                 }
             } else {
                 break;
             }
         }
-        --cindex;
+        --charIndex;
     }
-    return Coordinates(at.mLine, GetCharacterColumn(at.mLine, cindex));
+    return Coordinates(at.m_line, getCharacterColumn(at.m_line, charIndex));
 }
 
-TextEditor::Coordinates TextEditor::FindWordEnd(const Coordinates &aFrom) const {
+TextEditor::Coordinates TextEditor::findWordEnd(const Coordinates &aFrom) const {
     Coordinates at = aFrom;
-    if (at.mLine >= (int)mLines.size())
+    if (at.m_line >= (int32_t)m_lines.size())
         return at;
 
-    auto &line  = mLines[at.mLine];
-    auto cindex = GetCharacterIndex(at);
+    auto &line  = m_lines[at.m_line];
+    auto charIndex = getCharacterIndex(at);
 
-    if (cindex >= (int)line.size())
+    if (charIndex >= (int32_t)line.size())
         return at;
 
-    bool prevspace = (bool)isspace(line[cindex].mChar);
-    auto cstart    = (PaletteIndex)line[cindex].mColorIndex;
-    while (cindex < (int)line.size()) {
-        auto c = line[cindex].mChar;
+    bool previousSpace = (bool)isspace(line[charIndex].m_char);
+    auto charStart    = (PaletteIndex)line[charIndex].m_colorIndex;
+    while (charIndex < (int32_t)line.size()) {
+        auto c = line[charIndex].m_char;
         auto d = UTF8CharLength(c);
-        if (cstart != (PaletteIndex)line[cindex].mColorIndex)
+        if (charStart != (PaletteIndex)line[charIndex].m_colorIndex)
             break;
 
-        if (prevspace != !!isspace(c)) {
+        if (previousSpace != !!isspace(c)) {
             if (isspace(c))
-                while (cindex < (int)line.size() && isspace(line[cindex].mChar))
-                    ++cindex;
+                while (charIndex < (int32_t)line.size() && isspace(line[charIndex].m_char))
+                    ++charIndex;
             break;
         }
-        cindex += d;
+        charIndex += d;
     }
-    return Coordinates(aFrom.mLine, GetCharacterColumn(aFrom.mLine, cindex));
+    return Coordinates(aFrom.m_line, getCharacterColumn(aFrom.m_line, charIndex));
 }
 
-TextEditor::Coordinates TextEditor::FindNextWord(const Coordinates &aFrom) const {
+TextEditor::Coordinates TextEditor::findNextWord(const Coordinates &aFrom) const {
     Coordinates at = aFrom;
-    if (at.mLine >= (int)mLines.size())
+    if (at.m_line >= (int32_t)m_lines.size())
         return at;
 
     // skip to the next non-word character
-    auto cindex = GetCharacterIndex(aFrom);
+    auto charIndex = getCharacterIndex(aFrom);
     bool isword = false;
     bool skip   = false;
-    if (cindex < (int)mLines[at.mLine].size()) {
-        auto &line = mLines[at.mLine];
-        isword     = isalnum(line[cindex].mChar);
+    if (charIndex < (int32_t)m_lines[at.m_line].size()) {
+        auto &line = m_lines[at.m_line];
+        isword     = isalnum(line[charIndex].m_char);
         skip       = isword;
     }
 
     while (!isword || skip) {
-        if (at.mLine >= mLines.size()) {
-            auto l = std::max(0, (int)mLines.size() - 1);
-            return Coordinates(l, GetLineMaxColumn(l));
+        if (at.m_line >= m_lines.size()) {
+            auto l = std::max(0, (int32_t)m_lines.size() - 1);
+            return Coordinates(l, getLineMaxColumn(l));
         }
 
-        auto &line = mLines[at.mLine];
-        if (cindex < (int)line.size()) {
-            isword = isalnum(line[cindex].mChar);
+        auto &line = m_lines[at.m_line];
+        if (charIndex < (int32_t)line.size()) {
+            isword = isalnum(line[charIndex].m_char);
 
             if (isword && !skip)
-                return Coordinates(at.mLine, GetCharacterColumn(at.mLine, cindex));
+                return Coordinates(at.m_line, getCharacterColumn(at.m_line, charIndex));
 
             if (!isword)
                 skip = false;
 
-            cindex++;
+            charIndex++;
         } else {
-            cindex = 0;
-            ++at.mLine;
+            charIndex = 0;
+            ++at.m_line;
             skip   = false;
             isword = false;
         }
@@ -415,74 +415,74 @@ TextEditor::Coordinates TextEditor::FindNextWord(const Coordinates &aFrom) const
     return at;
 }
 
-int TextEditor::GetCharacterIndex(const Coordinates &aCoordinates) const {
-    if (aCoordinates.mLine >= mLines.size())
+int32_t TextEditor::getCharacterIndex(const Coordinates &aCoordinates) const {
+    if (aCoordinates.m_line >= m_lines.size())
         return -1;
-    auto &line = mLines[aCoordinates.mLine];
-    int c      = 0;
-    int i      = 0;
-    for (; i < line.size() && c < aCoordinates.mColumn;) {
-        if (line[i].mChar == '\t')
-            c = (c / mTabSize) * mTabSize + mTabSize;
+    auto &line = m_lines[aCoordinates.m_line];
+    int32_t c      = 0;
+    int32_t i      = 0;
+    for (; i < line.size() && c < aCoordinates.m_column;) {
+        if (line[i].m_char == '\t')
+            c = (c / m_tabSize) * m_tabSize + m_tabSize;
         else
             ++c;
-        i += UTF8CharLength(line[i].mChar);
+        i += UTF8CharLength(line[i].m_char);
     }
     return i;
 }
 
-int TextEditor::GetCharacterColumn(int aLine, int aIndex) const {
-    if (aLine >= mLines.size())
+int32_t TextEditor::getCharacterColumn(int32_t aLine, int32_t aIndex) const {
+    if (aLine >= m_lines.size())
         return 0;
-    auto &line = mLines[aLine];
-    int col    = 0;
-    int i      = 0;
-    while (i < aIndex && i < (int)line.size()) {
-        auto c = line[i].mChar;
+    auto &line = m_lines[aLine];
+    int32_t col    = 0;
+    int32_t i      = 0;
+    while (i < aIndex && i < (int32_t)line.size()) {
+        auto c = line[i].m_char;
         i += UTF8CharLength(c);
         if (c == '\t')
-            col = (col / mTabSize) * mTabSize + mTabSize;
+            col = (col / m_tabSize) * m_tabSize + m_tabSize;
         else
             col++;
     }
     return col;
 }
 
-int TextEditor::GetStringCharacterCount(std::string str) const {
+int32_t TextEditor::getStringCharacterCount(std::string str) const {
     if (str.empty())
         return 0;
-    int c      = 0;
-    for (unsigned i = 0; i < str.size(); c++)
+    int32_t c      = 0;
+    for (uint32_t i = 0; i < str.size(); c++)
         i += UTF8CharLength(str[i]);
     return c;
 }
 
-int TextEditor::GetLineCharacterCount(int aLine) const {
-    if (aLine >= mLines.size())
+int32_t TextEditor::getLineCharacterCount(int32_t aLine) const {
+    if (aLine >= m_lines.size())
         return 0;
-    auto &line = mLines[aLine];
-    int c      = 0;
-    for (unsigned i = 0; i < line.size(); c++)
-        i += UTF8CharLength(line[i].mChar);
+    auto &line = m_lines[aLine];
+    int32_t c      = 0;
+    for (uint32_t i = 0; i < line.size(); c++)
+        i += UTF8CharLength(line[i].m_char);
     return c;
 }
 
-unsigned long long TextEditor::GetLineByteCount(int aLine) const {
-    if (aLine >= mLines.size())
+uint64_t TextEditor::getLineByteCount(int32_t aLine) const {
+    if (aLine >= m_lines.size())
         return 0;
-    auto &line = mLines[aLine];
+    auto &line = m_lines[aLine];
     return line.size();
 }
 
-int TextEditor::GetLineMaxColumn(int aLine) const {
-    if (aLine >= mLines.size())
+int32_t TextEditor::getLineMaxColumn(int32_t aLine) const {
+    if (aLine >= m_lines.size())
         return 0;
-    auto &line = mLines[aLine];
-    int col    = 0;
-    for (unsigned i = 0; i < line.size();) {
-        auto c = line[i].mChar;
+    auto &line = m_lines[aLine];
+    int32_t col    = 0;
+    for (uint32_t i = 0; i < line.size();) {
+        auto c = line[i].m_char;
         if (c == '\t')
-            col = (col / mTabSize) * mTabSize + mTabSize;
+            col = (col / m_tabSize) * m_tabSize + m_tabSize;
         else
             col++;
         i += UTF8CharLength(c);
@@ -490,138 +490,138 @@ int TextEditor::GetLineMaxColumn(int aLine) const {
     return col;
 }
 
-bool TextEditor::IsOnWordBoundary(const Coordinates &aAt) const {
-    if (aAt.mLine >= (int)mLines.size() || aAt.mColumn == 0)
+bool TextEditor::isOnWordBoundary(const Coordinates &aAt) const {
+    if (aAt.m_line >= (int32_t)m_lines.size() || aAt.m_column == 0)
         return true;
 
-    auto &line  = mLines[aAt.mLine];
-    auto cindex = GetCharacterIndex(aAt);
-    if (cindex >= (int)line.size())
+    auto &line  = m_lines[aAt.m_line];
+    auto charIndex = getCharacterIndex(aAt);
+    if (charIndex >= (int32_t)line.size())
         return true;
 
-    if (mColorizerEnabled)
-        return line[cindex].mColorIndex != line[size_t(cindex - 1)].mColorIndex;
+    if (m_colorizerEnabled)
+        return line[charIndex].m_colorIndex != line[size_t(charIndex - 1)].m_colorIndex;
 
-    return isspace(line[cindex].mChar) != isspace(line[cindex - 1].mChar);
+    return isspace(line[charIndex].m_char) != isspace(line[charIndex - 1].m_char);
 }
 
-void TextEditor::RemoveLine(int aStart, int aEnd) {
-    assert(!mReadOnly);
+void TextEditor::removeLine(int32_t aStart, int32_t aEnd) {
+    assert(!m_readOnly);
     assert(aEnd >= aStart);
-    assert(mLines.size() > (size_t)(aEnd - aStart));
+    assert(m_lines.size() > (size_t)(aEnd - aStart));
 
-    ErrorMarkers etmp;
-    for (auto &i : mErrorMarkers) {
+    ErrorMarkers errorMarker;
+    for (auto &i : m_errorMarkers) {
         ErrorMarkers::value_type e(i.first >= aStart ? i.first - 1 : i.first, i.second);
         if (e.first >= aStart && e.first <= aEnd)
             continue;
-        etmp.insert(e);
+        errorMarker.insert(e);
     }
-    mErrorMarkers = std::move(etmp);
+    m_errorMarkers = std::move(errorMarker);
 
-    Breakpoints btmp;
-    for (auto i : mBreakpoints) {
+    Breakpoints breakpoints;
+    for (auto i : m_breakpoints) {
         if (i >= aStart && i <= aEnd)
             continue;
-        btmp.insert(i >= aStart ? i - 1 : i);
+        breakpoints.insert(i >= aStart ? i - 1 : i);
     }
-    mBreakpoints = std::move(btmp);
+    m_breakpoints = std::move(breakpoints);
 
-    mLines.erase(mLines.begin() + aStart, mLines.begin() + aEnd);
-    assert(!mLines.empty());
+    m_lines.erase(m_lines.begin() + aStart, m_lines.begin() + aEnd);
+    assert(!m_lines.empty());
 
-    mTextChanged = true;
+    m_textChanged = true;
 }
 
-void TextEditor::RemoveLine(int aIndex) {
-    assert(!mReadOnly);
-    assert(mLines.size() > 1);
+void TextEditor::removeLine(int32_t aIndex) {
+    assert(!m_readOnly);
+    assert(m_lines.size() > 1);
 
-    ErrorMarkers etmp;
-    for (auto &i : mErrorMarkers) {
+    ErrorMarkers errorMarkers;
+    for (auto &i : m_errorMarkers) {
         ErrorMarkers::value_type e(i.first > aIndex ? i.first - 1 : i.first, i.second);
         if (e.first - 1 == aIndex)
             continue;
-        etmp.insert(e);
+        errorMarkers.insert(e);
     }
-    mErrorMarkers = std::move(etmp);
+    m_errorMarkers = std::move(errorMarkers);
 
-    Breakpoints btmp;
-    for (auto i : mBreakpoints) {
+    Breakpoints breakpoints;
+    for (auto i : m_breakpoints) {
         if (i == aIndex)
             continue;
-        btmp.insert(i >= aIndex ? i - 1 : i);
+        breakpoints.insert(i >= aIndex ? i - 1 : i);
     }
-    mBreakpoints = std::move(btmp);
+    m_breakpoints = std::move(breakpoints);
 
-    mLines.erase(mLines.begin() + aIndex);
-    assert(!mLines.empty());
+    m_lines.erase(m_lines.begin() + aIndex);
+    assert(!m_lines.empty());
 
-    mTextChanged = true;
+    m_textChanged = true;
 }
 
-TextEditor::Line &TextEditor::InsertLine(int aIndex) {
-    auto &result = *mLines.insert(mLines.begin() + aIndex, Line());
+TextEditor::Line &TextEditor::insertLine(int32_t aIndex) {
+    auto &result = *m_lines.insert(m_lines.begin() + aIndex, Line());
 
-    ErrorMarkers etmp;
-    for (auto &i : mErrorMarkers)
-        etmp.insert(ErrorMarkers::value_type(i.first >= aIndex ? i.first + 1 : i.first, i.second));
-    mErrorMarkers = std::move(etmp);
+    ErrorMarkers errorMarkers;
+    for (auto &i : m_errorMarkers)
+        errorMarkers.insert(ErrorMarkers::value_type(i.first >= aIndex ? i.first + 1 : i.first, i.second));
+    m_errorMarkers = std::move(errorMarkers);
 
-    Breakpoints btmp;
-    for (auto i : mBreakpoints)
-        btmp.insert(i >= aIndex ? i + 1 : i);
-    mBreakpoints = std::move(btmp);
+    Breakpoints breakpoints;
+    for (auto i : m_breakpoints)
+        breakpoints.insert(i >= aIndex ? i + 1 : i);
+    m_breakpoints = std::move(breakpoints);
 
     return result;
 }
 
-std::string TextEditor::GetWordUnderCursor() const {
-    auto c = GetCursorPosition();
-    return GetWordAt(c);
+std::string TextEditor::getWordUnderCursor() const {
+    auto c = getCursorPosition();
+    return getWordAt(c);
 }
 
-std::string TextEditor::GetWordAt(const Coordinates &aCoords) const {
-    auto start = FindWordStart(aCoords);
-    auto end   = FindWordEnd(aCoords);
+std::string TextEditor::getWordAt(const Coordinates &aCoords) const {
+    auto start = findWordStart(aCoords);
+    auto end   = findWordEnd(aCoords);
 
     std::string r;
 
-    auto istart = GetCharacterIndex(start);
-    auto iend   = GetCharacterIndex(end);
+    auto istart = getCharacterIndex(start);
+    auto iend   = getCharacterIndex(end);
 
     for (auto it = istart; it < iend; ++it)
-        r.push_back(mLines[aCoords.mLine][it].mChar);
+        r.push_back(m_lines[aCoords.m_line][it].m_char);
 
     return r;
 }
 
-ImU32 TextEditor::GetGlyphColor(const Glyph &aGlyph) const {
-    if (!mColorizerEnabled)
-        return mPalette[(int)PaletteIndex::Default];
-    if (aGlyph.mGlobalDocComment)
-        return mPalette[(int)PaletteIndex::GlobalDocComment];
-    if (aGlyph.mDocComment)
-        return mPalette[(int)PaletteIndex::DocComment];
-    if (aGlyph.mComment)
-        return mPalette[(int)PaletteIndex::Comment];
-    if (aGlyph.mMultiLineComment)
-        return mPalette[(int)PaletteIndex::MultiLineComment];
-    if (aGlyph.mDeactivated)
-        return mPalette[(int)PaletteIndex::PreprocessorDeactivated];
-    const auto color = mPalette[(int)aGlyph.mColorIndex];
-    if (aGlyph.mPreprocessor) {
-        const auto ppcolor = mPalette[(int)PaletteIndex::Preprocessor];
-        const int c0       = ((ppcolor & 0xff) + (color & 0xff)) / 2;
-        const int c1       = (((ppcolor >> 8) & 0xff) + ((color >> 8) & 0xff)) / 2;
-        const int c2       = (((ppcolor >> 16) & 0xff) + ((color >> 16) & 0xff)) / 2;
-        const int c3       = (((ppcolor >> 24) & 0xff) + ((color >> 24) & 0xff)) / 2;
+ImU32 TextEditor::getGlyphColor(const Glyph &aGlyph) const {
+    if (!m_colorizerEnabled)
+        return m_palette[(int32_t)PaletteIndex::Default];
+    if (aGlyph.m_globalDocComment)
+        return m_palette[(int32_t)PaletteIndex::GlobalDocComment];
+    if (aGlyph.m_docComment)
+        return m_palette[(int32_t)PaletteIndex::DocComment];
+    if (aGlyph.m_comment)
+        return m_palette[(int32_t)PaletteIndex::Comment];
+    if (aGlyph.m_multiLineComment)
+        return m_palette[(int32_t)PaletteIndex::MultiLineComment];
+    if (aGlyph.m_deactivated)
+        return m_palette[(int32_t)PaletteIndex::PreprocessorDeactivated];
+    const auto color = m_palette[(int32_t)aGlyph.m_colorIndex];
+    if (aGlyph.m_preprocessor) {
+        const auto preprocessorColor = m_palette[(int32_t)PaletteIndex::Preprocessor];
+        const int32_t c0       = ((preprocessorColor & 0xff) + (color & 0xff)) / 2;
+        const int32_t c1       = (((preprocessorColor >> 8) & 0xff) + ((color >> 8) & 0xff)) / 2;
+        const int32_t c2       = (((preprocessorColor >> 16) & 0xff) + ((color >> 16) & 0xff)) / 2;
+        const int32_t c3       = (((preprocessorColor >> 24) & 0xff) + ((color >> 24) & 0xff)) / 2;
         return ImU32(c0 | (c1 << 8) | (c2 << 16) | (c3 << 24));
     }
     return color;
 }
 
-void TextEditor::HandleKeyboardInputs() {
+void TextEditor::handleKeyboardInputs() {
     ImGuiIO &io   = ImGui::GetIO();
 
     // command => Ctrl
@@ -652,91 +652,91 @@ void TextEditor::HandleKeyboardInputs() {
 
         bool handledKeyEvent = true;
 
-        if (!IsReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Z))
-            Undo();
-        else if (!IsReadOnly() && !ctrl && !shift && alt && ImGui::IsKeyPressed(ImGuiKey_Backspace))
-            Undo();
-        else if (!IsReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Y))
-            Redo();
+        if (!isReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Z))
+            undo();
+        else if (!isReadOnly() && !ctrl && !shift && alt && ImGui::IsKeyPressed(ImGuiKey_Backspace))
+            undo();
+        else if (!isReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Y))
+            redo();
         else if (!ctrl && !alt && up)
-            MoveUp(1, shift);
+            moveUp(1, shift);
         else if (!ctrl && !alt && down)
-            MoveDown(1, shift);
+            moveDown(1, shift);
         else if (!alt && left)
-            MoveLeft(1, shift, ctrl);
+            moveLeft(1, shift, ctrl);
         else if (!alt && right)
-            MoveRight(1, shift, ctrl);
+            moveRight(1, shift, ctrl);
         else if (!alt && pageUp)
-            MoveUp(GetPageSize() - 4, shift);
+            moveUp(getPageSize() - 4, shift);
         else if (!alt && pageDown)
-            MoveDown(GetPageSize() - 4, shift);
+            moveDown(getPageSize() - 4, shift);
         else if (!alt && top)
-            MoveTop(shift);
+            moveTop(shift);
         else if (!alt && bottom)
-            MoveBottom(shift);
+            moveBottom(shift);
         else if (!ctrl && !alt && home)
-            MoveHome(shift);
+            moveHome(shift);
         else if (!ctrl && !alt && end)
-            MoveEnd(shift);
-        else if (!IsReadOnly() && !ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Delete))
-            Delete();
-        else if (!IsReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Delete)) {
-            auto wordStart = GetCursorPosition();
-            MoveRight();
-            auto wordEnd = FindWordEnd(GetCursorPosition());
-            SetSelection(wordStart, wordEnd);
-            Backspace();
+            moveEnd(shift);
+        else if (!isReadOnly() && !ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Delete))
+            doDelete();
+        else if (!isReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Delete)) {
+            auto wordStart = getCursorPosition();
+            moveRight();
+            auto wordEnd = findWordEnd(getCursorPosition());
+            setSelection(wordStart, wordEnd);
+            backspace();
         }
-        else if (!IsReadOnly() && !ctrl && !alt && ImGui::IsKeyPressed(ImGuiKey_Backspace))
-            Backspace();
-        else if (!IsReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Backspace)) {
-            auto wordEnd = GetCursorPosition();
-            MoveLeft();
-            auto wordStart = FindWordStart(GetCursorPosition());
-            SetSelection(wordStart, wordEnd);
-            Backspace();
+        else if (!isReadOnly() && !ctrl && !alt && ImGui::IsKeyPressed(ImGuiKey_Backspace))
+            backspace();
+        else if (!isReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Backspace)) {
+            auto wordEnd = getCursorPosition();
+            moveLeft();
+            auto wordStart = findWordStart(getCursorPosition());
+            setSelection(wordStart, wordEnd);
+            backspace();
         }
         else if (!ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Insert))
-            mOverwrite = !mOverwrite;
+            m_overwrite = !m_overwrite;
         else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Insert))
-            Copy();
+            copy();
         else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_C))
-            Copy();
-        else if (!IsReadOnly() && !ctrl && shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Insert))
-            Paste();
-        else if (!IsReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_V))
-            Paste();
+            copy();
+        else if (!isReadOnly() && !ctrl && shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Insert))
+            paste();
+        else if (!isReadOnly() && ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_V))
+            paste();
         else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_X))
-            Cut();
+            cut();
         else if (!ctrl && shift && !alt && ImGui::IsKeyPressed(ImGuiKey_Delete))
-            Cut();
+            cut();
         else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGuiKey_A))
-            SelectAll();
-        else if (!IsReadOnly() && !ctrl && !shift && !alt && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter)))
-            EnterCharacter('\n', false);
-        else if (!IsReadOnly() && !ctrl && !alt && ImGui::IsKeyPressed(ImGuiKey_Tab))
-            EnterCharacter('\t', shift);
+            selectAll();
+        else if (!isReadOnly() && !ctrl && !shift && !alt && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter)))
+            enterCharacter('\n', false);
+        else if (!isReadOnly() && !ctrl && !alt && ImGui::IsKeyPressed(ImGuiKey_Tab))
+            enterCharacter('\t', shift);
         else if (!ctrl && !alt && !shift && ImGui::IsKeyPressed(ImGuiKey_F3))
-            mFindReplaceHandler.FindMatch(this, true);
+            m_findReplaceHandler.findMatch(this, true);
         else if (!ctrl && !alt && shift && ImGui::IsKeyPressed(ImGuiKey_F3))
-            mFindReplaceHandler.FindMatch(this, false);
+            m_findReplaceHandler.findMatch(this, false);
         else if (!ctrl && alt && !shift && ImGui::IsKeyPressed(ImGuiKey_C))
-            mFindReplaceHandler.SetMatchCase(this,!mFindReplaceHandler.GetMatchCase());
+            m_findReplaceHandler.setMatchCase(this, !m_findReplaceHandler.getMatchCase());
         else if (!ctrl && alt && !shift && ImGui::IsKeyPressed(ImGuiKey_R))
-            mFindReplaceHandler.SetFindRegEx(this,!mFindReplaceHandler.GetFindRegEx());
+            m_findReplaceHandler.setFindRegEx(this, !m_findReplaceHandler.getFindRegEx());
         else if (!ctrl && alt && !shift && ImGui::IsKeyPressed(ImGuiKey_W))
-            mFindReplaceHandler.SetWholeWord(this,!mFindReplaceHandler.GetWholeWord());
+            m_findReplaceHandler.setWholeWord(this, !m_findReplaceHandler.getWholeWord());
         else
             handledKeyEvent = false;
 
         if (handledKeyEvent)
-            ResetCursorBlinkTime();
+            resetCursorBlinkTime();
 
-        if (!IsReadOnly() && !io.InputQueueCharacters.empty()) {
-            for (int i = 0; i < io.InputQueueCharacters.Size; i++) {
+        if (!isReadOnly() && !io.InputQueueCharacters.empty()) {
+            for (int32_t i = 0; i < io.InputQueueCharacters.Size; i++) {
                 auto c = io.InputQueueCharacters[i];
                 if (c != 0 && (c == '\n' || c >= 32)) {
-                    EnterCharacter(c, shift);
+                    enterCharacter(c, shift);
                 }
             }
             io.InputQueueCharacters.resize(0);
@@ -744,7 +744,7 @@ void TextEditor::HandleKeyboardInputs() {
     }
 }
 
-void TextEditor::HandleMouseInputs() {
+void TextEditor::handleMouseInputs() {
     ImGuiIO &io = ImGui::GetIO();
     auto shift  = io.KeyShift;
     auto ctrl   = io.ConfigMacOSXBehaviors ? io.KeyAlt : io.KeyCtrl;
@@ -755,7 +755,7 @@ void TextEditor::HandleMouseInputs() {
             auto click       = ImGui::IsMouseClicked(0);
             auto doubleClick = ImGui::IsMouseDoubleClicked(0);
             auto t           = ImGui::GetTime();
-            auto tripleClick = click && !doubleClick && (mLastClick != -1.0f && (t - mLastClick) < io.MouseDoubleClickTime);
+            auto tripleClick = click && !doubleClick && (m_lastClick != -1.0f && (t - m_lastClick) < io.MouseDoubleClickTime);
 
             /*
             Left mouse button triple click
@@ -763,13 +763,14 @@ void TextEditor::HandleMouseInputs() {
 
             if (tripleClick) {
                 if (!ctrl) {
-                    mState.mCursorPosition = mInteractiveStart = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
-                    mSelectionMode                                               = SelectionMode::Line;
-                    SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
+                    m_state.m_cursorPosition = m_interactiveStart = m_interactiveEnd = screenPosToCoordinates(
+                            ImGui::GetMousePos());
+                    m_selectionMode                                               = SelectionMode::Line;
+                    setSelection(m_interactiveStart, m_interactiveEnd, m_selectionMode);
                 }
 
-                mLastClick = -1.0f;
-                ResetCursorBlinkTime();
+                m_lastClick = -1.0f;
+                resetCursorBlinkTime();
             }
 
             /*
@@ -778,16 +779,17 @@ void TextEditor::HandleMouseInputs() {
 
             else if (doubleClick) {
                 if (!ctrl) {
-                    mState.mCursorPosition = mInteractiveStart = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
-                    if (mSelectionMode == SelectionMode::Line)
-                        mSelectionMode = SelectionMode::Normal;
+                    m_state.m_cursorPosition = m_interactiveStart = m_interactiveEnd = screenPosToCoordinates(
+                            ImGui::GetMousePos());
+                    if (m_selectionMode == SelectionMode::Line)
+                        m_selectionMode = SelectionMode::Normal;
                     else
-                        mSelectionMode = SelectionMode::Word;
-                    SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
+                        m_selectionMode = SelectionMode::Word;
+                    setSelection(m_interactiveStart, m_interactiveEnd, m_selectionMode);
                 }
 
-                mLastClick = (float)ImGui::GetTime();
-                ResetCursorBlinkTime();
+                m_lastClick = (float)ImGui::GetTime();
+                resetCursorBlinkTime();
             }
 
             /*
@@ -795,115 +797,119 @@ void TextEditor::HandleMouseInputs() {
             */
             else if (click) {
                 if (ctrl) {
-                    mState.mCursorPosition = mInteractiveStart = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
-                    mSelectionMode = SelectionMode::Word;
+                    m_state.m_cursorPosition = m_interactiveStart = m_interactiveEnd = screenPosToCoordinates(
+                            ImGui::GetMousePos());
+                    m_selectionMode = SelectionMode::Word;
                 } else if (shift) {
-                    mSelectionMode = SelectionMode::Normal;
-                    mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
+                    m_selectionMode = SelectionMode::Normal;
+                    m_interactiveEnd = screenPosToCoordinates(ImGui::GetMousePos());
                 } else {
-                    mState.mCursorPosition = mInteractiveStart = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
-                    mSelectionMode = SelectionMode::Normal;
+                    m_state.m_cursorPosition = m_interactiveStart = m_interactiveEnd = screenPosToCoordinates(
+                            ImGui::GetMousePos());
+                    m_selectionMode = SelectionMode::Normal;
                 }
-                SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
-                ResetCursorBlinkTime();
+                setSelection(m_interactiveStart, m_interactiveEnd, m_selectionMode);
+                resetCursorBlinkTime();
 
-                mLastClick = (float)ImGui::GetTime();
+                m_lastClick = (float)ImGui::GetTime();
             }
             // Mouse left button dragging (=> update selection)
             else if (ImGui::IsMouseDragging(0) && ImGui::IsMouseDown(0)) {
                 io.WantCaptureMouse    = true;
-                mState.mCursorPosition = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
-                SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
-                ResetCursorBlinkTime();
+                m_state.m_cursorPosition = m_interactiveEnd = screenPosToCoordinates(ImGui::GetMousePos());
+                setSelection(m_interactiveStart, m_interactiveEnd, m_selectionMode);
+                resetCursorBlinkTime();
             }
         }
     }
 }
 
 void TextEditor::Render() {
-    /* Compute mCharAdvance regarding scaled font size (Ctrl + mouse wheel)*/
+    /* Compute m_charAdvance regarding scaled font size (Ctrl + mouse wheel)*/
     const float fontSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, "#", nullptr, nullptr).x;
-    mCharAdvance         = ImVec2(fontSize, ImGui::GetTextLineHeightWithSpacing() * mLineSpacing);
+    m_charAdvance         = ImVec2(fontSize, ImGui::GetTextLineHeightWithSpacing() * m_lineSpacing);
 
     /* Update palette with the current alpha from style */
-    for (int i = 0; i < (int)PaletteIndex::Max; ++i) {
-        auto color = ImGui::ColorConvertU32ToFloat4(sPaletteBase[i]);
+    for (int32_t i = 0; i < (int32_t)PaletteIndex::Max; ++i) {
+        auto color = ImGui::ColorConvertU32ToFloat4(s_paletteBase[i]);
         color.w *= ImGui::GetStyle().Alpha;
-        mPalette[i] = ImGui::ColorConvertFloat4ToU32(color);
+        m_palette[i] = ImGui::ColorConvertFloat4ToU32(color);
     }
 
-    assert(mLineBuffer.empty());
+    assert(m_lineBuffer.empty());
 
-    auto contentSize = ImGui::GetCurrentWindowRead()->ContentRegionRect.Max - ImGui::GetWindowPos() - ImVec2(0,mTopMargin);
+    auto contentSize = ImGui::GetCurrentWindowRead()->ContentRegionRect.Max - ImGui::GetWindowPos() - ImVec2(0, m_topMargin);
     auto drawList    = ImGui::GetWindowDrawList();
-    float longest(mTextStart);
+    float longest(m_textStart);
 
-    if (mScrollToTop) {
-        mScrollToTop = false;
+    if (m_scrollToTop) {
+        m_scrollToTop = false;
         ImGui::SetScrollY(0.f);
     }
 
-    if ( mScrollToBottom && ImGui::GetScrollMaxY() > ImGui::GetScrollY()) {
-        mScrollToBottom = false;
+    if (m_scrollToBottom && ImGui::GetScrollMaxY() > ImGui::GetScrollY()) {
+        m_scrollToBottom = false;
         ImGui::SetScrollY(ImGui::GetScrollMaxY());
     }
 
-    ImVec2 cursorScreenPos = ImGui::GetCursorScreenPos() + ImVec2(0, mTopMargin);
+    ImVec2 cursorScreenPos = ImGui::GetCursorScreenPos() + ImVec2(0, m_topMargin);
     auto scrollX           = ImGui::GetScrollX();
     auto scrollY           = ImGui::GetScrollY();
 
-    auto lineNo        = (int)(std::floor(scrollY / mCharAdvance.y));// + linesAdded);
-    auto globalLineMax = (int)mLines.size();
-    auto lineMax       = std::max(0, std::min((int)mLines.size() - 1, lineNo + (int)std::ceil((scrollY + contentSize.y) / mCharAdvance.y)));
+    auto lineNo        = (int32_t)(std::floor(scrollY / m_charAdvance.y));// + linesAdded);
+    auto globalLineMax = (int32_t)m_lines.size();
+    auto lineMax       = std::max(0, std::min((int32_t)m_lines.size() - 1, lineNo + (int32_t)std::ceil((scrollY + contentSize.y) / m_charAdvance.y)));
 
-    // Deduce mTextStart by evaluating mLines size (global lineMax) plus two spaces as text width
+    // Deduce m_textStart by evaluating m_lines size (global lineMax) plus two spaces as text width
     char buf[16];
 
-    if (mShowLineNumbers)
+    if (m_showLineNumbers)
         snprintf(buf, 16, " %d ", globalLineMax);
     else
         buf[0] = '\0';
-    mTextStart = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x + mLeftMargin;
+    m_textStart = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x + m_leftMargin;
 
-    if (!mLines.empty()) {
+    if (!m_lines.empty()) {
         float spaceSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, " ", nullptr, nullptr).x;
 
         while (lineNo <= lineMax) {
-            ImVec2 lineStartScreenPos = ImVec2(cursorScreenPos.x, cursorScreenPos.y + lineNo * mCharAdvance.y);
-            ImVec2 textScreenPos      = ImVec2(lineStartScreenPos.x + mTextStart, lineStartScreenPos.y);
+            ImVec2 lineStartScreenPos = ImVec2(cursorScreenPos.x, cursorScreenPos.y + lineNo * m_charAdvance.y);
+            ImVec2 textScreenPos      = ImVec2(lineStartScreenPos.x + m_textStart, lineStartScreenPos.y);
 
-            auto &line    = mLines[lineNo];
-            longest       = std::max(mTextStart + TextDistanceToLineStart(Coordinates(lineNo, GetLineMaxColumn(lineNo))), longest);
+            auto &line    = m_lines[lineNo];
+            longest       = std::max(m_textStart +
+                                             textDistanceToLineStart(Coordinates(lineNo, getLineMaxColumn(lineNo))), longest);
             auto columnNo = 0;
             Coordinates lineStartCoord(lineNo, 0);
-            Coordinates lineEndCoord(lineNo, GetLineMaxColumn(lineNo));
+            Coordinates lineEndCoord(lineNo, getLineMaxColumn(lineNo));
 
             // Draw selection for the current line
-            float sstart = -1.0f;
-            float ssend  = -1.0f;
+            float selectionStart = -1.0f;
+            float selectionEnd  = -1.0f;
 
-            assert(mState.mSelectionStart <= mState.mSelectionEnd);
-            if (mState.mSelectionStart <= lineEndCoord)
-                sstart = mState.mSelectionStart > lineStartCoord ? TextDistanceToLineStart(mState.mSelectionStart) : 0.0f;
-            if (mState.mSelectionEnd > lineStartCoord)
-                ssend = TextDistanceToLineStart(mState.mSelectionEnd < lineEndCoord ? mState.mSelectionEnd : lineEndCoord);
+            assert(m_state.m_selectionStart <= m_state.m_selectionEnd);
+            if (m_state.m_selectionStart <= lineEndCoord)
+                selectionStart = m_state.m_selectionStart > lineStartCoord ? textDistanceToLineStart(m_state.m_selectionStart) : 0.0f;
+            if (m_state.m_selectionEnd > lineStartCoord)
+                selectionEnd = textDistanceToLineStart(
+                        m_state.m_selectionEnd < lineEndCoord ? m_state.m_selectionEnd : lineEndCoord);
 
-            if (mState.mSelectionEnd.mLine > lineNo)
-                ssend += mCharAdvance.x;
+            if (m_state.m_selectionEnd.m_line > lineNo)
+                selectionEnd += m_charAdvance.x;
 
-            if (sstart != -1 && ssend != -1 && sstart < ssend) {
-                ImVec2 vstart(lineStartScreenPos.x + mTextStart + sstart, lineStartScreenPos.y);
-                ImVec2 vend(lineStartScreenPos.x + mTextStart + ssend, lineStartScreenPos.y + mCharAdvance.y);
-                drawList->AddRectFilled(vstart, vend, mPalette[(int)PaletteIndex::Selection]);
+            if (selectionStart != -1 && selectionEnd != -1 && selectionStart < selectionEnd) {
+                ImVec2 vstart(lineStartScreenPos.x + m_textStart + selectionStart, lineStartScreenPos.y);
+                ImVec2 vend(lineStartScreenPos.x + m_textStart + selectionEnd, lineStartScreenPos.y + m_charAdvance.y);
+                drawList->AddRectFilled(vstart, vend, m_palette[(int32_t)PaletteIndex::Selection]);
             }
 
             auto start = ImVec2(lineStartScreenPos.x + scrollX, lineStartScreenPos.y);
 
             // Draw error markers
-            auto errorIt = mErrorMarkers.find(lineNo + 1);
-            if (errorIt != mErrorMarkers.end()) {
-                auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + mCharAdvance.y);
-                drawList->AddRectFilled(start, end, mPalette[(int)PaletteIndex::ErrorMarker]);
+            auto errorIt = m_errorMarkers.find(lineNo + 1);
+            if (errorIt != m_errorMarkers.end()) {
+                auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + m_charAdvance.y);
+                drawList->AddRectFilled(start, end, m_palette[(int32_t)PaletteIndex::ErrorMarker]);
 
                 if (ImGui::IsMouseHoveringRect(lineStartScreenPos, end)) {
                     ImGui::BeginTooltip();
@@ -919,86 +925,86 @@ void TextEditor::Render() {
             }
 
             // Draw line number (right aligned)
-            if (mShowLineNumbers) {
+            if (m_showLineNumbers) {
                 snprintf(buf, 16, "%d  ", lineNo + 1);
 
                 auto lineNoWidth = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x;
-                drawList->AddText(ImVec2(lineStartScreenPos.x + mTextStart - lineNoWidth, lineStartScreenPos.y), mPalette[(int)PaletteIndex::LineNumber], buf);
+                drawList->AddText(ImVec2(lineStartScreenPos.x + m_textStart - lineNoWidth, lineStartScreenPos.y), m_palette[(int32_t)PaletteIndex::LineNumber], buf);
             }
 
             // Draw breakpoints
-            if (mBreakpoints.count(lineNo + 1) != 0) {
-                auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + mCharAdvance.y);
-                drawList->AddRectFilled(start + ImVec2(mTextStart, 0), end, mPalette[(int)PaletteIndex::Breakpoint]);
+            if (m_breakpoints.count(lineNo + 1) != 0) {
+                auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + m_charAdvance.y);
+                drawList->AddRectFilled(start + ImVec2(m_textStart, 0), end, m_palette[(int32_t)PaletteIndex::Breakpoint]);
 
-                drawList->AddCircleFilled(start + ImVec2(0, mCharAdvance.y) / 2, mCharAdvance.y / 3, mPalette[(int)PaletteIndex::Breakpoint]);
-                drawList->AddCircle(start + ImVec2(0, mCharAdvance.y) / 2, mCharAdvance.y / 3, mPalette[(int)PaletteIndex::Default]);
+                drawList->AddCircleFilled(start + ImVec2(0, m_charAdvance.y) / 2, m_charAdvance.y / 3, m_palette[(int32_t)PaletteIndex::Breakpoint]);
+                drawList->AddCircle(start + ImVec2(0, m_charAdvance.y) / 2, m_charAdvance.y / 3, m_palette[(int32_t)PaletteIndex::Default]);
             }
 
-            if (mState.mCursorPosition.mLine == lineNo && mShowCursor) {
+            if (m_state.m_cursorPosition.m_line == lineNo && m_showCursor) {
                 bool focused = ImGui::IsWindowFocused();
                 ImGuiViewport *viewport = ImGui::GetWindowViewport();
 
                 // Highlight the current line (where the cursor is)
-                if (!HasSelection()) {
-                    auto end = ImVec2(start.x + contentSize.x + scrollX, start.y + mCharAdvance.y);
-                    drawList->AddRectFilled(start, end, mPalette[(int)(focused ? PaletteIndex::CurrentLineFill : PaletteIndex::CurrentLineFillInactive)]);
-                    drawList->AddRect(start, end, mPalette[(int)PaletteIndex::CurrentLineEdge], 1.0f);
+                if (!hasSelection()) {
+                    auto end = ImVec2(start.x + contentSize.x + scrollX, start.y + m_charAdvance.y);
+                    drawList->AddRectFilled(start, end, m_palette[(int32_t)(focused ? PaletteIndex::CurrentLineFill : PaletteIndex::CurrentLineFillInactive)]);
+                    drawList->AddRect(start, end, m_palette[(int32_t)PaletteIndex::CurrentLineEdge], 1.0f);
                 }
 
                 // Render the cursor
                 if (focused) {
                     auto timeEnd = ImGui::GetTime() * 1000;
-                    auto elapsed = timeEnd - mStartTime;
-                    if (elapsed > sCursorBlinkOnTime) {
+                    auto elapsed = timeEnd - m_startTime;
+                    if (elapsed > s_cursorBlinkOnTime) {
                         float width = 1.0f;
-                        auto cindex = GetCharacterIndex(mState.mCursorPosition);
-                        float cx    = TextDistanceToLineStart(mState.mCursorPosition);
+                        auto charIndex = getCharacterIndex(m_state.m_cursorPosition);
+                        float toLineStart    = textDistanceToLineStart(m_state.m_cursorPosition);
 
-                        if (mOverwrite && cindex < (int)line.size()) {
-                            auto c = line[cindex].mChar;
+                        if (m_overwrite && charIndex < (int32_t)line.size()) {
+                            auto c = line[charIndex].m_char;
                             if (c == '\t') {
-                                auto x = (1.0f + std::floor((1.0f + cx) / (float(mTabSize) * spaceSize))) * (float(mTabSize) * spaceSize);
-                                width  = x - cx;
+                                auto x = (1.0f + std::floor((1.0f + toLineStart) / (float(m_tabSize) * spaceSize))) * (float(m_tabSize) * spaceSize);
+                                width  = x - toLineStart;
                             } else {
                                 char buf2[2];
-                                buf2[0] = line[cindex].mChar;
+                                buf2[0] = line[charIndex].m_char;
                                 buf2[1] = '\0';
                                 width   = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf2).x;
                             }
                         }
-                        ImVec2 cstart(textScreenPos.x + cx, lineStartScreenPos.y);
-                        ImVec2 cend(textScreenPos.x + cx + width, lineStartScreenPos.y + mCharAdvance.y);
-                        drawList->AddRectFilled(cstart, cend, mPalette[(int)PaletteIndex::Cursor]);
-                        if (elapsed > sCursorBlinkInterval)
-                            mStartTime = timeEnd;
+                        ImVec2 charStart(textScreenPos.x + toLineStart, lineStartScreenPos.y);
+                        ImVec2 charEnd(textScreenPos.x + toLineStart + width, lineStartScreenPos.y + m_charAdvance.y);
+                        drawList->AddRectFilled(charStart, charEnd, m_palette[(int32_t)PaletteIndex::Cursor]);
+                        if (elapsed > s_cursorBlinkInterval)
+                            m_startTime = timeEnd;
                     }
                 }
             }
 
             // Render colorized text
-            auto prevColor = line.empty() ? mPalette[(int)PaletteIndex::Default] : GetGlyphColor(line[0]);
+            auto prevColor = line.empty() ? m_palette[(int32_t)PaletteIndex::Default] : getGlyphColor(line[0]);
             ImVec2 bufferOffset;
 
-            for (int i = 0; i < line.size();) {
+            for (int32_t i = 0; i < line.size();) {
                 auto &glyph = line[i];
-                auto color  = GetGlyphColor(glyph);
+                auto color  = getGlyphColor(glyph);
 
-                if ((color != prevColor || glyph.mChar == '\t' || glyph.mChar == ' ') && !mLineBuffer.empty()) {
+                if ((color != prevColor || glyph.m_char == '\t' || glyph.m_char == ' ') && !m_lineBuffer.empty()) {
                     const ImVec2 newOffset(textScreenPos.x + bufferOffset.x, textScreenPos.y + bufferOffset.y);
-                    drawList->AddText(newOffset, prevColor, mLineBuffer.c_str());
-                    auto textSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, mLineBuffer.c_str(), nullptr, nullptr);
+                    drawList->AddText(newOffset, prevColor, m_lineBuffer.c_str());
+                    auto textSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, m_lineBuffer.c_str(), nullptr, nullptr);
                     bufferOffset.x += textSize.x;
-                    mLineBuffer.clear();
+                    m_lineBuffer.clear();
                 }
                 prevColor = color;
 
-                if (glyph.mChar == '\t') {
+                if (glyph.m_char == '\t') {
                     auto oldX      = bufferOffset.x;
-                    bufferOffset.x = (1.0f + std::floor((1.0f + bufferOffset.x) / (float(mTabSize) * spaceSize))) * (float(mTabSize) * spaceSize);
+                    bufferOffset.x = (1.0f + std::floor((1.0f + bufferOffset.x) / (float(m_tabSize) * spaceSize))) * (float(m_tabSize) * spaceSize);
                     ++i;
 
-                    if (mShowWhitespaces) {
+                    if (m_showWhitespaces) {
                         const auto s  = ImGui::GetFontSize();
                         const auto x1 = textScreenPos.x + oldX + 1.0f;
                         const auto x2 = textScreenPos.x + bufferOffset.x - 1.0f;
@@ -1011,8 +1017,8 @@ void TextEditor::Render() {
                         drawList->AddLine(p2, p3, 0x90909090);
                         drawList->AddLine(p2, p4, 0x90909090);
                     }
-                } else if (glyph.mChar == ' ') {
-                    if (mShowWhitespaces) {
+                } else if (glyph.m_char == ' ') {
+                    if (m_showWhitespaces) {
                         const auto s = ImGui::GetFontSize();
                         const auto x = textScreenPos.x + bufferOffset.x + spaceSize * 0.5f;
                         const auto y = textScreenPos.y + bufferOffset.y + s * 0.5f;
@@ -1021,38 +1027,39 @@ void TextEditor::Render() {
                     bufferOffset.x += spaceSize;
                     i++;
                 } else {
-                    auto l = UTF8CharLength(glyph.mChar);
+                    auto l = UTF8CharLength(glyph.m_char);
                     while (l-- > 0)
-                        mLineBuffer.push_back(line[i++].mChar);
+                        m_lineBuffer.push_back(line[i++].m_char);
                 }
                 ++columnNo;
             }
 
-            if (!mLineBuffer.empty()) {
+            if (!m_lineBuffer.empty()) {
                 const ImVec2 newOffset(textScreenPos.x + bufferOffset.x, textScreenPos.y + bufferOffset.y);
-                drawList->AddText(newOffset, prevColor, mLineBuffer.c_str());
-                mLineBuffer.clear();
+                drawList->AddText(newOffset, prevColor, m_lineBuffer.c_str());
+                m_lineBuffer.clear();
             }
 
             ++lineNo;
         }
-        if (lineNo < mLines.size() && ImGui::GetScrollMaxX() > 0.0f)
-            longest       = std::max(mTextStart + TextDistanceToLineStart(Coordinates(lineNo, GetLineMaxColumn(lineNo))), longest);
+        if (lineNo < m_lines.size() && ImGui::GetScrollMaxX() > 0.0f)
+            longest       = std::max(m_textStart +
+                                             textDistanceToLineStart(Coordinates(lineNo, getLineMaxColumn(lineNo))), longest);
 
         // Draw a tooltip on known identifiers/preprocessor symbols
         if (ImGui::IsMousePosValid()) {
-            auto id = GetWordAt(ScreenPosToCoordinates(ImGui::GetMousePos()));
+            auto id = getWordAt(screenPosToCoordinates(ImGui::GetMousePos()));
             if (!id.empty()) {
-                auto it = mLanguageDefinition.mIdentifiers.find(id);
-                if (it != mLanguageDefinition.mIdentifiers.end() && !it->second.mDeclaration.empty()) {
+                auto it = mL_languageDefinition.m_identifiers.find(id);
+                if (it != mL_languageDefinition.m_identifiers.end() && !it->second.m_declaration.empty()) {
                     ImGui::BeginTooltip();
-                    ImGui::TextUnformatted(it->second.mDeclaration.c_str());
+                    ImGui::TextUnformatted(it->second.m_declaration.c_str());
                     ImGui::EndTooltip();
                 } else {
-                    auto pi = mLanguageDefinition.mPreprocIdentifiers.find(id);
-                    if (pi != mLanguageDefinition.mPreprocIdentifiers.end() && !pi->second.mDeclaration.empty()) {
+                    auto pi = mL_languageDefinition.m_preprocIdentifiers.find(id);
+                    if (pi != mL_languageDefinition.m_preprocIdentifiers.end() && !pi->second.m_declaration.empty()) {
                         ImGui::BeginTooltip();
-                        ImGui::TextUnformatted(pi->second.mDeclaration.c_str());
+                        ImGui::TextUnformatted(pi->second.m_declaration.c_str());
                         ImGui::EndTooltip();
                     }
                 }
@@ -1060,38 +1067,39 @@ void TextEditor::Render() {
         }
     }
 
-    ImGui::Dummy(ImVec2((longest + 2), mLines.size() * mCharAdvance.y));
+    ImGui::Dummy(ImVec2((longest + 2), m_lines.size() * m_charAdvance.y));
 
-    if (mScrollToCursor) {
-        EnsureCursorVisible();
-        mScrollToCursor = false;
+    if (m_scrollToCursor) {
+        ensureCursorVisible();
+        m_scrollToCursor = false;
     }
 
     ImGuiPopupFlags_ popup_flags = ImGuiPopupFlags_None;
     ImGuiContext& g = *GImGui;
-    auto oldTopMargin = mTopMargin;
+    auto oldTopMargin = m_topMargin;
     auto popupStack = g.OpenPopupStack;
     if (popupStack.Size > 0) {
-        for (int n = 0; n < popupStack.Size; n++){
+        for (int32_t n = 0; n < popupStack.Size; n++){
             auto window = popupStack[n].Window;
             if (window != nullptr) {
-                if (window->Size.x == mFindReplaceHandler.GetFindWindowSize().x &&
-                    window->Size.y == mFindReplaceHandler.GetFindWindowSize().y &&
-                    window->Pos.x == mFindReplaceHandler.GetFindWindowPos().x &&
-                    window->Pos.y == mFindReplaceHandler.GetFindWindowPos().y) {
-                    mTopMargin = mFindReplaceHandler.GetFindWindowSize().y;
+                if (window->Size.x == m_findReplaceHandler.getFindWindowSize().x &&
+                    window->Size.y == m_findReplaceHandler.getFindWindowSize().y &&
+                    window->Pos.x == m_findReplaceHandler.getFindWindowPos().x &&
+                    window->Pos.y == m_findReplaceHandler.getFindWindowPos().y) {
+                    m_topMargin = m_findReplaceHandler.getFindWindowSize().y;
                 }
             }
         }
     } else {
-        mTopMargin = 0;
+        m_topMargin = 0;
     }
 
-    static float linesAdded = 0;
-    static float pixelsAdded = 0;
-    static float savedScrollY = 0;
-    static float shiftedScrollY = 0;
-    if (mTopMargin != oldTopMargin) {
+
+    if (m_topMargin != oldTopMargin) {
+        static float linesAdded = 0;
+        static float pixelsAdded = 0;
+        static float savedScrollY = 0;
+        static float shiftedScrollY = 0;
         if (oldTopMargin == 0)
             savedScrollY = ImGui::GetScrollY();
         auto window = ImGui::GetCurrentWindow();
@@ -1099,34 +1107,34 @@ void TextEditor::Render() {
         if (maxScroll > 0) {
             float lineCount;
             float pixelCount;
-            if (mTopMargin > oldTopMargin) {
-                pixelCount = mTopMargin - oldTopMargin;
-                lineCount = pixelCount / mCharAdvance.y;
-            } else if (mTopMargin > 0) {
-                pixelCount = oldTopMargin - mTopMargin;
-                lineCount = pixelCount / mCharAdvance.y;
+            if (m_topMargin > oldTopMargin) {
+                pixelCount = m_topMargin - oldTopMargin;
+                lineCount = pixelCount / m_charAdvance.y;
+            } else if (m_topMargin > 0) {
+                pixelCount = oldTopMargin - m_topMargin;
+                lineCount = pixelCount / m_charAdvance.y;
             } else {
                 pixelCount = oldTopMargin;
                 lineCount = std::round(linesAdded);
             }
-            auto state = mState;
+            auto state = m_state;
             auto oldScrollY = ImGui::GetScrollY();
-            int lineCountInt;
+            int32_t lineCountInt;
 
-            if (mTopMargin > oldTopMargin) {
+            if (m_topMargin > oldTopMargin) {
                 lineCountInt = std::round(lineCount + linesAdded - std::floor(linesAdded));
             } else
                 lineCountInt = std::round(lineCount);
-            for (int i = 0; i < lineCountInt; i++) {
-                if (mTopMargin > oldTopMargin)
-                    mLines.insert(mLines.begin() + mLines.size(), Line());
+            for (int32_t i = 0; i < lineCountInt; i++) {
+                if (m_topMargin > oldTopMargin)
+                    m_lines.insert(m_lines.begin() + m_lines.size(), Line());
                 else
-                    mLines.erase(mLines.begin() + mLines.size() - 1);
+                    m_lines.erase(m_lines.begin() + m_lines.size() - 1);
             }
-            if (mTopMargin > oldTopMargin) {
+            if (m_topMargin > oldTopMargin) {
                 linesAdded += lineCount;
                 pixelsAdded += pixelCount;
-            } else if (mTopMargin > 0) {
+            } else if (m_topMargin > 0) {
                 linesAdded -= lineCount;
                 pixelsAdded -= pixelCount;
             } else {
@@ -1134,9 +1142,9 @@ void TextEditor::Render() {
                 pixelsAdded = 0;
             }
             if (oldScrollY + pixelCount < maxScroll) {
-                if (mTopMargin > oldTopMargin)
+                if (m_topMargin > oldTopMargin)
                     shiftedScrollY = oldScrollY + pixelCount;
-                else if (mTopMargin > 0)
+                else if (m_topMargin > 0)
                     shiftedScrollY = oldScrollY - pixelCount;
                 else if (ImGui::GetScrollY() == shiftedScrollY)
                     shiftedScrollY = savedScrollY;
@@ -1144,417 +1152,417 @@ void TextEditor::Render() {
                     shiftedScrollY = ImGui::GetScrollY() - pixelCount;
                 ImGui::SetScrollY(shiftedScrollY);
             } else {
-                if (mTopMargin > oldTopMargin)
-                    mScrollToBottom = true;
+                if (m_topMargin > oldTopMargin)
+                    m_scrollToBottom = true;
             }
-            mState = state;
+            m_state = state;
         }
     }
 }
 
-void TextEditor::Render(const char *aTitle, const ImVec2 &aSize, bool aBorder) {
-    mWithinRender          = true;
-    mTextChanged           = false;
-    mCursorPositionChanged = false;
+void TextEditor::render(const char *aTitle, const ImVec2 &aSize, bool aBorder) {
+    m_withinRender          = true;
+    m_textChanged           = false;
+    m_cursorPositionChanged = false;
 
-    ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::ColorConvertU32ToFloat4(mPalette[(int)PaletteIndex::Background]));
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::ColorConvertU32ToFloat4(m_palette[(int32_t)PaletteIndex::Background]));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
-    if (!mIgnoreImGuiChild)
+    if (!m_ignoreImGuiChild)
         ImGui::BeginChild(aTitle, aSize, aBorder, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoMove);
 
-    if (mHandleKeyboardInputs) {
-        HandleKeyboardInputs();
+    if (m_handleKeyboardInputs) {
+        handleKeyboardInputs();
         ImGui::PushItemFlag(ImGuiItemFlags_NoTabStop, false);
     }
 
-    if (mHandleMouseInputs)
-        HandleMouseInputs();
+    if (m_handleMouseInputs)
+        handleMouseInputs();
 
-    ColorizeInternal();
+    colorizeInternal();
     Render();
 
-    if (mHandleKeyboardInputs)
+    if (m_handleKeyboardInputs)
         ImGui::PopItemFlag();
 
-    if (!mIgnoreImGuiChild)
+    if (!m_ignoreImGuiChild)
         ImGui::EndChild();
 
     ImGui::PopStyleVar();
     ImGui::PopStyleColor();
 
-    mWithinRender = false;
+    m_withinRender = false;
 }
 
-void TextEditor::SetText(const std::string &aText) {
-    mLines.clear();
-    mLines.emplace_back(Line());
+void TextEditor::setText(const std::string &aText) {
+    m_lines.clear();
+    m_lines.emplace_back(Line());
     for (auto chr : aText) {
         if (chr == '\r') {
             // ignore the carriage return character
         } else if (chr == '\n')
-            mLines.emplace_back(Line());
+            m_lines.emplace_back(Line());
         else {
-            mLines.back().emplace_back(Glyph(chr, PaletteIndex::Default));
+            m_lines.back().emplace_back(Glyph(chr, PaletteIndex::Default));
         }
     }
 
-    mTextChanged = true;
-    mScrollToTop = true;
+    m_textChanged = true;
+    m_scrollToTop = true;
 
-    mUndoBuffer.clear();
-    mUndoIndex = 0;
+    m_undoBuffer.clear();
+    m_undoIndex = 0;
 
-    Colorize();
+    colorize();
 }
 
-void TextEditor::SetTextLines(const std::vector<std::string> &aLines) {
-    mLines.clear();
+void TextEditor::setTextLines(const std::vector<std::string> &aLines) {
+    m_lines.clear();
 
     if (aLines.empty()) {
-        mLines.emplace_back(Line());
+        m_lines.emplace_back(Line());
     } else {
-        mLines.resize(aLines.size());
+        m_lines.resize(aLines.size());
 
         for (size_t i = 0; i < aLines.size(); ++i) {
             const std::string &aLine = aLines[i];
 
-            mLines[i].reserve(aLine.size());
+            m_lines[i].reserve(aLine.size());
             for (size_t j = 0; j < aLine.size(); ++j)
-                mLines[i].emplace_back(Glyph(aLine[j], PaletteIndex::Default));
+                m_lines[i].emplace_back(Glyph(aLine[j], PaletteIndex::Default));
         }
     }
 
-    mTextChanged = true;
-    mScrollToTop = true;
+    m_textChanged = true;
+    m_scrollToTop = true;
 
-    mUndoBuffer.clear();
-    mUndoIndex = 0;
+    m_undoBuffer.clear();
+    m_undoIndex = 0;
 
-    Colorize();
+    colorize();
 }
 
-void TextEditor::EnterCharacter(ImWchar aChar, bool aShift) {
-    assert(!mReadOnly);
+void TextEditor::enterCharacter(ImWchar aChar, bool aShift) {
+    assert(!m_readOnly);
 
     UndoRecord u;
 
-    u.mBefore = mState;
+    u.m_before = m_state;
 
-    ResetCursorBlinkTime();
+    resetCursorBlinkTime();
 
-    if (HasSelection()) {
-        if (aChar == '\t' && mState.mSelectionStart.mLine != mState.mSelectionEnd.mLine) {
+    if (hasSelection()) {
+        if (aChar == '\t' && m_state.m_selectionStart.m_line != m_state.m_selectionEnd.m_line) {
 
-            auto start       = mState.mSelectionStart;
-            auto end         = mState.mSelectionEnd;
+            auto start       = m_state.m_selectionStart;
+            auto end         = m_state.m_selectionEnd;
             auto originalEnd = end;
 
             if (start > end)
                 std::swap(start, end);
-            start.mColumn = 0;
+            start.m_column = 0;
 
-            if (end.mColumn == 0 && end.mLine > 0)
-                --end.mLine;
-            if (end.mLine >= (int)mLines.size())
-                end.mLine = mLines.empty() ? 0 : (int)mLines.size() - 1;
-            end.mColumn = GetLineMaxColumn(end.mLine);
+            if (end.m_column == 0 && end.m_line > 0)
+                --end.m_line;
+            if (end.m_line >= (int32_t)m_lines.size())
+                end.m_line = m_lines.empty() ? 0 : (int32_t)m_lines.size() - 1;
+            end.m_column = getLineMaxColumn(end.m_line);
 
-            u.mRemovedStart = start;
-            u.mRemovedEnd   = end;
-            u.mRemoved      = GetText(start, end);
+            u.m_removedStart = start;
+            u.m_removedEnd   = end;
+            u.m_removed      = getText(start, end);
 
             bool modified = false;
 
-            for (int i = start.mLine; i <= end.mLine; i++) {
-                auto &line = mLines[i];
+            for (int32_t i = start.m_line; i <= end.m_line; i++) {
+                auto &line = m_lines[i];
                 if (aShift) {
                     if (!line.empty()) {
-                        if (line.front().mChar == '\t') {
+                        if (line.front().m_char == '\t') {
                             line.erase(line.begin());
                             modified = true;
                         } else {
-                            for (int j = 0; j < mTabSize && !line.empty() && line.front().mChar == ' '; j++) {
+                            for (int32_t j = 0; j < m_tabSize && !line.empty() && line.front().m_char == ' '; j++) {
                                 line.erase(line.begin());
                                 modified = true;
                             }
                         }
                     }
                 } else {
-                    for (int j = start.mColumn % mTabSize; j < mTabSize; j++)
+                    for (int32_t j = start.m_column % m_tabSize; j < m_tabSize; j++)
                         line.insert(line.begin(), Glyph(' ', PaletteIndex::Background));
                     modified = true;
                 }
             }
 
             if (modified) {
-                start = Coordinates(start.mLine, GetCharacterColumn(start.mLine, 0));
+                start = Coordinates(start.m_line, getCharacterColumn(start.m_line, 0));
                 Coordinates rangeEnd;
-                if (originalEnd.mColumn != 0) {
-                    end      = Coordinates(end.mLine, GetLineMaxColumn(end.mLine));
+                if (originalEnd.m_column != 0) {
+                    end      = Coordinates(end.m_line, getLineMaxColumn(end.m_line));
                     rangeEnd = end;
-                    u.mAdded = GetText(start, end);
+                    u.m_added = getText(start, end);
                 } else {
-                    end      = Coordinates(originalEnd.mLine, 0);
-                    rangeEnd = Coordinates(end.mLine - 1, GetLineMaxColumn(end.mLine - 1));
-                    u.mAdded = GetText(start, rangeEnd);
+                    end      = Coordinates(originalEnd.m_line, 0);
+                    rangeEnd = Coordinates(end.m_line - 1, getLineMaxColumn(end.m_line - 1));
+                    u.m_added = getText(start, rangeEnd);
                 }
 
-                u.mAddedStart = start;
-                u.mAddedEnd   = rangeEnd;
-                u.mAfter      = mState;
+                u.m_addedStart = start;
+                u.m_addedEnd   = rangeEnd;
+                u.m_after      = m_state;
 
-                mState.mSelectionStart = start;
-                mState.mSelectionEnd   = end;
-                AddUndo(u);
+                m_state.m_selectionStart = start;
+                m_state.m_selectionEnd   = end;
+                addUndo(u);
 
-                mTextChanged = true;
+                m_textChanged = true;
 
-                EnsureCursorVisible();
+                ensureCursorVisible();
             }
 
             return;
         }    // c == '\t'
         else {
-            u.mRemoved      = GetSelectedText();
-            u.mRemovedStart = mState.mSelectionStart;
-            u.mRemovedEnd   = mState.mSelectionEnd;
-            DeleteSelection();
+            u.m_removed      = getSelectedText();
+            u.m_removedStart = m_state.m_selectionStart;
+            u.m_removedEnd   = m_state.m_selectionEnd;
+            deleteSelection();
         }
-    }    // HasSelection
+    }    // hasSelection
 
-    auto coord    = GetActualCursorCoordinates();
-    u.mAddedStart = coord;
+    auto coord    = getActualCursorCoordinates();
+    u.m_addedStart = coord;
 
-    assert(!mLines.empty());
+    assert(!m_lines.empty());
 
     if (aChar == '\n') {
-        InsertLine(coord.mLine + 1);
-        auto &line    = mLines[coord.mLine];
-        auto &newLine = mLines[coord.mLine + 1];
+        insertLine(coord.m_line + 1);
+        auto &line    = m_lines[coord.m_line];
+        auto &newLine = m_lines[coord.m_line + 1];
 
-        if (mLanguageDefinition.mAutoIndentation)
-            for (size_t it = 0; it < line.size() && isascii(line[it].mChar) && isblank(line[it].mChar); ++it)
+        if (mL_languageDefinition.m_autoIndentation)
+            for (size_t it = 0; it < line.size() && isascii(line[it].m_char) && isblank(line[it].m_char); ++it)
                 newLine.push_back(line[it]);
 
         const size_t whitespaceSize = newLine.size();
-        int cstart                  = 0;
-        int cpos                    = 0;
-        auto cindex                 = GetCharacterIndex(coord);
-        if (cindex < whitespaceSize && mLanguageDefinition.mAutoIndentation) {
-            cstart = (int) whitespaceSize;
-            cpos = cindex;
+        int32_t charStart                  = 0;
+        int32_t charPos                    = 0;
+        auto charIndex                 = getCharacterIndex(coord);
+        if (charIndex < whitespaceSize && mL_languageDefinition.m_autoIndentation) {
+            charStart = (int32_t) whitespaceSize;
+            charPos = charIndex;
         } else {
-            cstart = cindex;
-            cpos = (int) whitespaceSize;
+            charStart = charIndex;
+            charPos = (int32_t) whitespaceSize;
         }
-        newLine.insert(newLine.end(), line.begin() + cstart, line.end());
-        line.erase(line.begin() + cstart, line.begin() + line.size());
-        SetCursorPosition(Coordinates(coord.mLine + 1, GetCharacterColumn(coord.mLine + 1, cpos)));
-        u.mAdded = (char)aChar;
+        newLine.insert(newLine.end(), line.begin() + charStart, line.end());
+        line.erase(line.begin() + charStart, line.begin() + line.size());
+        setCursorPosition(Coordinates(coord.m_line + 1, getCharacterColumn(coord.m_line + 1, charPos)));
+        u.m_added = (char)aChar;
     } else if (aChar == '\t') {
-        auto &line  = mLines[coord.mLine];
-        auto cindex = GetCharacterIndex(coord);
+        auto &line  = m_lines[coord.m_line];
+        auto charIndex = getCharacterIndex(coord);
 
         if (!aShift) {
-            auto spacesToInsert = mTabSize - (cindex % mTabSize);
-            for (int j = 0; j < spacesToInsert; j++)
-                line.insert(line.begin() + cindex, Glyph(' ', PaletteIndex::Background));
-            SetCursorPosition(Coordinates(coord.mLine, GetCharacterColumn(coord.mLine, cindex + spacesToInsert)));
+            auto spacesToInsert = m_tabSize - (charIndex % m_tabSize);
+            for (int32_t j = 0; j < spacesToInsert; j++)
+                line.insert(line.begin() + charIndex, Glyph(' ', PaletteIndex::Background));
+            setCursorPosition(Coordinates(coord.m_line, getCharacterColumn(coord.m_line, charIndex + spacesToInsert)));
         } else {
-            auto spacesToRemove = (cindex % mTabSize);
+            auto spacesToRemove = (charIndex % m_tabSize);
             if (spacesToRemove == 0) spacesToRemove = 4;
 
-            for (int j = 0; j < spacesToRemove; j++) {
-                if ((line.begin() + cindex - 1)->mChar == ' ') {
-                    line.erase(line.begin() + cindex - 1);
-                    cindex -= 1;
+            for (int32_t j = 0; j < spacesToRemove; j++) {
+                if ((line.begin() + charIndex - 1)->m_char == ' ') {
+                    line.erase(line.begin() + charIndex - 1);
+                    charIndex -= 1;
                 }
             }
 
-            SetCursorPosition(Coordinates(coord.mLine, GetCharacterColumn(coord.mLine, std::max(0, cindex))));
+            setCursorPosition(Coordinates(coord.m_line, getCharacterColumn(coord.m_line, std::max(0, charIndex))));
         }
 
     } else {
-        char buf[7];
-        int e = ImTextCharToUtf8(buf, 7, aChar);
+        char buffer[7];
+        int32_t e = ImTextCharToUtf8(buffer, 7, aChar);
         if (e > 0) {
-            buf[e]      = '\0';
-            auto &line  = mLines[coord.mLine];
-            auto cindex = GetCharacterIndex(coord);
+            buffer[e]      = '\0';
+            auto &line  = m_lines[coord.m_line];
+            auto charIndex = getCharacterIndex(coord);
 
-            if (mOverwrite && cindex < (int)line.size()) {
-                auto d = UTF8CharLength(line[cindex].mChar);
+            if (m_overwrite && charIndex < (int32_t)line.size()) {
+                auto d = UTF8CharLength(line[charIndex].m_char);
 
-                u.mRemovedStart = mState.mCursorPosition;
-                u.mRemovedEnd   = Coordinates(coord.mLine, GetCharacterColumn(coord.mLine, cindex + d));
+                u.m_removedStart = m_state.m_cursorPosition;
+                u.m_removedEnd   = Coordinates(coord.m_line, getCharacterColumn(coord.m_line, charIndex + d));
 
-                while (d-- > 0 && cindex < (int)line.size()) {
-                    u.mRemoved += line[cindex].mChar;
-                    line.erase(line.begin() + cindex);
+                while (d-- > 0 && charIndex < (int32_t)line.size()) {
+                    u.m_removed += line[charIndex].m_char;
+                    line.erase(line.begin() + charIndex);
                 }
             }
 
-            for (auto p = buf; *p != '\0'; p++, ++cindex)
-                line.insert(line.begin() + cindex, Glyph(*p, PaletteIndex::Default));
-            u.mAdded = buf;
+            for (auto p = buffer; *p != '\0'; p++, ++charIndex)
+                line.insert(line.begin() + charIndex, Glyph(*p, PaletteIndex::Default));
+            u.m_added = buffer;
 
-            SetCursorPosition(Coordinates(coord.mLine, GetCharacterColumn(coord.mLine, cindex)));
+            setCursorPosition(Coordinates(coord.m_line, getCharacterColumn(coord.m_line, charIndex)));
         } else
             return;
     }
 
-    mTextChanged = true;
+    m_textChanged = true;
 
-    u.mAddedEnd = GetActualCursorCoordinates();
-    u.mAfter    = mState;
+    u.m_addedEnd = getActualCursorCoordinates();
+    u.m_after    = m_state;
 
-    AddUndo(u);
+    addUndo(u);
 
-    Colorize(coord.mLine - 1, 3);
-    EnsureCursorVisible();
+    colorize(coord.m_line - 1, 3);
+    ensureCursorVisible();
 }
 
-void TextEditor::SetReadOnly(bool aValue) {
-    mReadOnly = aValue;
+void TextEditor::setReadOnly(bool aValue) {
+    m_readOnly = aValue;
 }
 
-void TextEditor::SetColorizerEnable(bool aValue) {
-    mColorizerEnabled = aValue;
+void TextEditor::setColorizerEnable(bool aValue) {
+    m_colorizerEnabled = aValue;
 }
 
-void TextEditor::SetCursorPosition(const Coordinates &aPosition) {
-    if (mState.mCursorPosition != aPosition) {
-        mState.mCursorPosition = aPosition;
-        mCursorPositionChanged = true;
-        EnsureCursorVisible();
+void TextEditor::setCursorPosition(const Coordinates &aPosition) {
+    if (m_state.m_cursorPosition != aPosition) {
+        m_state.m_cursorPosition = aPosition;
+        m_cursorPositionChanged = true;
+        ensureCursorVisible();
     }
 }
 
-void TextEditor::SetSelectionStart(const Coordinates &aPosition) {
-    mState.mSelectionStart = SanitizeCoordinates(aPosition);
-    if (mState.mSelectionStart > mState.mSelectionEnd)
-        std::swap(mState.mSelectionStart, mState.mSelectionEnd);
+void TextEditor::setSelectionStart(const Coordinates &aPosition) {
+    m_state.m_selectionStart = sanitizeCoordinates(aPosition);
+    if (m_state.m_selectionStart > m_state.m_selectionEnd)
+        std::swap(m_state.m_selectionStart, m_state.m_selectionEnd);
 }
 
-void TextEditor::SetSelectionEnd(const Coordinates &aPosition) {
-    mState.mSelectionEnd = SanitizeCoordinates(aPosition);
-    if (mState.mSelectionStart > mState.mSelectionEnd)
-        std::swap(mState.mSelectionStart, mState.mSelectionEnd);
+void TextEditor::setSelectionEnd(const Coordinates &aPosition) {
+    m_state.m_selectionEnd = sanitizeCoordinates(aPosition);
+    if (m_state.m_selectionStart > m_state.m_selectionEnd)
+        std::swap(m_state.m_selectionStart, m_state.m_selectionEnd);
 }
 
-void TextEditor::SetSelection(const Coordinates &aStart, const Coordinates &aEnd, SelectionMode aMode) {
-    auto oldSelStart = mState.mSelectionStart;
-    auto oldSelEnd   = mState.mSelectionEnd;
+void TextEditor::setSelection(const Coordinates &aStart, const Coordinates &aEnd, SelectionMode aMode) {
+    auto oldSelStart = m_state.m_selectionStart;
+    auto oldSelEnd   = m_state.m_selectionEnd;
 
-    mState.mSelectionStart = SanitizeCoordinates(aStart);
-    mState.mSelectionEnd   = SanitizeCoordinates(aEnd);
-    if (mState.mSelectionStart > mState.mSelectionEnd)
-        std::swap(mState.mSelectionStart, mState.mSelectionEnd);
+    m_state.m_selectionStart = sanitizeCoordinates(aStart);
+    m_state.m_selectionEnd   = sanitizeCoordinates(aEnd);
+    if (m_state.m_selectionStart > m_state.m_selectionEnd)
+        std::swap(m_state.m_selectionStart, m_state.m_selectionEnd);
 
     switch (aMode) {
         case TextEditor::SelectionMode::Normal:
             break;
         case TextEditor::SelectionMode::Word:
             {
-                mState.mSelectionStart = FindWordStart(mState.mSelectionStart);
-                if (!IsOnWordBoundary(mState.mSelectionEnd))
-                    mState.mSelectionEnd = FindWordEnd(FindWordStart(mState.mSelectionEnd));
+                m_state.m_selectionStart = findWordStart(m_state.m_selectionStart);
+                if (!isOnWordBoundary(m_state.m_selectionEnd))
+                    m_state.m_selectionEnd = findWordEnd(findWordStart(m_state.m_selectionEnd));
                 break;
             }
         case TextEditor::SelectionMode::Line:
             {
-                const auto lineNo      = mState.mSelectionEnd.mLine;
-                const auto lineSize    = (size_t)lineNo < mLines.size() ? mLines[lineNo].size() : 0;
-                mState.mSelectionStart = Coordinates(mState.mSelectionStart.mLine, 0);
-                mState.mSelectionEnd   = Coordinates(lineNo, GetLineMaxColumn(lineNo));
+                const auto lineNo      = m_state.m_selectionEnd.m_line;
+                const auto lineSize    = (size_t)lineNo < m_lines.size() ? m_lines[lineNo].size() : 0;
+                m_state.m_selectionStart = Coordinates(m_state.m_selectionStart.m_line, 0);
+                m_state.m_selectionEnd   = Coordinates(lineNo, getLineMaxColumn(lineNo));
                 break;
             }
         default:
             break;
     }
 
-    if (mState.mSelectionStart != oldSelStart ||
-        mState.mSelectionEnd != oldSelEnd)
-        mCursorPositionChanged = true;
+    if (m_state.m_selectionStart != oldSelStart ||
+        m_state.m_selectionEnd != oldSelEnd)
+        m_cursorPositionChanged = true;
 }
 
-void TextEditor::SetTabSize(int aValue) {
-    mTabSize = std::max(0, std::min(32, aValue));
+void TextEditor::setTabSize(int32_t aValue) {
+    m_tabSize = std::max(0, std::min(32, aValue));
 }
 
-void TextEditor::InsertText(const std::string &aValue) {
-    InsertText(aValue.c_str());
+void TextEditor::insertText(const std::string &aValue) {
+    insertText(aValue.c_str());
 }
 
-void TextEditor::InsertText(const char *aValue) {
+void TextEditor::insertText(const char *aValue) {
     if (aValue == nullptr)
         return;
 
-    auto pos       = GetActualCursorCoordinates();
-    auto start     = std::min(pos, mState.mSelectionStart);
-    int totalLines = pos.mLine - start.mLine;
+    auto pos       = getActualCursorCoordinates();
+    auto start     = std::min(pos, m_state.m_selectionStart);
+    int32_t totalLines = pos.m_line - start.m_line;
 
-    totalLines += InsertTextAt(pos, aValue);
+    totalLines += insertTextAt(pos, aValue);
 
-    SetSelection(pos, pos);
-    SetCursorPosition(pos);
-    Colorize(start.mLine - 1, totalLines + 2);
+    setSelection(pos, pos);
+    setCursorPosition(pos);
+    colorize(start.m_line - 1, totalLines + 2);
 }
 
-void TextEditor::DeleteSelection() {
-    assert(mState.mSelectionEnd >= mState.mSelectionStart);
+void TextEditor::deleteSelection() {
+    assert(m_state.m_selectionEnd >= m_state.m_selectionStart);
 
-    if (mState.mSelectionEnd == mState.mSelectionStart)
+    if (m_state.m_selectionEnd == m_state.m_selectionStart)
         return;
 
-    DeleteRange(mState.mSelectionStart, mState.mSelectionEnd);
+    deleteRange(m_state.m_selectionStart, m_state.m_selectionEnd);
 
-    SetSelection(mState.mSelectionStart, mState.mSelectionStart);
-    SetCursorPosition(mState.mSelectionStart);
-    Colorize(mState.mSelectionStart.mLine, 1);
+    setSelection(m_state.m_selectionStart, m_state.m_selectionStart);
+    setCursorPosition(m_state.m_selectionStart);
+    colorize(m_state.m_selectionStart.m_line, 1);
 }
 
-void TextEditor::MoveUp(int aAmount, bool aSelect) {
-    auto oldPos                  = mState.mCursorPosition;
-    mState.mCursorPosition.mLine = std::max(0, mState.mCursorPosition.mLine - aAmount);
-    if (oldPos != mState.mCursorPosition) {
+void TextEditor::moveUp(int32_t aAmount, bool aSelect) {
+    auto oldPos                  = m_state.m_cursorPosition;
+    m_state.m_cursorPosition.m_line = std::max(0, m_state.m_cursorPosition.m_line - aAmount);
+    if (oldPos != m_state.m_cursorPosition) {
         if (aSelect) {
-            if (oldPos == mInteractiveStart)
-                mInteractiveStart = mState.mCursorPosition;
-            else if (oldPos == mInteractiveEnd)
-                mInteractiveEnd = mState.mCursorPosition;
+            if (oldPos == m_interactiveStart)
+                m_interactiveStart = m_state.m_cursorPosition;
+            else if (oldPos == m_interactiveEnd)
+                m_interactiveEnd = m_state.m_cursorPosition;
             else {
-                mInteractiveStart = mState.mCursorPosition;
-                mInteractiveEnd   = oldPos;
+                m_interactiveStart = m_state.m_cursorPosition;
+                m_interactiveEnd   = oldPos;
             }
         } else
-            mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-        SetSelection(mInteractiveStart, mInteractiveEnd);
+            m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+        setSelection(m_interactiveStart, m_interactiveEnd);
 
-        EnsureCursorVisible();
+        ensureCursorVisible();
     }
 }
 
-void TextEditor::MoveDown(int aAmount, bool aSelect) {
-    assert(mState.mCursorPosition.mColumn >= 0);
-    auto oldPos                  = mState.mCursorPosition;
-    mState.mCursorPosition.mLine = std::max(0, std::min((int)mLines.size() - 1, mState.mCursorPosition.mLine + aAmount));
+void TextEditor::moveDown(int32_t aAmount, bool aSelect) {
+    assert(m_state.m_cursorPosition.m_column >= 0);
+    auto oldPos                  = m_state.m_cursorPosition;
+    m_state.m_cursorPosition.m_line = std::max(0, std::min((int32_t)m_lines.size() - 1, m_state.m_cursorPosition.m_line + aAmount));
 
-    if (mState.mCursorPosition != oldPos) {
+    if (m_state.m_cursorPosition != oldPos) {
         if (aSelect) {
-            if (oldPos == mInteractiveEnd)
-                mInteractiveEnd = mState.mCursorPosition;
-            else if (oldPos == mInteractiveStart)
-                mInteractiveStart = mState.mCursorPosition;
+            if (oldPos == m_interactiveEnd)
+                m_interactiveEnd = m_state.m_cursorPosition;
+            else if (oldPos == m_interactiveStart)
+                m_interactiveStart = m_state.m_cursorPosition;
             else {
-                mInteractiveStart = oldPos;
-                mInteractiveEnd   = mState.mCursorPosition;
+                m_interactiveStart = oldPos;
+                m_interactiveEnd   = m_state.m_cursorPosition;
             }
         } else
-            mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-        SetSelection(mInteractiveStart, mInteractiveEnd);
+            m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+        setSelection(m_interactiveStart, m_interactiveEnd);
 
-        EnsureCursorVisible();
+        ensureCursorVisible();
     }
 }
 
@@ -1562,448 +1570,450 @@ static bool IsUTFSequence(char c) {
     return (c & 0xC0) == 0x80;
 }
 
-void TextEditor::MoveLeft(int aAmount, bool aSelect, bool aWordMode) {
-    if (mLines.empty())
+void TextEditor::moveLeft(int32_t aAmount, bool aSelect, bool aWordMode) {
+    if (m_lines.empty())
         return;
 
-    auto oldPos            = mState.mCursorPosition;
-    mState.mCursorPosition = GetActualCursorCoordinates();
-    auto line              = mState.mCursorPosition.mLine;
-    auto cindex            = GetCharacterIndex(mState.mCursorPosition);
+    auto oldPos            = m_state.m_cursorPosition;
+    m_state.m_cursorPosition = getActualCursorCoordinates();
+    auto line              = m_state.m_cursorPosition.m_line;
+    auto charIndex            = getCharacterIndex(m_state.m_cursorPosition);
 
     while (aAmount-- > 0) {
-        if (cindex == 0) {
+        if (charIndex == 0) {
             if (line > 0) {
                 --line;
-                if ((int)mLines.size() > line)
-                    cindex = (int)mLines[line].size();
+                if ((int32_t)m_lines.size() > line)
+                    charIndex = (int32_t)m_lines[line].size();
                 else
-                    cindex = 0;
+                    charIndex = 0;
             }
         } else {
-            --cindex;
-            if (cindex > 0) {
-                if ((int)mLines.size() > line) {
-                    while (cindex > 0 && IsUTFSequence(mLines[line][cindex].mChar))
-                        --cindex;
+            --charIndex;
+            if (charIndex > 0) {
+                if ((int32_t)m_lines.size() > line) {
+                    while (charIndex > 0 && IsUTFSequence(m_lines[line][charIndex].m_char))
+                        --charIndex;
                 }
             }
         }
 
-        mState.mCursorPosition = Coordinates(line, GetCharacterColumn(line, cindex));
+        m_state.m_cursorPosition = Coordinates(line, getCharacterColumn(line, charIndex));
         if (aWordMode) {
-            mState.mCursorPosition = FindWordStart(mState.mCursorPosition);
-            cindex                 = GetCharacterIndex(mState.mCursorPosition);
+            m_state.m_cursorPosition = findWordStart(m_state.m_cursorPosition);
+            charIndex                 = getCharacterIndex(m_state.m_cursorPosition);
         }
     }
 
-    mState.mCursorPosition = Coordinates(line, GetCharacterColumn(line, cindex));
+    m_state.m_cursorPosition = Coordinates(line, getCharacterColumn(line, charIndex));
 
-    assert(mState.mCursorPosition.mColumn >= 0);
+    assert(m_state.m_cursorPosition.m_column >= 0);
     if (aSelect) {
-        if (oldPos == mInteractiveStart)
-            mInteractiveStart = mState.mCursorPosition;
-        else if (oldPos == mInteractiveEnd)
-            mInteractiveEnd = mState.mCursorPosition;
+        if (oldPos == m_interactiveStart)
+            m_interactiveStart = m_state.m_cursorPosition;
+        else if (oldPos == m_interactiveEnd)
+            m_interactiveEnd = m_state.m_cursorPosition;
         else {
-            mInteractiveStart = mState.mCursorPosition;
-            mInteractiveEnd   = oldPos;
+            m_interactiveStart = m_state.m_cursorPosition;
+            m_interactiveEnd   = oldPos;
         }
     } else
-        mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-    SetSelection(mInteractiveStart, mInteractiveEnd, aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
+        m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+    setSelection(m_interactiveStart, m_interactiveEnd,
+                 aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
 
-    EnsureCursorVisible();
+    ensureCursorVisible();
 }
 
-void TextEditor::MoveRight(int aAmount, bool aSelect, bool aWordMode) {
-    auto oldPos = mState.mCursorPosition;
+void TextEditor::moveRight(int32_t aAmount, bool aSelect, bool aWordMode) {
+    auto oldPos = m_state.m_cursorPosition;
 
-    if (mLines.empty() || oldPos.mLine >= mLines.size())
+    if (m_lines.empty() || oldPos.m_line >= m_lines.size())
         return;
 
-    auto cindex = GetCharacterIndex(mState.mCursorPosition);
+    auto charIndex = getCharacterIndex(m_state.m_cursorPosition);
     while (aAmount-- > 0) {
-        auto lindex = mState.mCursorPosition.mLine;
-        auto &line  = mLines[lindex];
+        auto lindex = m_state.m_cursorPosition.m_line;
+        auto &line  = m_lines[lindex];
 
-        if (cindex >= line.size()) {
-            if (mState.mCursorPosition.mLine < mLines.size() - 1) {
-                mState.mCursorPosition.mLine   = std::max(0, std::min((int)mLines.size() - 1, mState.mCursorPosition.mLine + 1));
-                mState.mCursorPosition.mColumn = 0;
+        if (charIndex >= line.size()) {
+            if (m_state.m_cursorPosition.m_line < m_lines.size() - 1) {
+                m_state.m_cursorPosition.m_line   = std::max(0, std::min((int32_t)m_lines.size() - 1, m_state.m_cursorPosition.m_line + 1));
+                m_state.m_cursorPosition.m_column = 0;
             } else
                 return;
         } else {
-            cindex += UTF8CharLength(line[cindex].mChar);
-            mState.mCursorPosition = Coordinates(lindex, GetCharacterColumn(lindex, cindex));
+            charIndex += UTF8CharLength(line[charIndex].m_char);
+            m_state.m_cursorPosition = Coordinates(lindex, getCharacterColumn(lindex, charIndex));
             if (aWordMode)
-                mState.mCursorPosition = FindNextWord(mState.mCursorPosition);
+                m_state.m_cursorPosition = findNextWord(m_state.m_cursorPosition);
         }
     }
 
     if (aSelect) {
-        if (oldPos == mInteractiveEnd)
-            mInteractiveEnd = SanitizeCoordinates(mState.mCursorPosition);
-        else if (oldPos == mInteractiveStart)
-            mInteractiveStart = mState.mCursorPosition;
+        if (oldPos == m_interactiveEnd)
+            m_interactiveEnd = sanitizeCoordinates(m_state.m_cursorPosition);
+        else if (oldPos == m_interactiveStart)
+            m_interactiveStart = m_state.m_cursorPosition;
         else {
-            mInteractiveStart = oldPos;
-            mInteractiveEnd   = mState.mCursorPosition;
+            m_interactiveStart = oldPos;
+            m_interactiveEnd   = m_state.m_cursorPosition;
         }
     } else
-        mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-    SetSelection(mInteractiveStart, mInteractiveEnd, aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
+        m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+    setSelection(m_interactiveStart, m_interactiveEnd,
+                 aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
 
-    EnsureCursorVisible();
+    ensureCursorVisible();
 }
 
-void TextEditor::MoveTop(bool aSelect) {
-    auto oldPos = mState.mCursorPosition;
-    SetCursorPosition(Coordinates(0, 0));
+void TextEditor::moveTop(bool aSelect) {
+    auto oldPos = m_state.m_cursorPosition;
+    setCursorPosition(Coordinates(0, 0));
 
-    if (mState.mCursorPosition != oldPos) {
+    if (m_state.m_cursorPosition != oldPos) {
         if (aSelect) {
-            mInteractiveEnd   = oldPos;
-            mInteractiveStart = mState.mCursorPosition;
+            m_interactiveEnd   = oldPos;
+            m_interactiveStart = m_state.m_cursorPosition;
         } else
-            mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-        SetSelection(mInteractiveStart, mInteractiveEnd);
+            m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+        setSelection(m_interactiveStart, m_interactiveEnd);
     }
 }
 
-void TextEditor::TextEditor::MoveBottom(bool aSelect) {
-    auto oldPos = GetCursorPosition();
-    auto newPos = Coordinates((int)mLines.size() - 1, 0);
-    SetCursorPosition(newPos);
+void TextEditor::TextEditor::moveBottom(bool aSelect) {
+    auto oldPos = getCursorPosition();
+    auto newPos = Coordinates((int32_t)m_lines.size() - 1, 0);
+    setCursorPosition(newPos);
     if (aSelect) {
-        mInteractiveStart = oldPos;
-        mInteractiveEnd   = newPos;
+        m_interactiveStart = oldPos;
+        m_interactiveEnd   = newPos;
     } else
-        mInteractiveStart = mInteractiveEnd = newPos;
-    SetSelection(mInteractiveStart, mInteractiveEnd);
+        m_interactiveStart = m_interactiveEnd = newPos;
+    setSelection(m_interactiveStart, m_interactiveEnd);
 }
 
-void TextEditor::MoveHome(bool aSelect) {
-    auto oldPos = mState.mCursorPosition;
-    SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, 0));
+void TextEditor::moveHome(bool aSelect) {
+    auto oldPos = m_state.m_cursorPosition;
+    setCursorPosition(Coordinates(m_state.m_cursorPosition.m_line, 0));
 
-    if (mState.mCursorPosition != oldPos) {
+    if (m_state.m_cursorPosition != oldPos) {
         if (aSelect) {
-            if (oldPos == mInteractiveStart)
-                mInteractiveStart = mState.mCursorPosition;
-            else if (oldPos == mInteractiveEnd)
-                mInteractiveEnd = mState.mCursorPosition;
+            if (oldPos == m_interactiveStart)
+                m_interactiveStart = m_state.m_cursorPosition;
+            else if (oldPos == m_interactiveEnd)
+                m_interactiveEnd = m_state.m_cursorPosition;
             else {
-                mInteractiveStart = mState.mCursorPosition;
-                mInteractiveEnd   = oldPos;
+                m_interactiveStart = m_state.m_cursorPosition;
+                m_interactiveEnd   = oldPos;
             }
         } else
-            mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-        SetSelection(mInteractiveStart, mInteractiveEnd);
+            m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+        setSelection(m_interactiveStart, m_interactiveEnd);
     }
 }
 
-void TextEditor::MoveEnd(bool aSelect) {
-    auto oldPos = mState.mCursorPosition;
-    SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, GetLineMaxColumn(oldPos.mLine)));
+void TextEditor::moveEnd(bool aSelect) {
+    auto oldPos = m_state.m_cursorPosition;
+    setCursorPosition(Coordinates(m_state.m_cursorPosition.m_line, getLineMaxColumn(oldPos.m_line)));
 
-    if (mState.mCursorPosition != oldPos) {
+    if (m_state.m_cursorPosition != oldPos) {
         if (aSelect) {
-            if (oldPos == mInteractiveEnd)
-                mInteractiveEnd = mState.mCursorPosition;
-            else if (oldPos == mInteractiveStart)
-                mInteractiveStart = mState.mCursorPosition;
+            if (oldPos == m_interactiveEnd)
+                m_interactiveEnd = m_state.m_cursorPosition;
+            else if (oldPos == m_interactiveStart)
+                m_interactiveStart = m_state.m_cursorPosition;
             else {
-                mInteractiveStart = oldPos;
-                mInteractiveEnd   = mState.mCursorPosition;
+                m_interactiveStart = oldPos;
+                m_interactiveEnd   = m_state.m_cursorPosition;
             }
         } else
-            mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-        SetSelection(mInteractiveStart, mInteractiveEnd);
+            m_interactiveStart = m_interactiveEnd = m_state.m_cursorPosition;
+        setSelection(m_interactiveStart, m_interactiveEnd);
     }
 }
 
-void TextEditor::Delete() {
-    assert(!mReadOnly);
+void TextEditor::doDelete() {
+    assert(!m_readOnly);
 
-    if (mLines.empty())
+    if (m_lines.empty())
         return;
 
     UndoRecord u;
-    u.mBefore = mState;
+    u.m_before = m_state;
 
-    if (HasSelection()) {
-        u.mRemoved      = GetSelectedText();
-        u.mRemovedStart = mState.mSelectionStart;
-        u.mRemovedEnd   = mState.mSelectionEnd;
+    if (hasSelection()) {
+        u.m_removed      = getSelectedText();
+        u.m_removedStart = m_state.m_selectionStart;
+        u.m_removedEnd   = m_state.m_selectionEnd;
 
-        DeleteSelection();
+        deleteSelection();
     } else {
-        auto pos = GetActualCursorCoordinates();
-        SetCursorPosition(pos);
-        auto &line = mLines[pos.mLine];
+        auto pos = getActualCursorCoordinates();
+        setCursorPosition(pos);
+        auto &line = m_lines[pos.m_line];
 
-        if (pos.mColumn == GetLineMaxColumn(pos.mLine)) {
-            if (pos.mLine == (int)mLines.size() - 1)
+        if (pos.m_column == getLineMaxColumn(pos.m_line)) {
+            if (pos.m_line == (int32_t)m_lines.size() - 1)
                 return;
 
-            u.mRemoved      = '\n';
-            u.mRemovedStart = u.mRemovedEnd = GetActualCursorCoordinates();
-            Advance(u.mRemovedEnd);
+            u.m_removed      = '\n';
+            u.m_removedStart = u.m_removedEnd = getActualCursorCoordinates();
+            advance(u.m_removedEnd);
 
-            auto &nextLine = mLines[pos.mLine + 1];
+            auto &nextLine = m_lines[pos.m_line + 1];
             line.insert(line.end(), nextLine.begin(), nextLine.end());
-            RemoveLine(pos.mLine + 1);
+            removeLine(pos.m_line + 1);
         } else {
-            auto cindex     = GetCharacterIndex(pos);
-            u.mRemovedStart = u.mRemovedEnd = GetActualCursorCoordinates();
-            u.mRemovedEnd.mColumn++;
-            u.mRemoved = GetText(u.mRemovedStart, u.mRemovedEnd);
+            auto charIndex     = getCharacterIndex(pos);
+            u.m_removedStart = u.m_removedEnd = getActualCursorCoordinates();
+            u.m_removedEnd.m_column++;
+            u.m_removed = getText(u.m_removedStart, u.m_removedEnd);
 
-            auto d = UTF8CharLength(line[cindex].mChar);
-            while (d-- > 0 && cindex < (int)line.size())
-                line.erase(line.begin() + cindex);
+            auto d = UTF8CharLength(line[charIndex].m_char);
+            while (d-- > 0 && charIndex < (int32_t)line.size())
+                line.erase(line.begin() + charIndex);
         }
 
-        mTextChanged = true;
+        m_textChanged = true;
 
-        Colorize(pos.mLine, 1);
+        colorize(pos.m_line, 1);
     }
 
-    u.mAfter = mState;
-    AddUndo(u);
+    u.m_after = m_state;
+    addUndo(u);
 }
 
-void TextEditor::Backspace() {
-    assert(!mReadOnly);
+void TextEditor::backspace() {
+    assert(!m_readOnly);
 
-    if (mLines.empty())
+    if (m_lines.empty())
         return;
 
     UndoRecord u;
-    u.mBefore = mState;
+    u.m_before = m_state;
 
-    if (HasSelection()) {
-        u.mRemoved      = GetSelectedText();
-        u.mRemovedStart = mState.mSelectionStart;
-        u.mRemovedEnd   = mState.mSelectionEnd;
+    if (hasSelection()) {
+        u.m_removed      = getSelectedText();
+        u.m_removedStart = m_state.m_selectionStart;
+        u.m_removedEnd   = m_state.m_selectionEnd;
 
-        DeleteSelection();
+        deleteSelection();
     } else {
-        auto pos = GetActualCursorCoordinates();
-        SetCursorPosition(pos);
+        auto pos = getActualCursorCoordinates();
+        setCursorPosition(pos);
 
-        if (mState.mCursorPosition.mColumn == 0) {
-            if (mState.mCursorPosition.mLine == 0)
+        if (m_state.m_cursorPosition.m_column == 0) {
+            if (m_state.m_cursorPosition.m_line == 0)
                 return;
 
-            u.mRemoved      = '\n';
-            u.mRemovedStart = u.mRemovedEnd = Coordinates(pos.mLine - 1, GetLineMaxColumn(pos.mLine - 1));
-            Advance(u.mRemovedEnd);
+            u.m_removed      = '\n';
+            u.m_removedStart = u.m_removedEnd = Coordinates(pos.m_line - 1, getLineMaxColumn(pos.m_line - 1));
+            advance(u.m_removedEnd);
 
-            auto &line     = mLines[mState.mCursorPosition.mLine];
-            auto &prevLine = mLines[mState.mCursorPosition.mLine - 1];
-            auto prevSize  = GetLineMaxColumn(mState.mCursorPosition.mLine - 1);
+            auto &line     = m_lines[m_state.m_cursorPosition.m_line];
+            auto &prevLine = m_lines[m_state.m_cursorPosition.m_line - 1];
+            auto prevSize  = getLineMaxColumn(m_state.m_cursorPosition.m_line - 1);
             prevLine.insert(prevLine.end(), line.begin(), line.end());
 
-            ErrorMarkers etmp;
-            for (auto &i : mErrorMarkers)
-                etmp.insert(ErrorMarkers::value_type(i.first - 1 == mState.mCursorPosition.mLine ? i.first - 1 : i.first, i.second));
-            mErrorMarkers = std::move(etmp);
+            ErrorMarkers errorMarkers;
+            for (auto &i : m_errorMarkers)
+                errorMarkers.insert(ErrorMarkers::value_type(i.first - 1 == m_state.m_cursorPosition.m_line ? i.first - 1 : i.first, i.second));
+            m_errorMarkers = std::move(errorMarkers);
 
-            RemoveLine(mState.mCursorPosition.mLine);
-            --mState.mCursorPosition.mLine;
-            mState.mCursorPosition.mColumn = prevSize;
+            removeLine(m_state.m_cursorPosition.m_line);
+            --m_state.m_cursorPosition.m_line;
+            m_state.m_cursorPosition.m_column = prevSize;
         } else {
-            auto &line  = mLines[mState.mCursorPosition.mLine];
-            auto cindex = GetCharacterIndex(pos) - 1;
-            auto cend   = cindex + 1;
-            while (cindex > 0 && IsUTFSequence(line[cindex].mChar))
-                --cindex;
+            auto &line  = m_lines[m_state.m_cursorPosition.m_line];
+            auto charIndex = getCharacterIndex(pos) - 1;
+            auto charEnd   = charIndex + 1;
+            while (charIndex > 0 && IsUTFSequence(line[charIndex].m_char))
+                --charIndex;
 
-            u.mRemovedStart = u.mRemovedEnd = GetActualCursorCoordinates();
-            --u.mRemovedStart.mColumn;
-            mState.mCursorPosition.mColumn = GetCharacterColumn(mState.mCursorPosition.mLine, cindex);
+            u.m_removedStart = u.m_removedEnd = getActualCursorCoordinates();
+            --u.m_removedStart.m_column;
+            m_state.m_cursorPosition.m_column = getCharacterColumn(m_state.m_cursorPosition.m_line, charIndex);
 
-            while (cindex < line.size() && cend-- > cindex) {
-                u.mRemoved += line[cindex].mChar;
-                line.erase(line.begin() + cindex);
+            while (charIndex < line.size() && charEnd-- > charIndex) {
+                u.m_removed += line[charIndex].m_char;
+                line.erase(line.begin() + charIndex);
             }
         }
 
-        mTextChanged = true;
+        m_textChanged = true;
 
-        EnsureCursorVisible();
-        Colorize(mState.mCursorPosition.mLine, 1);
+        ensureCursorVisible();
+        colorize(m_state.m_cursorPosition.m_line, 1);
     }
 
-    u.mAfter = mState;
-    AddUndo(u);
+    u.m_after = m_state;
+    addUndo(u);
 }
 
-void TextEditor::SelectWordUnderCursor() {
-    auto c = GetCursorPosition();
-    SetSelection(FindWordStart(c), FindWordEnd(c));
+void TextEditor::selectWordUnderCursor() {
+    auto c = getCursorPosition();
+    setSelection(findWordStart(c), findWordEnd(c));
 }
 
-void TextEditor::SelectAll() {
-    SetSelection(Coordinates(0, 0), Coordinates((int)mLines.size(), 0));
+void TextEditor::selectAll() {
+    setSelection(Coordinates(0, 0), Coordinates((int32_t) m_lines.size(), 0));
 }
 
-bool TextEditor::HasSelection() const {
-    return mState.mSelectionEnd > mState.mSelectionStart;
+bool TextEditor::hasSelection() const {
+    return m_state.m_selectionEnd > m_state.m_selectionStart;
 }
 
-void TextEditor::Copy() {
-    if (HasSelection()) {
-        ImGui::SetClipboardText(GetSelectedText().c_str());
+void TextEditor::copy() {
+    if (hasSelection()) {
+        ImGui::SetClipboardText(getSelectedText().c_str());
     } else {
-        if (!mLines.empty()) {
+        if (!m_lines.empty()) {
             std::string str;
-            auto &line = mLines[GetActualCursorCoordinates().mLine];
+            auto &line = m_lines[getActualCursorCoordinates().m_line];
             for (auto &g : line)
-                str.push_back(g.mChar);
+                str.push_back(g.m_char);
             ImGui::SetClipboardText(str.c_str());
         }
     }
 }
 
-void TextEditor::Cut() {
-    if (IsReadOnly()) {
-        Copy();
+void TextEditor::cut() {
+    if (isReadOnly()) {
+        copy();
     } else {
-        if (HasSelection()) {
+        if (hasSelection()) {
             UndoRecord u;
-            u.mBefore       = mState;
-            u.mRemoved      = GetSelectedText();
-            u.mRemovedStart = mState.mSelectionStart;
-            u.mRemovedEnd   = mState.mSelectionEnd;
+            u.m_before       = m_state;
+            u.m_removed      = getSelectedText();
+            u.m_removedStart = m_state.m_selectionStart;
+            u.m_removedEnd   = m_state.m_selectionEnd;
 
-            Copy();
-            DeleteSelection();
+            copy();
+            deleteSelection();
 
-            u.mAfter = mState;
-            AddUndo(u);
+            u.m_after = m_state;
+            addUndo(u);
         }
     }
 }
 
-void TextEditor::Paste() {
-    if (IsReadOnly())
+void TextEditor::paste() {
+    if (isReadOnly())
         return;
 
     auto clipText = ImGui::GetClipboardText();
     if (clipText != nullptr && strlen(clipText) > 0) {
         UndoRecord u;
-        u.mBefore = mState;
+        u.m_before = m_state;
 
-        if (HasSelection()) {
-            u.mRemoved      = GetSelectedText();
-            u.mRemovedStart = mState.mSelectionStart;
-            u.mRemovedEnd   = mState.mSelectionEnd;
-            DeleteSelection();
+        if (hasSelection()) {
+            u.m_removed      = getSelectedText();
+            u.m_removedStart = m_state.m_selectionStart;
+            u.m_removedEnd   = m_state.m_selectionEnd;
+            deleteSelection();
         }
 
-        u.mAdded      = clipText;
-        u.mAddedStart = GetActualCursorCoordinates();
+        u.m_added      = clipText;
+        u.m_addedStart = getActualCursorCoordinates();
 
-        InsertText(clipText);
+        insertText(clipText);
 
-        u.mAddedEnd = GetActualCursorCoordinates();
-        u.mAfter    = mState;
-        AddUndo(u);
+        u.m_addedEnd = getActualCursorCoordinates();
+        u.m_after    = m_state;
+        addUndo(u);
     }
 }
 
-bool TextEditor::CanUndo() const {
-    return !mReadOnly && mUndoIndex > 0;
+bool TextEditor::canUndo() const {
+    return !m_readOnly && m_undoIndex > 0;
 }
 
-bool TextEditor::CanRedo() const {
-    return !mReadOnly && mUndoIndex < (int)mUndoBuffer.size();
+bool TextEditor::canRedo() const {
+    return !m_readOnly && m_undoIndex < (int32_t)m_undoBuffer.size();
 }
 
-void TextEditor::Undo(int aSteps) {
-    while (CanUndo() && aSteps-- > 0)
-        mUndoBuffer[--mUndoIndex].Undo(this);
+void TextEditor::undo(int32_t aSteps) {
+    while (canUndo() && aSteps-- > 0)
+        m_undoBuffer[--m_undoIndex].undo(this);
 }
 
-void TextEditor::Redo(int aSteps) {
-    while (CanRedo() && aSteps-- > 0)
-        mUndoBuffer[mUndoIndex++].Redo(this);
+void TextEditor::redo(int32_t aSteps) {
+    while (canRedo() && aSteps-- > 0)
+        m_undoBuffer[m_undoIndex++].redo(this);
 }
 
 // the index here is array index so zero based
-void TextEditor::FindReplaceHandler::SelectFound(TextEditor *editor, int index) {
-    assert(index >= 0 && index < mMatches.size());
-    auto selectionStart = mMatches[index].mSelectionStart;
-    auto selectionEnd = mMatches[index].mSelectionEnd;
-    editor->SetSelection(selectionStart, selectionEnd);
-    editor->SetCursorPosition(selectionEnd);
-    editor->mScrollToCursor = true;
+void TextEditor::FindReplaceHandler::selectFound(TextEditor *editor, int32_t found) {
+    assert(found >= 0 && found < m_matches.size());
+    auto selectionStart = m_matches[found].m_selectionStart;
+    auto selectionEnd = m_matches[found].m_selectionEnd;
+    editor->setSelection(selectionStart, selectionEnd);
+    editor->setCursorPosition(selectionEnd);
+    editor->m_scrollToCursor = true;
 }
 
 // The returned index is shown in the form
 //  'index of count' so 1 based
-unsigned TextEditor::FindReplaceHandler::FindMatch(TextEditor *editor, bool isNext) {
+uint32_t TextEditor::FindReplaceHandler::findMatch(TextEditor *editor, bool isNex) {
 
-    if ( editor->mTextChanged || mOptionsChanged) {
-        std::string findWord = GetFindWord();
+    if (editor->m_textChanged || m_optionsChanged) {
+        std::string findWord = getFindWord();
         if (findWord.empty())
             return 0;
         resetMatches();
-        FindAllMatches(editor, findWord);
+        findAllMatches(editor, findWord);
     }
 
-    auto targetPos = editor->mState.mCursorPosition;
-    auto count = mMatches.size();
+    auto targetPos = editor->m_state.m_cursorPosition;
+    auto count = m_matches.size();
 
     if (count == 0) {
-        editor->SetCursorPosition(targetPos);
+        editor->setCursorPosition(targetPos);
         return 0;
     }
 
-    for (unsigned i=0; i < count; i++) {
-        if (targetPos >= mMatches[i].mSelectionStart && targetPos <= mMatches[i].mSelectionEnd) {
-            if (isNext) {
+    for (uint32_t i=0; i < count; i++) {
+        if (targetPos >= m_matches[i].m_selectionStart && targetPos <= m_matches[i].m_selectionEnd) {
+            if (isNex) {
                 if (i == count - 1) {
-                    SelectFound(editor, 0);
+                    selectFound(editor, 0);
                     return 1;
                 } else {
-                    SelectFound(editor, i + 1);
+                    selectFound(editor, i + 1);
                     return (i + 2);
                 }
             } else {
                 if (i == 0) {
-                    SelectFound(editor, count - 1);
+                    selectFound(editor, count - 1);
                     return count;
                 } else {
-                    SelectFound(editor, i - 1);
+                    selectFound(editor, i - 1);
                     return i;
                 }
             }
         }
     }
 
-    if ((targetPos > mMatches[count - 1].mSelectionEnd) || (targetPos < mMatches[0].mSelectionStart)) {
-        if (isNext) {
-            SelectFound(editor,0);
+    if ((targetPos > m_matches[count - 1].m_selectionEnd) || (targetPos < m_matches[0].m_selectionStart)) {
+        if (isNex) {
+            selectFound(editor, 0);
             return 1;
         } else {
-            SelectFound(editor,count - 1);
+            selectFound(editor, count - 1);
             return count;
         }
     }
 
-    for (unsigned i=1;i < count;i++) {
+    for (uint32_t i=1;i < count;i++) {
 
-        if (mMatches[i - 1].mSelectionEnd <= targetPos &&
-            mMatches[i].mSelectionStart >= targetPos ) {
-            if (isNext) {
-                SelectFound(editor,i);
+        if (m_matches[i - 1].m_selectionEnd <= targetPos &&
+            m_matches[i].m_selectionStart >= targetPos ) {
+            if (isNex) {
+                selectFound(editor, i);
                 return i + 1;
             } else {
-                SelectFound(editor,i - 1);
+                selectFound(editor, i - 1);
                 return i;
             }
         }
@@ -2013,30 +2023,30 @@ unsigned TextEditor::FindReplaceHandler::FindMatch(TextEditor *editor, bool isNe
 }
 
 // returns 1 based index
-unsigned TextEditor::FindReplaceHandler::FindPosition( TextEditor *editor, TextEditor::Coordinates targetPos, bool isNext) {
-    if ( editor->mTextChanged || mOptionsChanged) {
-        std::string findWord = GetFindWord();
+uint32_t TextEditor::FindReplaceHandler::findPosition(TextEditor *editor, Coordinates pos, bool isNext) {
+    if (editor->m_textChanged || m_optionsChanged) {
+        std::string findWord = getFindWord();
         if (findWord.empty())
             return 0;
         resetMatches();
-        FindAllMatches(editor,findWord);
+        findAllMatches(editor, findWord);
     }
 
-    int count = mMatches.size();
+    int32_t count = m_matches.size();
     if (count == 0)
         return 0;
     if( isNext) {
-        if (targetPos > mMatches[count - 1].mSelectionEnd || targetPos <= mMatches[0].mSelectionEnd)
+        if (pos > m_matches[count - 1].m_selectionEnd || pos <= m_matches[0].m_selectionEnd)
             return 1;
-        for (unsigned i = 1; i < count; i++) {
-            if (targetPos > mMatches[i-1].mSelectionEnd && targetPos <= mMatches[i].mSelectionEnd)
+        for (uint32_t i = 1; i < count; i++) {
+            if (pos > m_matches[i - 1].m_selectionEnd && pos <= m_matches[i].m_selectionEnd)
                 return i+1;
         }
     } else {
-        if (targetPos >= mMatches[count - 1].mSelectionStart || targetPos < mMatches[0].mSelectionStart)
+        if (pos >= m_matches[count - 1].m_selectionStart || pos < m_matches[0].m_selectionStart)
             return count;
-        for (unsigned i = 1; i < count; i++) {
-            if (targetPos >= mMatches[i-1].mSelectionStart && targetPos < mMatches[i].mSelectionStart)
+        for (uint32_t i = 1; i < count; i++) {
+            if (pos >= m_matches[i - 1].m_selectionStart && pos < m_matches[i].m_selectionStart)
                 return i ;
         }
     }
@@ -2063,33 +2073,33 @@ std::string make_wholeWord(const std::string &s) {
     return out;
 }
 
-// Performs actual search to fill mMatches
-bool TextEditor::FindReplaceHandler::FindNext(TextEditor *editor, bool wrapAround) {
-    auto curPos = editor->mState.mCursorPosition;
-    unsigned long selectionLength = editor->GetStringCharacterCount(mFindWord);
+// Performs actual search to fill m_matches
+bool TextEditor::FindReplaceHandler::findNext(TextEditor *editor, bool wrapAround) {
+    auto curPos = editor->m_state.m_cursorPosition;
+    uint64_t selectionLength = editor->getStringCharacterCount(m_findWord);
     size_t byteIndex = 0;
 
-    for (size_t ln = 0; ln < curPos.mLine; ln++)
-        byteIndex += editor->GetLineByteCount(ln) + 1;
-    byteIndex += curPos.mColumn;
+    for (size_t ln = 0; ln < curPos.m_line; ln++)
+        byteIndex += editor->getLineByteCount(ln) + 1;
+    byteIndex += curPos.m_column;
 
-    std::string wordLower = mFindWord;
-    if (!GetMatchCase())
+    std::string wordLower = m_findWord;
+    if (!getMatchCase())
         std::transform(wordLower.begin(), wordLower.end(), wordLower.begin(), ::tolower);
 
-    std::string textSrc = editor->GetText();
-    if (!GetMatchCase())
+    std::string textSrc = editor->getText();
+    if (!getMatchCase())
         std::transform(textSrc.begin(), textSrc.end(), textSrc.begin(), ::tolower);
 
     size_t textLoc;
     // TODO: use regexp find iterator in all cases
-    //  to find all matches for FindAllMatches.
+    //  to find all matches for findAllMatches.
     //  That should make things faster (no need
-    //  to call FindNext many times) and remove
+    //  to call findNext many times) and remove
     //  clunky match case code
-    if (GetWholeWord() || GetFindRegEx()) {
+    if (getWholeWord() || getFindRegEx()) {
         std::regex regularExpression;
-        if (GetFindRegEx()) {
+        if (getFindRegEx()) {
             try {
                 regularExpression.assign(wordLower);
             } catch (std::regex_error &e) {
@@ -2109,7 +2119,7 @@ bool TextEditor::FindReplaceHandler::FindNext(TextEditor *editor, bool wrapAroun
         if (!iter->ready())
             return false;
         size_t firstLoc = iter->position();
-        unsigned long firstLength = iter->length();
+        uint64_t firstLength = iter->length();
 
         if(firstLoc > byteIndex) {
             pos = firstLoc;
@@ -2144,20 +2154,20 @@ bool TextEditor::FindReplaceHandler::FindNext(TextEditor *editor, bool wrapAroun
         }
     }
     if (textLoc != std::string::npos) {
-        curPos.mLine = curPos.mColumn = 0;
+        curPos.m_line = curPos.m_column = 0;
         byteIndex = 0;
 
-        for (size_t ln = 0; ln < editor->mLines.size(); ln++) {
-            auto byteCount = editor->GetLineByteCount(ln) + 1;
+        for (size_t ln = 0; ln < editor->m_lines.size(); ln++) {
+            auto byteCount = editor->getLineByteCount(ln) + 1;
 
             if (byteIndex + byteCount > textLoc) {
-                curPos.mLine = ln;
-                curPos.mColumn = textLoc - byteIndex;
+                curPos.m_line = ln;
+                curPos.m_column = textLoc - byteIndex;
 
-                auto &line = editor->mLines[curPos.mLine];
-                for (int i = 0; i < line.size(); i++) {
-                    if (line[i].mChar == '\t')
-                        curPos.mColumn += (editor->mTabSize - 1);
+                auto &line = editor->m_lines[curPos.m_line];
+                for (int32_t i = 0; i < line.size(); i++) {
+                    if (line[i].m_char == '\t')
+                        curPos.m_column += (editor->m_tabSize - 1);
                 }
                 break;
             } else {// just keep adding
@@ -2168,127 +2178,128 @@ bool TextEditor::FindReplaceHandler::FindNext(TextEditor *editor, bool wrapAroun
         return false;
 
     auto selStart = curPos, selEnd = curPos;
-    selEnd.mColumn += selectionLength;
-    editor->SetSelection(selStart, selEnd);
-    editor->SetCursorPosition(selEnd);
-    editor->mScrollToCursor = true;
+    selEnd.m_column += selectionLength;
+    editor->setSelection(selStart, selEnd);
+    editor->setCursorPosition(selEnd);
+    editor->m_scrollToCursor = true;
     return true;
 }
 
-void TextEditor::FindReplaceHandler::FindAllMatches(TextEditor *editor,std::string findWord) {
+void TextEditor::FindReplaceHandler::findAllMatches(TextEditor *editor, std::string findWord) {
 
     if (findWord.empty()) {
-        editor->mScrollToCursor = true;
-        mFindWord = "";
-        mMatches.clear();
+        editor->m_scrollToCursor = true;
+        m_findWord = "";
+        m_matches.clear();
         return;
     }
 
-    if(findWord == mFindWord && !editor->mTextChanged && !mOptionsChanged)
+    if(findWord == m_findWord && !editor->m_textChanged && !m_optionsChanged)
         return;
 
-    if (mOptionsChanged)
-        mOptionsChanged = false;
+    if (m_optionsChanged)
+        m_optionsChanged = false;
 
-    mMatches.clear();
-    mFindWord = findWord;
-    auto startingPos = editor->mState.mCursorPosition;
-    auto state = editor->mState;
+    m_matches.clear();
+    m_findWord = findWord;
+    auto startingPos = editor->m_state.m_cursorPosition;
+    auto state = editor->m_state;
     Coordinates begin = Coordinates(0,0);
-    editor->mState.mCursorPosition = begin;
+    editor->m_state.m_cursorPosition = begin;
 
-    if (!FindNext(editor,false)) {
-        editor->mState = state;
-        editor->mScrollToCursor = true;
+    if (!findNext(editor, false)) {
+        editor->m_state = state;
+        editor->m_scrollToCursor = true;
         return;
     }
-    auto initialPos = editor->mState.mCursorPosition;
-    mMatches.push_back(editor->mState);
+    auto initialPos = editor->m_state.m_cursorPosition;
+    m_matches.push_back(editor->m_state);
 
-    while( editor->mState.mCursorPosition < startingPos) {
-        if (!FindNext(editor,false)) {
-            editor->mState = state;
-            editor->mScrollToCursor = true;
+    while(editor->m_state.m_cursorPosition < startingPos) {
+        if (!findNext(editor, false)) {
+            editor->m_state = state;
+            editor->m_scrollToCursor = true;
             return;
         }
-        mMatches.push_back(editor->mState);
+        m_matches.push_back(editor->m_state);
     }
 
-    while (FindNext(editor,false))
-        mMatches.push_back(editor->mState);
+    while (findNext(editor, false))
+        m_matches.push_back(editor->m_state);
 
-    editor->mState = state;
-    editor->mScrollToCursor = true;
+    editor->m_state = state;
+    editor->m_scrollToCursor = true;
     return;
 }
 
 
-bool TextEditor::FindReplaceHandler::Replace(TextEditor *editor, bool next) {
+bool TextEditor::FindReplaceHandler::replace(TextEditor *editor, bool next) {
 
-    if (mMatches.empty() || mFindWord == mReplaceWord || mFindWord.empty())
+    if (m_matches.empty() || m_findWord == m_replaceWord || m_findWord.empty())
         return false;
 
 
-    auto state = editor->mState;
+    auto state = editor->m_state;
 
-    if (editor->mState.mCursorPosition <= editor->mState.mSelectionEnd && editor->mState.mSelectionEnd > editor->mState.mSelectionStart && editor->mState.mCursorPosition > editor->mState.mSelectionStart) {
+    if (editor->m_state.m_cursorPosition <= editor->m_state.m_selectionEnd && editor->m_state.m_selectionEnd > editor->m_state.m_selectionStart && editor->m_state.m_cursorPosition > editor->m_state.m_selectionStart) {
 
-        editor->mState.mCursorPosition = editor->mState.mSelectionStart;
-        if(editor->mState.mCursorPosition.mColumn == 0) {
-            editor->mState.mCursorPosition.mLine--;
-            editor->mState.mCursorPosition.mColumn = editor->GetLineMaxColumn(editor->mState.mCursorPosition.mLine);
+        editor->m_state.m_cursorPosition = editor->m_state.m_selectionStart;
+        if(editor->m_state.m_cursorPosition.m_column == 0) {
+            editor->m_state.m_cursorPosition.m_line--;
+            editor->m_state.m_cursorPosition.m_column = editor->getLineMaxColumn(
+                    editor->m_state.m_cursorPosition.m_line);
         } else
-            editor->mState.mCursorPosition.mColumn--;
+            editor->m_state.m_cursorPosition.m_column--;
     }
-    auto matchIndex = FindMatch(editor,next);
+    auto matchIndex = findMatch(editor, next);
     if(matchIndex != 0) {
         UndoRecord u;
-        u.mBefore = editor->mState;
+        u.m_before = editor->m_state;
 
-        auto selectionEnd = editor->mState.mSelectionEnd;
+        auto selectionEnd = editor->m_state.m_selectionEnd;
 
-        u.mRemoved = editor->GetSelectedText();
-        u.mRemovedStart = editor->mState.mSelectionStart;
-        u.mRemovedEnd = editor->mState.mSelectionEnd;
+        u.m_removed = editor->getSelectedText();
+        u.m_removedStart = editor->m_state.m_selectionStart;
+        u.m_removedEnd = editor->m_state.m_selectionEnd;
 
-        editor->DeleteSelection();
-        if (GetFindRegEx()) {
-            std::string replacedText = std::regex_replace(editor->GetText(), std::regex(mFindWord), mReplaceWord, std::regex_constants::format_first_only | std::regex_constants::format_no_copy);
-            u.mAdded = replacedText;
+        editor->deleteSelection();
+        if (getFindRegEx()) {
+            std::string replacedText = std::regex_replace(editor->getText(), std::regex(m_findWord), m_replaceWord, std::regex_constants::format_first_only | std::regex_constants::format_no_copy);
+            u.m_added = replacedText;
         } else
-            u.mAdded = mReplaceWord;
+            u.m_added = m_replaceWord;
 
-        u.mAddedStart = editor->GetActualCursorCoordinates();
+        u.m_addedStart = editor->getActualCursorCoordinates();
 
-        editor->InsertText(u.mAdded);
-        editor->SetCursorPosition(editor->mState.mSelectionEnd);
+        editor->insertText(u.m_added);
+        editor->setCursorPosition(editor->m_state.m_selectionEnd);
 
-        u.mAddedEnd = editor->GetActualCursorCoordinates();
+        u.m_addedEnd = editor->getActualCursorCoordinates();
 
-        editor->mScrollToCursor = true;
+        editor->m_scrollToCursor = true;
         ImGui::SetKeyboardFocusHere(0);
 
-        u.mAfter = editor->mState;
-        editor->AddUndo(u);
-        editor->mTextChanged = true;
-        mMatches.erase(mMatches.begin() + matchIndex - 1);
+        u.m_after = editor->m_state;
+        editor->addUndo(u);
+        editor->m_textChanged = true;
+        m_matches.erase(m_matches.begin() + matchIndex - 1);
 
         return true;
     }
-    editor->mState = state;
+    editor->m_state = state;
     return false;
 }
 
-bool TextEditor::FindReplaceHandler::ReplaceAll(TextEditor *editor) {
-    unsigned count = mMatches.size();
+bool TextEditor::FindReplaceHandler::replaceAll(TextEditor *editor) {
+    uint32_t count = m_matches.size();
 
-    for (unsigned i = 0; i < count; i++)
-        Replace(editor,true);
+    for (uint32_t i = 0; i < count; i++)
+        replace(editor,true);
 
     return true;
 }
 
-const TextEditor::Palette &TextEditor::GetDarkPalette() {
+const TextEditor::Palette &TextEditor::getDarkPalette() {
     const static Palette p = {
         {
          0xff7f7f7f, // Default
@@ -2320,7 +2331,7 @@ const TextEditor::Palette &TextEditor::GetDarkPalette() {
     return p;
 }
 
-const TextEditor::Palette &TextEditor::GetLightPalette() {
+const TextEditor::Palette &TextEditor::getLightPalette() {
     const static Palette p = {
         {
          0xff7f7f7f, // None
@@ -2352,7 +2363,7 @@ const TextEditor::Palette &TextEditor::GetLightPalette() {
     return p;
 }
 
-const TextEditor::Palette &TextEditor::GetRetroBluePalette() {
+const TextEditor::Palette &TextEditor::getRetroBluePalette() {
     const static Palette p = {
         {
          0xff00ffff, // None
@@ -2385,22 +2396,22 @@ const TextEditor::Palette &TextEditor::GetRetroBluePalette() {
 }
 
 
-std::string TextEditor::GetText() const {
-    return GetText(Coordinates(), Coordinates((int)mLines.size(), 0));
+std::string TextEditor::getText() const {
+    return getText(Coordinates(), Coordinates((int32_t)m_lines.size(), 0));
 }
 
-std::vector<std::string> TextEditor::GetTextLines() const {
+std::vector<std::string> TextEditor::getTextLines() const {
     std::vector<std::string> result;
 
-    result.reserve(mLines.size());
+    result.reserve(m_lines.size());
 
-    for (auto &line : mLines) {
+    for (auto &line : m_lines) {
         std::string text;
 
         text.resize(line.size());
 
         for (size_t i = 0; i < line.size(); ++i)
-            text[i] = line[i].mChar;
+            text[i] = line[i].m_char;
 
         result.emplace_back(std::move(text));
     }
@@ -2408,40 +2419,40 @@ std::vector<std::string> TextEditor::GetTextLines() const {
     return result;
 }
 
-std::string TextEditor::GetSelectedText() const {
-    return GetText(mState.mSelectionStart, mState.mSelectionEnd);
+std::string TextEditor::getSelectedText() const {
+    return getText(m_state.m_selectionStart, m_state.m_selectionEnd);
 }
 
-std::string TextEditor::GetCurrentLineText() const {
-    auto lineLength = GetLineMaxColumn(mState.mCursorPosition.mLine);
-    return GetText(
-        Coordinates(mState.mCursorPosition.mLine, 0),
-        Coordinates(mState.mCursorPosition.mLine, lineLength));
+std::string TextEditor::getCurrentLineText() const {
+    auto lineLength = getLineMaxColumn(m_state.m_cursorPosition.m_line);
+    return getText(
+        Coordinates(m_state.m_cursorPosition.m_line, 0),
+        Coordinates(m_state.m_cursorPosition.m_line, lineLength));
 }
 
-void TextEditor::ProcessInputs() {
+void TextEditor::processInputs() {
 }
 
-void TextEditor::Colorize(int aFromLine, int aLines) {
-    int toLine     = aLines == -1 ? (int)mLines.size() : std::min((int)mLines.size(), aFromLine + aLines);
-    mColorRangeMin = std::min(mColorRangeMin, aFromLine);
-    mColorRangeMax = std::max(mColorRangeMax, toLine);
-    mColorRangeMin = std::max(0, mColorRangeMin);
-    mColorRangeMax = std::max(mColorRangeMin, mColorRangeMax);
-    mCheckComments = true;
+void TextEditor::colorize(int32_t aFromLine, int32_t aCount) {
+    int32_t toLine     = aCount == -1 ? (int32_t)m_lines.size() : std::min((int32_t)m_lines.size(), aFromLine + aCount);
+    m_colorRangeMin = std::min(m_colorRangeMin, aFromLine);
+    m_colorRangeMax = std::max(m_colorRangeMax, toLine);
+    m_colorRangeMin = std::max(0, m_colorRangeMin);
+    m_colorRangeMax = std::max(m_colorRangeMin, m_colorRangeMax);
+    m_checkComments = true;
 }
 
-void TextEditor::ColorizeRange(int aFromLine, int aToLine) {
-    if (mLines.empty() || aFromLine >= aToLine)
+void TextEditor::colorizeRange(int32_t aFromLine, int32_t aToLine) {
+    if (m_lines.empty() || aFromLine >= aToLine)
         return;
 
     std::string buffer;
     std::cmatch results;
     std::string id;
 
-    int endLine = std::max(0, std::min((int)mLines.size(), aToLine));
-    for (int i = aFromLine; i < endLine; ++i) {
-        auto &line = mLines[i];
+    int32_t endLine = std::max(0, std::min((int32_t)m_lines.size(), aToLine));
+    for (int32_t i = aFromLine; i < endLine; ++i) {
+        auto &line = m_lines[i];
 
         if (line.empty())
             continue;
@@ -2449,8 +2460,8 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine) {
         buffer.resize(line.size());
         for (size_t j = 0; j < line.size(); ++j) {
             auto &col       = line[j];
-            buffer[j]       = col.mChar;
-            col.mColorIndex = PaletteIndex::Default;
+            buffer[j]       = col.m_char;
+            col.m_colorIndex = PaletteIndex::Default;
         }
 
         const char *bufferBegin = &buffer.front();
@@ -2465,16 +2476,16 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine) {
 
             bool hasTokenizeResult = false;
 
-            if (mLanguageDefinition.mTokenize != nullptr) {
-                if (mLanguageDefinition.mTokenize(first, last, token_begin, token_end, token_color))
+            if (mL_languageDefinition.m_tokenize != nullptr) {
+                if (mL_languageDefinition.m_tokenize(first, last, token_begin, token_end, token_color))
                     hasTokenizeResult = true;
             }
 
             if (hasTokenizeResult == false) {
                 // todo : remove
-                // printf("using regex for %.*s\n", first + 10 < last ? 10 : int(last - first), first);
+                // printf("using regex for %.*s\n", first + 10 < last ? 10 : int32_t(last - first), first);
 
-                for (auto &p : mRegexList) {
+                for (auto &p : m_regexList) {
                     if (std::regex_search(first, last, results, p.first, std::regex_constants::match_continuous)) {
                         hasTokenizeResult = true;
 
@@ -2496,24 +2507,24 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine) {
                     id.assign(token_begin, token_end);
 
                     // todo : allmost all language definitions use lower case to specify keywords, so shouldn't this use ::tolower ?
-                    if (!mLanguageDefinition.mCaseSensitive)
+                    if (!mL_languageDefinition.m_caseSensitive)
                         std::transform(id.begin(), id.end(), id.begin(), ::toupper);
 
-                    if (!line[first - bufferBegin].mPreprocessor) {
-                        if (mLanguageDefinition.mKeywords.count(id) != 0)
+                    if (!line[first - bufferBegin].m_preprocessor) {
+                        if (mL_languageDefinition.m_keywords.count(id) != 0)
                             token_color = PaletteIndex::Keyword;
-                        else if (mLanguageDefinition.mIdentifiers.count(id) != 0)
+                        else if (mL_languageDefinition.m_identifiers.count(id) != 0)
                             token_color = PaletteIndex::KnownIdentifier;
-                        else if (mLanguageDefinition.mPreprocIdentifiers.count(id) != 0)
+                        else if (mL_languageDefinition.m_preprocIdentifiers.count(id) != 0)
                             token_color = PaletteIndex::PreprocIdentifier;
                     } else {
-                        if (mLanguageDefinition.mPreprocIdentifiers.count(id) != 0)
+                        if (mL_languageDefinition.m_preprocIdentifiers.count(id) != 0)
                             token_color = PaletteIndex::PreprocIdentifier;
                     }
                 }
 
                 for (size_t j = 0; j < token_length; ++j)
-                    line[(token_begin - bufferBegin) + j].mColorIndex = token_color;
+                    line[(token_begin - bufferBegin) + j].m_colorIndex = token_color;
 
                 first = token_end;
             }
@@ -2521,12 +2532,12 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine) {
     }
 }
 
-void TextEditor::ColorizeInternal() {
-    if (mLines.empty() || !mColorizerEnabled)
+void TextEditor::colorizeInternal() {
+    if (m_lines.empty() || !m_colorizerEnabled)
         return;
 
-    if (mCheckComments) {
-        auto endLine                 = mLines.size();
+    if (m_checkComments) {
+        auto endLine                 = m_lines.size();
         auto endIndex                = 0;
         auto commentStartLine        = endLine;
         auto commentStartIndex       = endIndex;
@@ -2541,23 +2552,23 @@ void TextEditor::ColorizeInternal() {
         auto currentLine             = 0;
         auto currentIndex            = 0;
         auto commentLength           = 0;
-        auto &startStr               = mLanguageDefinition.mCommentStart;
-        auto &singleStartStr         = mLanguageDefinition.mSingleLineComment;
-        auto &docStartStr            = mLanguageDefinition.mDocComment;
-        auto &globalStartStr         = mLanguageDefinition.mGlobalDocComment;
+        auto &startStr               = mL_languageDefinition.m_commentStart;
+        auto &singleStartStr         = mL_languageDefinition.m_singleLineComment;
+        auto &docStartStr            = mL_languageDefinition.m_docComment;
+        auto &globalStartStr         = mL_languageDefinition.m_globalDocComment;
 
         std::vector<bool> ifDefs;
         ifDefs.push_back(true);
 
         while (currentLine < endLine || currentIndex < endIndex) {
-            auto &line = mLines[currentLine];
+            auto &line = m_lines[currentLine];
 
-            auto setGlyphFlags = [&](int index) {
-                line[index].mMultiLineComment = withinComment;
-                line[index].mComment          = withinSingleLineComment;
-                line[index].mDocComment       = withinDocComment;
-                line[index].mGlobalDocComment = withinGlobalDocComment;
-                line[index].mDeactivated      = withinNotDef;
+            auto setGlyphFlags = [&](int32_t index) {
+                line[index].m_multiLineComment = withinComment;
+                line[index].m_comment          = withinSingleLineComment;
+                line[index].m_docComment       = withinDocComment;
+                line[index].m_globalDocComment = withinGlobalDocComment;
+                line[index].m_deactivated      = withinNotDef;
             };
 
             if (currentIndex == 0) {
@@ -2568,9 +2579,9 @@ void TextEditor::ColorizeInternal() {
 
             if (!line.empty()) {
                 auto &g = line[currentIndex];
-                auto c  = g.mChar;
+                auto c  = g.m_char;
 
-                if (c != mLanguageDefinition.mPreprocChar && !isspace(c))
+                if (c != mL_languageDefinition.m_preprocChar && !isspace(c))
                     firstChar = false;
 
                 bool inComment = (commentStartLine < currentLine || (commentStartLine == currentLine && commentStartIndex <= currentIndex));
@@ -2583,62 +2594,62 @@ void TextEditor::ColorizeInternal() {
                     } else if (c == '\"')
                         withinString = false;
                 } else {
-                    if (firstChar && c == mLanguageDefinition.mPreprocChar) {
+                    if (firstChar && c == mL_languageDefinition.m_preprocChar) {
                         withinPreproc = true;
                         std::string directive;
                         auto start = currentIndex + 1;
-                        while (start < (int) line.size() && !isspace(line[start].mChar)) {
-                            directive += line[start].mChar;
+                        while (start < (int32_t) line.size() && !isspace(line[start].m_char)) {
+                            directive += line[start].m_char;
                             start++;
                         }
 
-                        if (start < (int) line.size()) {
+                        if (start < (int32_t) line.size()) {
 
-                            if (isspace(line[start].mChar)) {
+                            if (isspace(line[start].m_char)) {
                                 start += 1;
                                  if (directive == "define") {
-                                     while (start < (int) line.size() && isspace(line[start].mChar))
+                                     while (start < (int32_t) line.size() && isspace(line[start].m_char))
                                          start++;
                                      std::string identifier;
-                                     while (start < (int) line.size() && !isspace(line[start].mChar)) {
-                                         identifier += line[start].mChar;
+                                     while (start < (int32_t) line.size() && !isspace(line[start].m_char)) {
+                                         identifier += line[start].m_char;
                                          start++;
                                      }
-                                     if (identifier.size() > 0 && !withinNotDef && std::find(mDefines.begin(),mDefines.end(),identifier) == mDefines.end())
-                                         mDefines.push_back(identifier);
+                                     if (identifier.size() > 0 && !withinNotDef && std::find(m_defines.begin(), m_defines.end(), identifier) == m_defines.end())
+                                         m_defines.push_back(identifier);
                                     } else if (directive == "undef") {
-                                         while (start < (int) line.size() && isspace(line[start].mChar))
+                                         while (start < (int32_t) line.size() && isspace(line[start].m_char))
                                              start++;
                                          std::string identifier;
-                                         while (start < (int) line.size() && !isspace(line[start].mChar)) {
-                                             identifier += line[start].mChar;
+                                         while (start < (int32_t) line.size() && !isspace(line[start].m_char)) {
+                                             identifier += line[start].m_char;
                                              start++;
                                          }
                                          if (identifier.size() > 0  && !withinNotDef)
-                                             mDefines.erase(std::remove(mDefines.begin(), mDefines.end(), identifier), mDefines.end());
+                                             m_defines.erase(std::remove(m_defines.begin(), m_defines.end(), identifier), m_defines.end());
                                 } else if (directive == "ifdef") {
-                                    while (start < (int) line.size() && isspace(line[start].mChar))
+                                    while (start < (int32_t) line.size() && isspace(line[start].m_char))
                                         start++;
                                     std::string identifier;
-                                    while (start < (int) line.size() && !isspace(line[start].mChar)) {
-                                        identifier += line[start].mChar;
+                                    while (start < (int32_t) line.size() && !isspace(line[start].m_char)) {
+                                        identifier += line[start].m_char;
                                         start++;
                                     }
                                     if (!withinNotDef) {
-                                        bool isConditionMet = std::find(mDefines.begin(),mDefines.end(),identifier) != mDefines.end();
+                                        bool isConditionMet = std::find(m_defines.begin(), m_defines.end(), identifier) != m_defines.end();
                                         ifDefs.push_back(isConditionMet);
                                     } else
                                         ifDefs.push_back(false);
                                 } else if (directive == "ifndef") {
-                                    while (start < (int) line.size() && isspace(line[start].mChar))
+                                    while (start < (int32_t) line.size() && isspace(line[start].m_char))
                                         start++;
                                     std::string identifier;
-                                    while (start < (int) line.size() && !isspace(line[start].mChar)) {
-                                        identifier += line[start].mChar;
+                                    while (start < (int32_t) line.size() && !isspace(line[start].m_char)) {
+                                        identifier += line[start].m_char;
                                         start++;
                                     }
                                     if (!withinNotDef) {
-                                        bool isConditionMet =  std::find(mDefines.begin(),mDefines.end(),identifier) == mDefines.end();
+                                        bool isConditionMet = std::find(m_defines.begin(), m_defines.end(), identifier) == m_defines.end();
                                         ifDefs.push_back(isConditionMet);
                                     } else
                                         ifDefs.push_back(false);
@@ -2658,7 +2669,7 @@ void TextEditor::ColorizeInternal() {
                         withinString                         = true;
                         setGlyphFlags(currentIndex);
                     } else {
-                        auto pred            = [](const char &a, const Glyph &b) { return a == b.mChar; };
+                        auto pred            = [](const char &a, const Glyph &b) { return a == b.m_char; };
 
                         auto compareForth    = [&](const std::string &a, const std::vector<Glyph> &b) {
                             return !a.empty() && currentIndex + a.size() <= b.size() && equals(a.begin(), a.end(),
@@ -2666,7 +2677,7 @@ void TextEditor::ColorizeInternal() {
                         };
 
                         auto compareBack     = [&](const std::string &a, const std::vector<Glyph> &b) {
-                            return !a.empty() && currentIndex + 1 >= (int)a.size() && equals(a.begin(), a.end(),
+                            return !a.empty() && currentIndex + 1 >= (int32_t)a.size() && equals(a.begin(), a.end(),
                                     b.begin() + currentIndex + 1 - a.size(), b.begin() + currentIndex + 1, pred);
                         };
 
@@ -2696,7 +2707,7 @@ void TextEditor::ColorizeInternal() {
                         }
                         setGlyphFlags(currentIndex);
 
-                        auto &endStr = mLanguageDefinition.mCommentEnd;
+                        auto &endStr = mL_languageDefinition.m_commentEnd;
                         if (compareBack(endStr, line) && ((commentStartLine != currentLine) || (commentStartIndex + commentLength < currentIndex))) {
                             withinComment          = false;
                             withinDocComment        = false;
@@ -2708,10 +2719,10 @@ void TextEditor::ColorizeInternal() {
                     }
                 }
                 if (currentIndex < line.size())
-                    line[currentIndex].mPreprocessor = withinPreproc;
+                    line[currentIndex].m_preprocessor = withinPreproc;
                 
                 currentIndex += UTF8CharLength(c);
-                if (currentIndex >= (int)line.size()) {
+                if (currentIndex >= (int32_t)line.size()) {
                     withinNotDef = !ifDefs.back();
                     currentIndex = 0;
                     ++currentLine;
@@ -2721,39 +2732,39 @@ void TextEditor::ColorizeInternal() {
                 ++currentLine;
             }
         }
-        mDefines.clear();
-        mCheckComments = false;
+        m_defines.clear();
+        m_checkComments = false;
     }
 
-    if (mColorRangeMin < mColorRangeMax) {
-        const int increment = (mLanguageDefinition.mTokenize == nullptr) ? 10 : 10000;
-        const int to        = std::min(mColorRangeMin + increment, mColorRangeMax);
-        ColorizeRange(mColorRangeMin, to);
-        mColorRangeMin = to;
+    if (m_colorRangeMin < m_colorRangeMax) {
+        const int32_t increment = (mL_languageDefinition.m_tokenize == nullptr) ? 10 : 10000;
+        const int32_t to        = std::min(m_colorRangeMin + increment, m_colorRangeMax);
+        colorizeRange(m_colorRangeMin, to);
+        m_colorRangeMin = to;
 
-        if (mColorRangeMax == mColorRangeMin) {
-            mColorRangeMin = std::numeric_limits<int>::max();
-            mColorRangeMax = 0;
+        if (m_colorRangeMax == m_colorRangeMin) {
+            m_colorRangeMin = std::numeric_limits<int32_t>::max();
+            m_colorRangeMax = 0;
         }
         return;
     }
 }
 
-float TextEditor::TextDistanceToLineStart(const Coordinates &aFrom) const {
-    auto &line      = mLines[aFrom.mLine];
+float TextEditor::textDistanceToLineStart(const Coordinates &aFrom) const {
+    auto &line      = m_lines[aFrom.m_line];
     float distance  = 0.0f;
     float spaceSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, " ", nullptr, nullptr).x;
-    int colIndex    = GetCharacterIndex(aFrom);
+    int32_t colIndex    = getCharacterIndex(aFrom);
     for (size_t it = 0u; it < line.size() && it < colIndex;) {
-        if (line[it].mChar == '\t') {
-            distance = (1.0f + std::floor((1.0f + distance) / (float(mTabSize) * spaceSize))) * (float(mTabSize) * spaceSize);
+        if (line[it].m_char == '\t') {
+            distance = (1.0f + std::floor((1.0f + distance) / (float(m_tabSize) * spaceSize))) * (float(m_tabSize) * spaceSize);
             ++it;
         } else {
-            auto d = UTF8CharLength(line[it].mChar);
+            auto d = UTF8CharLength(line[it].m_char);
             char tempCString[7];
-            int i = 0;
-            for (; i < 6 && d-- > 0 && it < (int)line.size(); i++, it++)
-                tempCString[i] = line[it].mChar;
+            int32_t i = 0;
+            for (; i < 6 && d-- > 0 && it < (int32_t)line.size(); i++, it++)
+                tempCString[i] = line[it].m_char;
 
             tempCString[i] = '\0';
             distance += ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, tempCString, nullptr, nullptr).x;
@@ -2763,9 +2774,9 @@ float TextEditor::TextDistanceToLineStart(const Coordinates &aFrom) const {
     return distance;
 }
 
-void TextEditor::EnsureCursorVisible() {
-    if (!mWithinRender) {
-        mScrollToCursor = true;
+void TextEditor::ensureCursorVisible() {
+    if (!m_withinRender) {
+        m_scrollToCursor = true;
         return;
     }
 
@@ -2774,37 +2785,37 @@ void TextEditor::EnsureCursorVisible() {
 
     auto windowPadding = ImGui::GetStyle().WindowPadding * 2.0f;
 
-    auto height = ImGui::GetWindowHeight() - mTopMargin - windowPadding.y;
+    auto height = ImGui::GetWindowHeight() - m_topMargin - windowPadding.y;
     auto width  = ImGui::GetWindowWidth() - windowPadding.x;
 
-    auto top    = (int)ceil(scrollY / mCharAdvance.y);
-    auto bottom = (int)ceil((scrollY + height) / mCharAdvance.y);
+    auto top    = (int32_t)ceil(scrollY / m_charAdvance.y);
+    auto bottom = (int32_t)ceil((scrollY + height) / m_charAdvance.y);
 
     auto left  = scrollX;
     auto right = scrollX + width;
 
-    auto pos = GetActualCursorCoordinates();
-    auto len = TextDistanceToLineStart(pos);
+    auto pos = getActualCursorCoordinates();
+    auto len = textDistanceToLineStart(pos);
 
-    if (pos.mLine <= top + 1)
-        ImGui::SetScrollY(std::max(0.0f, (pos.mLine - 1) * mCharAdvance.y));
-    if (pos.mLine >= bottom - 2)
-        ImGui::SetScrollY(std::max(0.0f, (pos.mLine + 2) * mCharAdvance.y - height));
+    if (pos.m_line <= top + 1)
+        ImGui::SetScrollY(std::max(0.0f, (pos.m_line - 1) * m_charAdvance.y));
+    if (pos.m_line >= bottom - 2)
+        ImGui::SetScrollY(std::max(0.0f, (pos.m_line + 2) * m_charAdvance.y - height));
     if (len == 0)
         ImGui::SetScrollX(0);
-    else if (len + mTextStart <= left + 4)
-        ImGui::SetScrollX(std::max(0.0f, len + mTextStart - 4));
-    if (len + mTextStart + mCharAdvance.x * 2 >= right - 4)
-        ImGui::SetScrollX(std::max(0.0f, len + mTextStart + 4 - width + mCharAdvance.x * 2));
+    else if (len + m_textStart <= left + 4)
+        ImGui::SetScrollX(std::max(0.0f, len + m_textStart - 4));
+    if (len + m_textStart + m_charAdvance.x * 2 >= right - 4)
+        ImGui::SetScrollX(std::max(0.0f, len + m_textStart + 4 - width + m_charAdvance.x * 2));
 }
 
-int TextEditor::GetPageSize() const {
-    auto height = ImGui::GetWindowHeight() - 20.0f - mTopMargin;
-    return (int)floor(height / mCharAdvance.y);
+int32_t TextEditor::getPageSize() const {
+    auto height = ImGui::GetWindowHeight() - 20.0f - m_topMargin;
+    return (int32_t)floor(height / m_charAdvance.y);
 }
 
-void TextEditor::ResetCursorBlinkTime() {
-    mStartTime = ImGui::GetTime() * 1000 - sCursorBlinkOnTime;
+void TextEditor::resetCursorBlinkTime() {
+    m_startTime = ImGui::GetTime() * 1000 - s_cursorBlinkOnTime;
 }
 
 TextEditor::UndoRecord::UndoRecord(
@@ -2816,44 +2827,44 @@ TextEditor::UndoRecord::UndoRecord(
     const TextEditor::Coordinates aRemovedEnd,
     TextEditor::EditorState &aBefore,
     TextEditor::EditorState &aAfter)
-    : mAdded(aAdded), mAddedStart(aAddedStart), mAddedEnd(aAddedEnd), mRemoved(aRemoved), mRemovedStart(aRemovedStart), mRemovedEnd(aRemovedEnd), mBefore(aBefore), mAfter(aAfter) {
-    assert(mAddedStart <= mAddedEnd);
-    assert(mRemovedStart <= mRemovedEnd);
+    : m_added(aAdded), m_addedStart(aAddedStart), m_addedEnd(aAddedEnd), m_removed(aRemoved), m_removedStart(aRemovedStart), m_removedEnd(aRemovedEnd), m_before(aBefore), m_after(aAfter) {
+    assert(m_addedStart <= m_addedEnd);
+    assert(m_removedStart <= m_removedEnd);
 }
 
-void TextEditor::UndoRecord::Undo(TextEditor *aEditor) {
-    if (!mAdded.empty()) {
-        aEditor->DeleteRange(mAddedStart, mAddedEnd);
-        aEditor->Colorize(mAddedStart.mLine - 1, mAddedEnd.mLine - mAddedStart.mLine + 2);
+void TextEditor::UndoRecord::undo(TextEditor *aEditor) {
+    if (!m_added.empty()) {
+        aEditor->deleteRange(m_addedStart, m_addedEnd);
+        aEditor->colorize(m_addedStart.m_line - 1, m_addedEnd.m_line - m_addedStart.m_line + 2);
     }
 
-    if (!mRemoved.empty()) {
-        auto start = mRemovedStart;
-        aEditor->InsertTextAt(start, mRemoved.c_str());
-        aEditor->Colorize(mRemovedStart.mLine - 1, mRemovedEnd.mLine - mRemovedStart.mLine + 2);
+    if (!m_removed.empty()) {
+        auto start = m_removedStart;
+        aEditor->insertTextAt(start, m_removed.c_str());
+        aEditor->colorize(m_removedStart.m_line - 1, m_removedEnd.m_line - m_removedStart.m_line + 2);
     }
 
-    aEditor->mState = mBefore;
-    aEditor->EnsureCursorVisible();
+    aEditor->m_state = m_before;
+    aEditor->ensureCursorVisible();
 }
 
-void TextEditor::UndoRecord::Redo(TextEditor *aEditor) {
-    if (!mRemoved.empty()) {
-        aEditor->DeleteRange(mRemovedStart, mRemovedEnd);
-        aEditor->Colorize(mRemovedStart.mLine - 1, mRemovedEnd.mLine - mRemovedStart.mLine + 1);
+void TextEditor::UndoRecord::redo(TextEditor *aEditor) {
+    if (!m_removed.empty()) {
+        aEditor->deleteRange(m_removedStart, m_removedEnd);
+        aEditor->colorize(m_removedStart.m_line - 1, m_removedEnd.m_line - m_removedStart.m_line + 1);
     }
 
-    if (!mAdded.empty()) {
-        auto start = mAddedStart;
-        aEditor->InsertTextAt(start, mAdded.c_str());
-        aEditor->Colorize(mAddedStart.mLine - 1, mAddedEnd.mLine - mAddedStart.mLine + 1);
+    if (!m_added.empty()) {
+        auto start = m_addedStart;
+        aEditor->insertTextAt(start, m_added.c_str());
+        aEditor->colorize(m_addedStart.m_line - 1, m_addedEnd.m_line - m_addedStart.m_line + 1);
     }
 
-    aEditor->mState = mAfter;
-    aEditor->EnsureCursorVisible();
+    aEditor->m_state = m_after;
+    aEditor->ensureCursorVisible();
 }
 
-bool TokenizeCStyleString(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
+bool tokenizeCStyleString(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
     const char *p = in_begin;
 
     if (*p == '"') {
@@ -2880,7 +2891,7 @@ bool TokenizeCStyleString(const char *in_begin, const char *in_end, const char *
     return false;
 }
 
-bool TokenizeCStyleCharacterLiteral(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
+bool tokenizeCStyleCharacterLiteral(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
     const char *p = in_begin;
 
     if (*p == '\'') {
@@ -2904,7 +2915,7 @@ bool TokenizeCStyleCharacterLiteral(const char *in_begin, const char *in_end, co
     return false;
 }
 
-bool TokenizeCStyleIdentifier(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
+bool tokenizeCStyleIdentifier(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
     const char *p = in_begin;
 
     if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || *p == '_') {
@@ -2921,7 +2932,7 @@ bool TokenizeCStyleIdentifier(const char *in_begin, const char *in_end, const ch
     return false;
 }
 
-bool TokenizeCStyleNumber(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
+bool tokenizeCStyleNumber(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
     const char *p = in_begin;
 
     const bool startsWithNumber = *p >= '0' && *p <= '9';
@@ -3013,7 +3024,7 @@ bool TokenizeCStyleNumber(const char *in_begin, const char *in_end, const char *
     return true;
 }
 
-bool TokenizeCStylePunctuation(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
+bool tokenizeCStylePunctuation(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end) {
     (void)in_end;
 
     switch (*in_begin) {
@@ -3057,18 +3068,18 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::CPlusPlus(
             "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "atomic_commit", "atomic_noexcept", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char16_t", "char32_t", "class", "compl", "concept", "const", "constexpr", "const_cast", "continue", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "import", "inline", "int", "long", "module", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch", "synchronized", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
         };
         for (auto &k : cppKeywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "abort", "abs", "acos", "asin", "atan", "atexit", "atof", "atoi", "atol", "ceil", "clock", "cosh", "ctime", "div", "exit", "fabs", "floor", "fmod", "getchar", "getenv", "isalnum", "isalpha", "isdigit", "isgraph", "ispunct", "isspace", "isupper", "kbhit", "log10", "log2", "log", "memcmp", "modf", "pow", "printf", "sprintf", "snprintf", "putchar", "putenv", "puts", "rand", "remove", "rename", "sinh", "sqrt", "srand", "strcat", "strcmp", "strerror", "time", "tolower", "toupper", "std", "string", "vector", "map", "unordered_map", "set", "unordered_set", "min", "max"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenize = [](const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end, PaletteIndex &paletteIndex) -> bool {
+        langDef.m_tokenize = [](const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end, PaletteIndex &paletteIndex) -> bool {
             paletteIndex = PaletteIndex::Max;
 
             while (in_begin < in_end && isascii(*in_begin) && isblank(*in_begin))
@@ -3078,28 +3089,28 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::CPlusPlus(
                 out_begin    = in_end;
                 out_end      = in_end;
                 paletteIndex = PaletteIndex::Default;
-            } else if (TokenizeCStyleString(in_begin, in_end, out_begin, out_end))
+            } else if (tokenizeCStyleString(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::String;
-            else if (TokenizeCStyleCharacterLiteral(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleCharacterLiteral(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::CharLiteral;
-            else if (TokenizeCStyleIdentifier(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleIdentifier(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Identifier;
-            else if (TokenizeCStyleNumber(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleNumber(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Number;
-            else if (TokenizeCStylePunctuation(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStylePunctuation(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Punctuation;
 
             return paletteIndex != PaletteIndex::Max;
         };
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = true;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = true;
 
-        langDef.mName = "C++";
+        langDef.m_name = "C++";
 
         inited = true;
     }
@@ -3300,35 +3311,35 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::HLSL() {
             "half4x4",
         };
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "abort", "abs", "acos", "all", "AllMemoryBarrier", "AllMemoryBarrierWithGroupSync", "any", "asdouble", "asfloat", "asin", "asint", "asint", "asuint", "asuint", "atan", "atan2", "ceil", "CheckAccessFullyMapped", "clamp", "clip", "cos", "cosh", "countbits", "cross", "D3DCOLORtoUBYTE4", "ddx", "ddx_coarse", "ddx_fine", "ddy", "ddy_coarse", "ddy_fine", "degrees", "determinant", "DeviceMemoryBarrier", "DeviceMemoryBarrierWithGroupSync", "distance", "dot", "dst", "errorf", "EvaluateAttributeAtCentroid", "EvaluateAttributeAtSample", "EvaluateAttributeSnapped", "exp", "exp2", "f16tof32", "f32tof16", "faceforward", "firstbithigh", "firstbitlow", "floor", "fma", "fmod", "frac", "frexp", "fwidth", "GetRenderTargetSampleCount", "GetRenderTargetSamplePosition", "GroupMemoryBarrier", "GroupMemoryBarrierWithGroupSync", "InterlockedAdd", "InterlockedAnd", "InterlockedCompareExchange", "InterlockedCompareStore", "InterlockedExchange", "InterlockedMax", "InterlockedMin", "InterlockedOr", "InterlockedXor", "isfinite", "isinf", "isnan", "ldexp", "length", "lerp", "lit", "log", "log10", "log2", "mad", "max", "min", "modf", "msad4", "mul", "noise", "normalize", "pow", "printf", "Process2DQuadTessFactorsAvg", "Process2DQuadTessFactorsMax", "Process2DQuadTessFactorsMin", "ProcessIsolineTessFactors", "ProcessQuadTessFactorsAvg", "ProcessQuadTessFactorsMax", "ProcessQuadTessFactorsMin", "ProcessTriTessFactorsAvg", "ProcessTriTessFactorsMax", "ProcessTriTessFactorsMin", "radians", "rcp", "reflect", "refract", "reversebits", "round", "rsqrt", "saturate", "sign", "sin", "sincos", "sinh", "smoothstep", "sqrt", "step", "tan", "tanh", "tex1D", "tex1D", "tex1Dbias", "tex1Dgrad", "tex1Dlod", "tex1Dproj", "tex2D", "tex2D", "tex2Dbias", "tex2Dgrad", "tex2Dlod", "tex2Dproj", "tex3D", "tex3D", "tex3Dbias", "tex3Dgrad", "tex3Dlod", "tex3Dproj", "texCUBE", "texCUBE", "texCUBEbias", "texCUBEgrad", "texCUBElod", "texCUBEproj", "transpose", "trunc"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = true;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = true;
 
-        langDef.mName = "HLSL";
+        langDef.m_name = "HLSL";
 
         inited = true;
     }
@@ -3343,35 +3354,35 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::GLSL() {
             "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else", "enum", "extern", "float", "for", "goto", "if", "inline", "int", "long", "register", "restrict", "return", "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union", "unsigned", "void", "volatile", "while", "_Alignas", "_Alignof", "_Atomic", "_Bool", "_Complex", "_Generic", "_Imaginary", "_Noreturn", "_Static_assert", "_Thread_local"
         };
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "abort", "abs", "acos", "asin", "atan", "atexit", "atof", "atoi", "atol", "ceil", "clock", "cosh", "ctime", "div", "exit", "fabs", "floor", "fmod", "getchar", "getenv", "isalnum", "isalpha", "isdigit", "isgraph", "ispunct", "isspace", "isupper", "kbhit", "log10", "log2", "log", "memcmp", "modf", "pow", "putchar", "putenv", "puts", "rand", "remove", "rename", "sinh", "sqrt", "srand", "strcat", "strcmp", "strerror", "time", "tolower", "toupper"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = true;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = true;
 
-        langDef.mName = "GLSL";
+        langDef.m_name = "GLSL";
 
         inited = true;
     }
@@ -3386,18 +3397,18 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::C() {
             "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else", "enum", "extern", "float", "for", "goto", "if", "inline", "int", "long", "register", "restrict", "return", "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union", "unsigned", "void", "volatile", "while", "_Alignas", "_Alignof", "_Atomic", "_Bool", "_Complex", "_Generic", "_Imaginary", "_Noreturn", "_Static_assert", "_Thread_local"
         };
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "abort", "abs", "acos", "asin", "atan", "atexit", "atof", "atoi", "atol", "ceil", "clock", "cosh", "ctime", "div", "exit", "fabs", "floor", "fmod", "getchar", "getenv", "isalnum", "isalpha", "isdigit", "isgraph", "ispunct", "isspace", "isupper", "kbhit", "log10", "log2", "log", "memcmp", "modf", "pow", "putchar", "putenv", "puts", "rand", "remove", "rename", "sinh", "sqrt", "srand", "strcat", "strcmp", "strerror", "time", "tolower", "toupper"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenize = [](const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end, PaletteIndex &paletteIndex) -> bool {
+        langDef.m_tokenize = [](const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end, PaletteIndex &paletteIndex) -> bool {
             paletteIndex = PaletteIndex::Max;
 
             while (in_begin < in_end && isascii(*in_begin) && isblank(*in_begin))
@@ -3407,28 +3418,28 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::C() {
                 out_begin    = in_end;
                 out_end      = in_end;
                 paletteIndex = PaletteIndex::Default;
-            } else if (TokenizeCStyleString(in_begin, in_end, out_begin, out_end))
+            } else if (tokenizeCStyleString(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::String;
-            else if (TokenizeCStyleCharacterLiteral(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleCharacterLiteral(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::CharLiteral;
-            else if (TokenizeCStyleIdentifier(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleIdentifier(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Identifier;
-            else if (TokenizeCStyleNumber(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStyleNumber(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Number;
-            else if (TokenizeCStylePunctuation(in_begin, in_end, out_begin, out_end))
+            else if (tokenizeCStylePunctuation(in_begin, in_end, out_begin, out_end))
                 paletteIndex = PaletteIndex::Punctuation;
 
             return paletteIndex != PaletteIndex::Max;
         };
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = true;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = true;
 
-        langDef.mName = "C";
+        langDef.m_name = "C";
 
         inited = true;
     }
@@ -3444,34 +3455,34 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::SQL() {
         };
 
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "ABS", "ACOS", "ADD_MONTHS", "ASCII", "ASCIISTR", "ASIN", "ATAN", "ATAN2", "AVG", "BFILENAME", "BIN_TO_NUM", "BITAND", "CARDINALITY", "CASE", "CAST", "CEIL", "CHARTOROWID", "CHR", "COALESCE", "COMPOSE", "CONCAT", "CONVERT", "CORR", "COS", "COSH", "COUNT", "COVAR_POP", "COVAR_SAMP", "CUME_DIST", "CURRENT_DATE", "CURRENT_TIMESTAMP", "DBTIMEZONE", "DECODE", "DECOMPOSE", "DENSE_RANK", "DUMP", "EMPTY_BLOB", "EMPTY_CLOB", "EXP", "EXTRACT", "FIRST_VALUE", "FLOOR", "FROM_TZ", "GREATEST", "GROUP_ID", "HEXTORAW", "INITCAP", "INSTR", "INSTR2", "INSTR4", "INSTRB", "INSTRC", "LAG", "LAST_DAY", "LAST_VALUE", "LEAD", "LEAST", "LENGTH", "LENGTH2", "LENGTH4", "LENGTHB", "LENGTHC", "LISTAGG", "LN", "LNNVL", "LOCALTIMESTAMP", "LOG", "LOWER", "LPAD", "LTRIM", "MAX", "MEDIAN", "MIN", "MOD", "MONTHS_BETWEEN", "NANVL", "NCHR", "NEW_TIME", "NEXT_DAY", "NTH_VALUE", "NULLIF", "NUMTODSINTERVAL", "NUMTOYMINTERVAL", "NVL", "NVL2", "POWER", "RANK", "RAWTOHEX", "REGEXP_COUNT", "REGEXP_INSTR", "REGEXP_REPLACE", "REGEXP_SUBSTR", "REMAINDER", "REPLACE", "ROUND", "ROWNUM", "RPAD", "RTRIM", "SESSIONTIMEZONE", "SIGN", "SIN", "SINH", "SOUNDEX", "SQRT", "STDDEV", "SUBSTR", "SUM", "SYS_CONTEXT", "SYSDATE", "SYSTIMESTAMP", "TAN", "TANH", "TO_CHAR", "TO_CLOB", "TO_DATE", "TO_DSINTERVAL", "TO_LOB", "TO_MULTI_BYTE", "TO_NCLOB", "TO_NUMBER", "TO_SINGLE_BYTE", "TO_TIMESTAMP", "TO_TIMESTAMP_TZ", "TO_YMINTERVAL", "TRANSLATE", "TRIM", "TRUNC", "TZ_OFFSET", "UID", "UPPER", "USER", "USERENV", "VAR_POP", "VAR_SAMP", "VARIANCE", "VSIZE "
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\\'[^\\\']*\\\'", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\\'[^\\\']*\\\'", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = false;
-        langDef.mAutoIndentation = false;
+        langDef.m_caseSensitive   = false;
+        langDef.m_autoIndentation = false;
 
-        langDef.mName = "SQL";
+        langDef.m_name = "SQL";
 
         inited = true;
     }
@@ -3487,34 +3498,34 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::AngelScrip
         };
 
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "cos", "sin", "tab", "acos", "asin", "atan", "atan2", "cosh", "sinh", "tanh", "log", "log10", "pow", "sqrt", "abs", "ceil", "floor", "fraction", "closeTo", "fpFromIEEE", "fpToIEEE", "complex", "opEquals", "opAddAssign", "opSubAssign", "opMulAssign", "opDivAssign", "opAdd", "opSub", "opMul", "opDiv"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
 
-        langDef.mCommentStart      = "/*";
-        langDef.mCommentEnd        = "*/";
-        langDef.mSingleLineComment = "//";
+        langDef.m_commentStart      = "/*";
+        langDef.m_commentEnd        = "*/";
+        langDef.m_singleLineComment = "//";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = true;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = true;
 
-        langDef.mName = "AngelScript";
+        langDef.m_name = "AngelScript";
 
         inited = true;
     }
@@ -3530,33 +3541,33 @@ const TextEditor::LanguageDefinition &TextEditor::LanguageDefinition::Lua() {
         };
 
         for (auto &k : keywords)
-            langDef.mKeywords.insert(k);
+            langDef.m_keywords.insert(k);
 
         static const char *const identifiers[] = {
             "assert", "collectgarbage", "dofile", "error", "getmetatable", "ipairs", "loadfile", "load", "loadstring", "next", "pairs", "pcall", "print", "rawequal", "rawlen", "rawget", "rawset", "select", "setmetatable", "tonumber", "tostring", "type", "xpcall", "_G", "_VERSION", "arshift", "band", "bnot", "bor", "bxor", "btest", "extract", "lrotate", "lshift", "replace", "rrotate", "rshift", "create", "resume", "running", "status", "wrap", "yield", "isyieldable", "debug", "getuservalue", "gethook", "getinfo", "getlocal", "getregistry", "getmetatable", "getupvalue", "upvaluejoin", "upvalueid", "setuservalue", "sethook", "setlocal", "setmetatable", "setupvalue", "traceback", "close", "flush", "input", "lines", "open", "output", "popen", "read", "tmpfile", "type", "write", "close", "flush", "lines", "read", "seek", "setvbuf", "write", "__gc", "__tostring", "abs", "acos", "asin", "atan", "ceil", "cos", "deg", "exp", "tointeger", "floor", "fmod", "ult", "log", "max", "min", "modf", "rad", "random", "randomseed", "sin", "sqrt", "string", "tan", "type", "atan2", "cosh", "sinh", "tanh", "pow", "frexp", "ldexp", "log10", "pi", "huge", "maxinteger", "mininteger", "loadlib", "searchpath", "seeall", "preload", "cpath", "path", "searchers", "loaded", "module", "require", "clock", "date", "difftime", "execute", "exit", "getenv", "remove", "rename", "setlocale", "time", "tmpname", "byte", "char", "dump", "find", "format", "gmatch", "gsub", "len", "lower", "match", "rep", "reverse", "sub", "upper", "pack", "packsize", "unpack", "concat", "maxn", "insert", "pack", "unpack", "remove", "move", "sort", "offset", "codepoint", "char", "len", "codes", "charpattern", "coroutine", "table", "io", "os", "string", "utf8", "bit32", "math", "debug", "package"
         };
         for (auto &k : identifiers) {
             Identifier id;
-            id.mDeclaration = "Built-in function";
-            langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
+            id.m_declaration = "Built-in function";
+            langDef.m_identifiers.insert(std::make_pair(std::string(k), id));
         }
 
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\\'[^\\\']*\\\'", PaletteIndex::String));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-        langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\\'[^\\\']*\\\'", PaletteIndex::String));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
+        langDef.m_tokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
 
-        langDef.mCommentStart      = "--[[";
-        langDef.mCommentEnd        = "]]";
-        langDef.mSingleLineComment = "--";
+        langDef.m_commentStart      = "--[[";
+        langDef.m_commentEnd        = "]]";
+        langDef.m_singleLineComment = "--";
 
-        langDef.mCaseSensitive   = true;
-        langDef.mAutoIndentation = false;
+        langDef.m_caseSensitive   = true;
+        langDef.m_autoIndentation = false;
 
-        langDef.mName = "Lua";
+        langDef.m_name = "Lua";
 
         inited = true;
     }

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -344,7 +344,7 @@ namespace hex::plugin::builtin {
                     fs::DialogMode::Save, { {"Pattern", "hexpat"} },
                     [this](const auto &path) {
                         wolv::io::File file(path, wolv::io::File::Mode::Create);
-                        file.writeString(wolv::util::trim(m_textEditor.GetText()));
+                        file.writeString(wolv::util::trim(m_textEditor.getText()));
                     }
             );
         };

--- a/plugins/builtin/source/content/themes.cpp
+++ b/plugins/builtin/source/content/themes.cpp
@@ -242,12 +242,12 @@ namespace hex::plugin::builtin {
 
                 ThemeManager::addThemeHandler("text-editor", TextEditorColorMap,
                     [](u32 colorId) -> ImColor {
-                        return TextEditor::GetPalette()[colorId];
+                        return TextEditor::getPalette()[colorId];
                     },
                    [](u32 colorId, ImColor color) {
-                        auto palette = TextEditor::GetPalette();
+                        auto palette = TextEditor::getPalette();
                         palette[colorId] = color;
-                        TextEditor::SetPalette(palette);
+                       TextEditor::setPalette(palette);
                     }
                 );
             }

--- a/plugins/builtin/source/content/tools/demangler.cpp
+++ b/plugins/builtin/source/content/tools/demangler.cpp
@@ -11,25 +11,25 @@
 namespace hex::plugin::builtin {
 
     void drawDemangler() {
-        static std::string mangledName, demangledName, wrappedDemangledName;
         static TextEditor outputField = []{
             TextEditor editor;
-            editor.SetReadOnly(true);
-            editor.SetShowLineNumbers(false);
-            editor.SetShowWhitespaces(false);
-            editor.SetShowCursor(false);
-            editor.SetImGuiChildIgnored(true);
+            editor.setReadOnly(true);
+            editor.setShowLineNumbers(false);
+            editor.setShowWhitespaces(false);
+            editor.setShowCursor(false);
+            editor.setImGuiChildIgnored(true);
 
             auto languageDef = TextEditor::LanguageDefinition::CPlusPlus();
-            for (auto &[name, identifier] : languageDef.mIdentifiers)
-                identifier.mDeclaration = "";
+            for (auto &[name, identifier] : languageDef.m_identifiers)
+                identifier.m_declaration = "";
 
-            editor.SetLanguageDefinition(languageDef);
+            editor.setLanguageDefinition(languageDef);
 
             return editor;
         }();
-        static float prevWindowWidth;
 
+        static float prevWindowWidth;
+        static std::string mangledName,demangledName;
         if (ImGui::InputTextWithHint("hex.builtin.tools.demangler.mangled"_lang, "Itanium, MSVC, Dlang & Rust", mangledName)) {
             demangledName = hex::plugin::builtin::demangle(mangledName);
 
@@ -42,20 +42,20 @@ namespace hex::plugin::builtin {
 
         const auto windowWidth = ImGui::GetContentRegionAvail().x;
         if (prevWindowWidth != windowWidth) {
-            wrappedDemangledName = wolv::util::wrapMonospacedString(
+            static std::string wrappedDemangledName = wolv::util::wrapMonospacedString(
                 demangledName,
                 ImGui::CalcTextSize("M").x,
                 ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ScrollbarSize - ImGui::GetStyle().FrameBorderSize
             );
 
-            outputField.SetText(wrappedDemangledName);
+            outputField.setText(wrappedDemangledName);
             prevWindowWidth = windowWidth;
         }
 
         ImGuiExt::Header("hex.builtin.tools.demangler.demangled"_lang);
 
         if (ImGui::BeginChild("Demangled", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true, ImGuiWindowFlags_NoMove)) {
-            outputField.Render("Demangled", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
+            outputField.render("Demangled", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
         }
         ImGui::EndChild();
     }

--- a/plugins/builtin/source/content/tools/http_requests.cpp
+++ b/plugins/builtin/source/content/tools/http_requests.cpp
@@ -23,29 +23,29 @@ namespace hex::plugin::builtin {
         static std::future<HttpRequest::Result<std::string>> response;
 
         AT_FIRST_TIME {
-            responseEditor.SetReadOnly(true);
-            responseEditor.SetShowLineNumbers(false);
-            responseEditor.SetShowWhitespaces(true);
-            responseEditor.SetShowCursor(false);
+            responseEditor.setReadOnly(true);
+            responseEditor.setShowLineNumbers(false);
+            responseEditor.setShowWhitespaces(true);
+            responseEditor.setShowCursor(false);
 
             auto languageDef = TextEditor::LanguageDefinition();
-            for (auto &[name, identifier] : languageDef.mIdentifiers)
-                identifier.mDeclaration = "";
-            languageDef.mCaseSensitive   = false;
-            languageDef.mAutoIndentation = false;
-            languageDef.mCommentStart = "";
-            languageDef.mCommentEnd = "";
-            languageDef.mSingleLineComment = "";
-            languageDef.mDocComment = "";
-            languageDef.mGlobalDocComment = "";
+            for (auto &[name, identifier] : languageDef.m_identifiers)
+                identifier.m_declaration = "";
+            languageDef.m_caseSensitive   = false;
+            languageDef.m_autoIndentation = false;
+            languageDef.m_commentStart = "";
+            languageDef.m_commentEnd = "";
+            languageDef.m_singleLineComment = "";
+            languageDef.m_docComment = "";
+            languageDef.m_globalDocComment = "";
 
-            responseEditor.SetLanguageDefinition(languageDef);
+            responseEditor.setLanguageDefinition(languageDef);
 
-            bodyEditor.SetShowLineNumbers(true);
-            bodyEditor.SetShowWhitespaces(true);
-            bodyEditor.SetShowCursor(true);
+            bodyEditor.setShowLineNumbers(true);
+            bodyEditor.setShowWhitespaces(true);
+            bodyEditor.setShowCursor(true);
 
-            bodyEditor.SetLanguageDefinition(languageDef);
+            bodyEditor.setLanguageDefinition(languageDef);
         };
 
         constexpr static auto Methods = std::array{
@@ -130,7 +130,7 @@ namespace hex::plugin::builtin {
                     ImGui::EndTabItem();
                 }
                 if (ImGui::BeginTabItem("hex.builtin.tools.http_requests.body"_lang)) {
-                    bodyEditor.Render("Body", ImGui::GetContentRegionAvail(), true);
+                    bodyEditor.render("Body", ImGui::GetContentRegionAvail(), true);
                     ImGui::EndTabItem();
                 }
 
@@ -140,16 +140,16 @@ namespace hex::plugin::builtin {
         ImGui::EndChild();
 
         ImGuiExt::Header("hex.builtin.tools.http_requests.response"_lang);
-        responseEditor.Render("Response", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
+        responseEditor.render("Response", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
 
         if (response.valid() && response.wait_for(0s) != std::future_status::timeout) {
             const auto result = response.get();
             const auto data = result.getData();
 
             if (const auto status = result.getStatusCode(); status != 0)
-                responseEditor.SetText("Status: " + std::to_string(result.getStatusCode()) + "\n\n" + data);
+                responseEditor.setText("Status: " + std::to_string(result.getStatusCode()) + "\n\n" + data);
             else
-                responseEditor.SetText("Status: No Response");
+                responseEditor.setText("Status: No Response");
         }
 
     }

--- a/plugins/builtin/source/content/views/view_bookmarks.cpp
+++ b/plugins/builtin/source/content/views/view_bookmarks.cpp
@@ -490,17 +490,17 @@ namespace hex::plugin::builtin {
                     }
 
                     // Draw comment if the bookmark is locked or an input text box if it's unlocked
-                    editor.SetReadOnly(locked);
-                    editor.SetShowLineNumbers(!locked);
-                    editor.SetShowCursor(!locked);
-                    editor.SetShowWhitespaces(false);
+                    editor.setReadOnly(locked);
+                    editor.setShowLineNumbers(!locked);
+                    editor.setShowCursor(!locked);
+                    editor.setShowWhitespaces(false);
 
-                    if (!locked || (locked && !comment.empty())) {
+                    if (!locked || !comment.empty()) {
                         ImGuiExt::Header("hex.builtin.view.bookmarks.header.comment"_lang);
-                        editor.Render("##comment", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
+                        editor.render("##comment", ImVec2(ImGui::GetContentRegionAvail().x, 150_scaled), true);
 
-                        if (editor.IsTextChanged())
-                            comment = editor.GetText();
+                        if (editor.isTextChanged())
+                            comment = editor.getText();
                     }
 
                     ImGui::NewLine();
@@ -533,7 +533,7 @@ namespace hex::plugin::builtin {
                 continue;
 
             TextEditor editor;
-            editor.SetText(bookmark["comment"]);
+            editor.setText(bookmark["comment"]);
             m_bookmarks.get(provider).push_back({
                 {
                     .region     = { region["address"], region["size"] },
@@ -560,7 +560,7 @@ namespace hex::plugin::builtin {
         for (const auto &[bookmark, editor]  : m_bookmarks.get(provider)) {
             json["bookmarks"][index] = {
                     { "name",       bookmark.name },
-                    { "comment",    editor.GetText() },
+                    { "comment",    editor.getText() },
                     { "color",      bookmark.color },
                     { "region", {
                             { "address",    bookmark.region.address },

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -45,18 +45,18 @@ namespace hex::plugin::builtin {
                 "using", "struct", "union", "enum", "bitfield", "be", "le", "if", "else", "match", "false", "true", "this", "parent", "addressof", "sizeof", "typenameof", "$", "while", "for", "fn", "return", "break", "continue", "namespace", "in", "out", "ref", "null", "const", "unsigned", "signed", "try", "catch", "import", "as"
             };
             for (auto &k : keywords)
-                langDef.mKeywords.insert(k);
+                langDef.m_keywords.insert(k);
 
             constexpr static std::array builtInTypes = {
                 "u8", "u16", "u24", "u32", "u48", "u64", "u96", "u128", "s8", "s16", "s24", "s32", "s48", "s64", "s96", "s128", "float", "double", "char", "char16", "bool", "padding", "str", "auto"
             };
             for (const auto name : builtInTypes) {
                 TextEditor::Identifier id;
-                id.mDeclaration = "";
-                langDef.mIdentifiers.insert(std::make_pair(std::string(name), id));
+                id.m_declaration = "";
+                langDef.m_identifiers.insert(std::make_pair(std::string(name), id));
             }
 
-            langDef.mTokenize = [](const char *inBegin, const char *inEnd, const char *&outBegin, const char *&outEnd, TextEditor::PaletteIndex &paletteIndex) -> bool {
+            langDef.m_tokenize = [](const char *inBegin, const char *inEnd, const char *&outBegin, const char *&outEnd, TextEditor::PaletteIndex &paletteIndex) -> bool {
                 paletteIndex = TextEditor::PaletteIndex::Max;
 
                 while (inBegin < inEnd && isascii(*inBegin) && std::isblank(*inBegin))
@@ -66,31 +66,31 @@ namespace hex::plugin::builtin {
                     outBegin     = inEnd;
                     outEnd       = inEnd;
                     paletteIndex = TextEditor::PaletteIndex::Default;
-                } else if (TokenizeCStyleIdentifier(inBegin, inEnd, outBegin, outEnd)) {
+                } else if (tokenizeCStyleIdentifier(inBegin, inEnd, outBegin, outEnd)) {
                     paletteIndex = TextEditor::PaletteIndex::Identifier;
-                } else if (TokenizeCStyleNumber(inBegin, inEnd, outBegin, outEnd)) {
+                } else if (tokenizeCStyleNumber(inBegin, inEnd, outBegin, outEnd)) {
                     paletteIndex = TextEditor::PaletteIndex::Number;
-                } else if (TokenizeCStyleCharacterLiteral(inBegin, inEnd, outBegin, outEnd)) {
+                } else if (tokenizeCStyleCharacterLiteral(inBegin, inEnd, outBegin, outEnd)) {
                     paletteIndex = TextEditor::PaletteIndex::CharLiteral;
-                } else if (TokenizeCStyleString(inBegin, inEnd, outBegin, outEnd)) {
+                } else if (tokenizeCStyleString(inBegin, inEnd, outBegin, outEnd)) {
                     paletteIndex = TextEditor::PaletteIndex::String;
                 }
 
                 return paletteIndex != TextEditor::PaletteIndex::Max;
             };
 
-            langDef.mCommentStart      = "/*";
-            langDef.mCommentEnd        = "*/";
-            langDef.mSingleLineComment = "//";
+            langDef.m_commentStart      = "/*";
+            langDef.m_commentEnd        = "*/";
+            langDef.m_singleLineComment = "//";
 
-            langDef.mCaseSensitive   = true;
-            langDef.mAutoIndentation = true;
-            langDef.mPreprocChar     = '#';
+            langDef.m_caseSensitive   = true;
+            langDef.m_autoIndentation = true;
+            langDef.m_preprocChar     = '#';
 
-            langDef.mGlobalDocComment = "/*!";
-            langDef.mDocComment      = "/**";
+            langDef.m_globalDocComment = "/*!";
+            langDef.m_docComment      = "/**";
 
-            langDef.mName = "Pattern Language";
+            langDef.m_name = "Pattern Language";
 
             initialized = true;
         }
@@ -102,7 +102,7 @@ namespace hex::plugin::builtin {
         static bool initialized = false;
         static TextEditor::LanguageDefinition langDef;
         if (!initialized) {
-            langDef.mTokenize = [](const char *inBegin, const char *inEnd, const char *&outBegin, const char *&outEnd, TextEditor::PaletteIndex &paletteIndex) -> bool {
+            langDef.m_tokenize = [](const char *inBegin, const char *inEnd, const char *&outBegin, const char *&outEnd, TextEditor::PaletteIndex &paletteIndex) -> bool {
                 if (std::string_view(inBegin).starts_with("D: "))
                     paletteIndex = TextEditor::PaletteIndex::Comment;
                 else if (std::string_view(inBegin).starts_with("I: "))
@@ -120,14 +120,14 @@ namespace hex::plugin::builtin {
                 return true;
             };
 
-            langDef.mName = "Console Log";
-            langDef.mCaseSensitive   = false;
-            langDef.mAutoIndentation = false;
-            langDef.mCommentStart = "";
-            langDef.mCommentEnd = "";
-            langDef.mSingleLineComment = "";
-            langDef.mDocComment = "";
-            langDef.mGlobalDocComment = "";
+            langDef.m_name = "Console Log";
+            langDef.m_caseSensitive   = false;
+            langDef.m_autoIndentation = false;
+            langDef.m_commentStart = "";
+            langDef.m_commentEnd = "";
+            langDef.m_singleLineComment = "";
+            langDef.m_docComment = "";
+            langDef.m_globalDocComment = "";
 
             initialized = true;
         }
@@ -189,14 +189,14 @@ namespace hex::plugin::builtin {
         m_editorRuntime = std::make_unique<pl::PatternLanguage>();
         ContentRegistry::PatternLanguage::configureRuntime(*m_editorRuntime, nullptr);
 
-        m_textEditor.SetLanguageDefinition(PatternLanguage());
-        m_textEditor.SetShowWhitespaces(false);
+        m_textEditor.setLanguageDefinition(PatternLanguage());
+        m_textEditor.setShowWhitespaces(false);
 
-        m_consoleEditor.SetLanguageDefinition(ConsoleLog());
-        m_consoleEditor.SetShowWhitespaces(false);
-        m_consoleEditor.SetReadOnly(true);
-        m_consoleEditor.SetShowCursor(false);
-        m_consoleEditor.SetShowLineNumbers(false);
+        m_consoleEditor.setLanguageDefinition(ConsoleLog());
+        m_consoleEditor.setShowWhitespaces(false);
+        m_consoleEditor.setReadOnly(true);
+        m_consoleEditor.setShowCursor(false);
+        m_consoleEditor.setShowLineNumbers(false);
 
         this->registerEvents();
         this->registerMenuItems();
@@ -229,8 +229,8 @@ namespace hex::plugin::builtin {
             if (availableSize.y > 1)
                 textEditorSize.y = std::clamp(textEditorSize.y, 1.0F, std::max(1.0F, availableSize.y - ImGui::GetTextLineHeightWithSpacing() * 3));
 
-            m_textEditor.Render("hex.builtin.view.pattern_editor.name"_lang, textEditorSize, true);
-            TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.GetFindReplaceHandler();
+            m_textEditor.render("hex.builtin.view.pattern_editor.name"_lang, textEditorSize, true);
+            TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.getFindReplaceHandler();
             if (ImGui::IsMouseDown(ImGuiMouseButton_Right) && ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) && !ImGui::IsMouseDragging(ImGuiMouseButton_Right)) {
                 ImGui::OpenPopup("##pattern_editor_context_menu");
             }
@@ -246,48 +246,48 @@ namespace hex::plugin::builtin {
 
                 ImGui::Separator();
 
-                const bool hasSelection = m_textEditor.HasSelection();
+                const bool hasSelection = m_textEditor.hasSelection();
                 if (ImGui::MenuItem("hex.builtin.view.hex_editor.menu.edit.cut"_lang, Shortcut(CTRLCMD + Keys::X).toString().c_str(), false, hasSelection)) {
-                    m_textEditor.Cut();
+                    m_textEditor.cut();
                 }
                 if (ImGui::MenuItem("hex.builtin.view.hex_editor.menu.edit.copy"_lang, Shortcut(CTRLCMD + Keys::C).toString().c_str(), false, hasSelection)) {
-                    m_textEditor.Copy();
+                    m_textEditor.copy();
                 }
                 if (ImGui::MenuItem("hex.builtin.view.hex_editor.menu.edit.paste"_lang, Shortcut(CTRLCMD + Keys::V).toString().c_str())) {
-                    m_textEditor.Paste();
+                    m_textEditor.paste();
                 }
 
                 ImGui::Separator();
 
-                if (ImGui::MenuItem("hex.builtin.menu.edit.undo"_lang, Shortcut(CTRLCMD + Keys::Z).toString().c_str(), false, m_textEditor.CanUndo())) {
-                    m_textEditor.Undo();
+                if (ImGui::MenuItem("hex.builtin.menu.edit.undo"_lang, Shortcut(CTRLCMD + Keys::Z).toString().c_str(), false,m_textEditor.canUndo())) {
+                    m_textEditor.undo();
                 }
-                if (ImGui::MenuItem("hex.builtin.menu.edit.redo"_lang, Shortcut(CTRLCMD + Keys::Y).toString().c_str(), false, m_textEditor.CanRedo())) {
-                    m_textEditor.Redo();
+                if (ImGui::MenuItem("hex.builtin.menu.edit.redo"_lang, Shortcut(CTRLCMD + Keys::Y).toString().c_str(), false,m_textEditor.canRedo())) {
+                    m_textEditor.redo();
                 }
 
                 ImGui::Separator();
                 // Search and replace entries
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str(),false,this->m_textEditor.HasSelection()))
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str(),false,this->m_textEditor.hasSelection()))
                     clickedMenuFind = true;
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find_next"_lang, Shortcut(Keys::F3).toString().c_str(),false,!findReplaceHandler->GetFindWord().empty()))
-                    findReplaceHandler->FindMatch(&m_textEditor,true);
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find_next"_lang, Shortcut(Keys::F3).toString().c_str(),false,!findReplaceHandler->getFindWord().empty()))
+                    findReplaceHandler->findMatch(&m_textEditor, true);
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find_previous"_lang, Shortcut(SHIFT + Keys::F3).toString().c_str(),false,!findReplaceHandler->GetFindWord().empty()))
-                    findReplaceHandler->FindMatch(&m_textEditor,false);
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find_previous"_lang, Shortcut(SHIFT + Keys::F3).toString().c_str(),false,!findReplaceHandler->getFindWord().empty()))
+                    findReplaceHandler->findMatch(&m_textEditor, false);
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace"_lang, Shortcut(CTRLCMD +  Keys::H).toString().c_str(),false,!findReplaceHandler->GetReplaceWord().empty()))
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace"_lang, Shortcut(CTRLCMD +  Keys::H).toString().c_str(),false,!findReplaceHandler->getReplaceWord().empty()))
                     clickedMenuReplace = true;
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_next"_lang,"",false,!findReplaceHandler->GetReplaceWord().empty()))
-                    findReplaceHandler->Replace(&m_textEditor,true);
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_next"_lang,"",false,!findReplaceHandler->getReplaceWord().empty()))
+                    findReplaceHandler->replace(&m_textEditor,true);
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_previous"_lang, "",false,!findReplaceHandler->GetReplaceWord().empty()))
-                    findReplaceHandler->Replace(&m_textEditor,false);
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_previous"_lang, "",false,!findReplaceHandler->getReplaceWord().empty()))
+                    findReplaceHandler->replace(&m_textEditor,false);
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_all"_lang, "",false,!findReplaceHandler->GetReplaceWord().empty()))
-                    findReplaceHandler->ReplaceAll(&m_textEditor);
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace_all"_lang, "",false,!findReplaceHandler->getReplaceWord().empty()))
+                    findReplaceHandler->replaceAll(&m_textEditor);
 
                 ImGui::EndPopup();
             }
@@ -339,7 +339,7 @@ namespace hex::plugin::builtin {
                 float scrollbarSize = 0;
 
                 // Calculate the number of lines to display in the text editor
-                auto totalTextHeight =  m_textEditor.GetTotalLines() * m_textEditor.GetCharAdvance().y;
+                auto totalTextHeight = m_textEditor.getTotalLines() * m_textEditor.getCharAdvance().y;
 
                 // Compare it to the window height
                 if (totalTextHeight > windowSize.y)
@@ -372,7 +372,7 @@ namespace hex::plugin::builtin {
 
                 // Move to the right so as not to overlap the scrollbar
                 windowPosForPopup.x += windowSize.x - popupSize.x;
-                findReplaceHandler->SetFindWindowPos(windowPosForPopup);
+                findReplaceHandler->setFindWindowPos(windowPosForPopup);
 
                 if (m_replaceMode) {
                     // Remove one window padding
@@ -388,16 +388,16 @@ namespace hex::plugin::builtin {
                 findReplaceHandler->resetMatches();
 
                 // Use selection as find word if there is one, otherwise use the word under the cursor
-                if (!this->m_textEditor.HasSelection())
-                    this->m_textEditor.SelectWordUnderCursor();
+                if (!this->m_textEditor.hasSelection())
+                    this->m_textEditor.selectWordUnderCursor();
 
-                findWord = this->m_textEditor.GetSelectedText();
+                findWord = this->m_textEditor.getSelectedText();
 
                 // Find all matches to findWord
-                findReplaceHandler->FindAllMatches(&m_textEditor,findWord);
-                position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
-                count = findReplaceHandler->GetMatches().size();
-                findReplaceHandler->SetFindWord(&m_textEditor,findWord);
+                findReplaceHandler->findAllMatches(&m_textEditor, findWord);
+                position = findReplaceHandler->findPosition(&m_textEditor, m_textEditor.getCursorPosition(), true);
+                count = findReplaceHandler->getMatches().size();
+                findReplaceHandler->setFindWord(&m_textEditor, findWord);
                 requestFocus = true;
                 updateCount = true;
             }
@@ -474,7 +474,7 @@ namespace hex::plugin::builtin {
                 } else {
                     if (ImGuiExt::IconButton(ICON_VS_DEBUG_START, ImGuiExt::GetCustomColorVec4(ImGuiCustomCol_ToolbarGreen)) || m_triggerEvaluation) {
                         m_triggerEvaluation = false;
-                        this->evaluatePattern(m_textEditor.GetText(), provider);
+                        this->evaluatePattern(m_textEditor.getText(), provider);
                     }
                 }
 
@@ -547,7 +547,7 @@ namespace hex::plugin::builtin {
                 }
             }
 
-            if (m_textEditor.IsTextChanged()) {
+            if (m_textEditor.isTextChanged()) {
                 m_hasUnevaluatedChanges = true;
                 m_lastEditorChangeTime = std::chrono::steady_clock::now();
                 ImHexApi::Provider::markDirty();
@@ -557,7 +557,7 @@ namespace hex::plugin::builtin {
                 if ((std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1)) {
                     m_hasUnevaluatedChanges = false;
 
-                    auto code = m_textEditor.GetText();
+                    auto code = m_textEditor.getText();
                     EventPatternEditorChanged::post(code);
 
                     TaskManager::createBackgroundTask("hex.builtin.task.parsing_pattern"_lang, [this, code = std::move(code), provider](auto &){
@@ -570,7 +570,7 @@ namespace hex::plugin::builtin {
             }
 
             if (m_triggerAutoEvaluate.exchange(false)) {
-                this->evaluatePattern(m_textEditor.GetText(), provider);
+                this->evaluatePattern(m_textEditor.getText(), provider);
             }
         }
 
@@ -606,16 +606,13 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::drawFindReplaceDialog(std::string &findWord, bool &requestFocus, u64 &position, u64 &count, bool &updateCount) {
-        static std::string replaceWord;
 
-        TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.GetFindReplaceHandler();
-        static bool requestFocusReplace = false;
-        static bool requestFocusFind = false;
+        TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.getFindReplaceHandler();
 
-        static bool downArrowFind = false;
-        static bool upArrowFind = false;
-        static bool downArrowReplace = false;
-        static bool upArrowReplace = false;
+
+
+
+
         static bool enterPressedFind = false;
 
         bool enter     = ImGui::IsKeyPressed(ImGuiKey_Enter, false)         || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter, false);
@@ -633,6 +630,8 @@ namespace hex::plugin::builtin {
 
                 bool oldReplace = m_replaceMode;
                 ImGuiExt::DimmedIconToggle(ICON_VS_TRIANGLE_DOWN, ICON_VS_TRIANGLE_RIGHT, &m_replaceMode);
+                static bool requestFocusReplace = false;
+                static bool requestFocusFind = false;
                 if (oldReplace != m_replaceMode) {
                     if (m_replaceMode)
                         requestFocusReplace = true;
@@ -664,11 +663,10 @@ namespace hex::plugin::builtin {
                 if (ImGui::InputTextWithHint("###findInputTextWidget", hint.c_str(), findWord, findFlags) || enter ) {
                     if (enter) {
                         enterPressedFind = true;
-                        enter = false;
                     }
                     updateCount = true;
                     requestFocusFind = true;
-                    findReplaceHandler->SetFindWord(&m_textEditor,findWord);
+                    findReplaceHandler->setFindWord(&m_textEditor, findWord);
                 }
 
                 if ((!m_replaceMode && requestFocus) || requestFocusFind) {
@@ -686,9 +684,9 @@ namespace hex::plugin::builtin {
                         m_findHistoryIndex = (m_findHistoryIndex + 1) % m_findHistorySize;
 
                     findWord = m_findHistory[m_findHistoryIndex];
-                    findReplaceHandler->SetFindWord(&m_textEditor,findWord);
-                    position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
-                    count = findReplaceHandler->GetMatches().size();
+                    findReplaceHandler->setFindWord(&m_textEditor, findWord);
+                    position = findReplaceHandler->findPosition(&m_textEditor, m_textEditor.getCursorPosition(), true);
+                    count = findReplaceHandler->getMatches().size();
                     updateCount = true;
                     requestFocusFind = true;
                 }
@@ -696,48 +694,48 @@ namespace hex::plugin::builtin {
 
                 ImGui::SameLine();
 
-                bool matchCase = findReplaceHandler->GetMatchCase();
+                bool matchCase = findReplaceHandler->getMatchCase();
 
                 // Allow Alt-C to toggle case sensitivity
                 bool altCPressed = ImGui::IsKeyPressed(ImGuiKey_C, false) && alt;
                 if (altCPressed || ImGuiExt::DimmedIconToggle(ICON_VS_CASE_SENSITIVE, &matchCase)) {
                     if (altCPressed)
                         matchCase = !matchCase;
-                    findReplaceHandler->SetMatchCase(&m_textEditor,matchCase);
-                    position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
-                    count = findReplaceHandler->GetMatches().size();
+                    findReplaceHandler->setMatchCase(&m_textEditor, matchCase);
+                    position = findReplaceHandler->findPosition(&m_textEditor, m_textEditor.getCursorPosition(), true);
+                    count = findReplaceHandler->getMatches().size();
                     updateCount = true;
                     requestFocusFind = true;
                 }
 
                 ImGui::SameLine();
 
-                bool matchWholeWord = findReplaceHandler->GetWholeWord();
+                bool matchWholeWord = findReplaceHandler->getWholeWord();
 
                 // Allow Alt-W to toggle whole word
                 bool altWPressed = ImGui::IsKeyPressed(ImGuiKey_W, false) && alt;
                 if (altWPressed || ImGuiExt::DimmedIconToggle(ICON_VS_WHOLE_WORD, &matchWholeWord)) {
                     if (altWPressed)
                         matchWholeWord = !matchWholeWord;
-                    findReplaceHandler->SetWholeWord(&m_textEditor,matchWholeWord);
-                    position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
-                    count = findReplaceHandler->GetMatches().size();
+                    findReplaceHandler->setWholeWord(&m_textEditor, matchWholeWord);
+                    position = findReplaceHandler->findPosition(&m_textEditor, m_textEditor.getCursorPosition(), true);
+                    count = findReplaceHandler->getMatches().size();
                     updateCount = true;
                     requestFocusFind = true;
                 }
 
                 ImGui::SameLine();
 
-                bool useRegex = findReplaceHandler->GetFindRegEx();
+                bool useRegex = findReplaceHandler->getFindRegEx();
 
                 // Allow Alt-R to toggle regex
                 bool altRPressed = ImGui::IsKeyPressed(ImGuiKey_R, false) && alt;
                 if (altRPressed || ImGuiExt::DimmedIconToggle(ICON_VS_REGEX, &useRegex)) {
                     if (altRPressed)
                         useRegex = !useRegex;
-                    findReplaceHandler->SetFindRegEx(&m_textEditor,useRegex);
-                    position = findReplaceHandler->FindPosition(&m_textEditor,m_textEditor.GetCursorPosition(), true);
-                    count = findReplaceHandler->GetMatches().size();
+                    findReplaceHandler->setFindRegEx(&m_textEditor, useRegex);
+                    position = findReplaceHandler->findPosition(&m_textEditor, m_textEditor.getCursorPosition(), true);
+                    count = findReplaceHandler->getMatches().size();
                     updateCount = true;
                     requestFocusFind = true;
                 }
@@ -777,10 +775,12 @@ namespace hex::plugin::builtin {
                 ImGui::InvisibleButton("##find_result_padding", buttonSize);
 
                 ImGui::SameLine();
+                static bool downArrowFind = false;
                 if (ImGuiExt::IconButton(ICON_VS_ARROW_DOWN, ImVec4(1, 1, 1, 1)))
                     downArrowFind = true;
 
                 ImGui::SameLine();
+                static bool upArrowFind = false;
                 if (ImGuiExt::IconButton(ICON_VS_ARROW_UP, ImVec4(1, 1, 1, 1)))
                     upArrowFind = true;
 
@@ -803,11 +803,14 @@ namespace hex::plugin::builtin {
                     }
 
                     ImGui::PushItemWidth(ImGui::GetFontSize() * 12);
+                    static std::string replaceWord;
+                    static bool downArrowReplace = false;
+                    static bool upArrowReplace = false;
                     if (ImGui::InputTextWithHint("##replaceInputTextWidget", hint.c_str(), replaceWord, replaceFlags) || downArrowReplace || upArrowReplace) {
-                        findReplaceHandler->SetReplaceWord(replaceWord);
+                        findReplaceHandler->setReplaceWord(replaceWord);
                         historyInsert(m_replaceHistory, m_replaceHistorySize, m_replaceHistoryIndex, replaceWord);
 
-                        bool textReplaced = findReplaceHandler->Replace(&m_textEditor,!shift && !upArrowReplace);
+                        bool textReplaced = findReplaceHandler->replace(&m_textEditor,!shift && !upArrowReplace);
                         if (textReplaced) {
                             if (count > 0) {
                                 if (position == count)
@@ -844,7 +847,7 @@ namespace hex::plugin::builtin {
                             m_replaceHistoryIndex = (m_replaceHistoryIndex + 1) % m_replaceHistorySize;
 
                         replaceWord = m_replaceHistory[m_replaceHistoryIndex];
-                        findReplaceHandler->SetReplaceWord(replaceWord);
+                        findReplaceHandler->setReplaceWord(replaceWord);
 
                         requestFocusReplace = true;
                     }
@@ -861,22 +864,22 @@ namespace hex::plugin::builtin {
 
                     ImGui::SameLine();
                     if (ImGuiExt::IconButton(ICON_VS_REPLACE_ALL, ImVec4(1, 1, 1, 1))) {
-                        findReplaceHandler->SetReplaceWord(replaceWord);
+                        findReplaceHandler->setReplaceWord(replaceWord);
                         historyInsert(m_replaceHistory,m_replaceHistorySize, m_replaceHistoryIndex, replaceWord);
-                        findReplaceHandler->ReplaceAll(&m_textEditor);
+                        findReplaceHandler->replaceAll(&m_textEditor);
                         count = 0;
                         position = 0;
                         requestFocusFind = true;
                         updateCount = true;
                     }
-                    findReplaceHandler->SetFindWindowSize(ImGui::GetWindowSize());
+                    findReplaceHandler->setFindWindowSize(ImGui::GetWindowSize());
                 } else
-                    findReplaceHandler->SetFindWindowSize(ImGui::GetWindowSize());
+                    findReplaceHandler->setFindWindowSize(ImGui::GetWindowSize());
 
                 if ((ImGui::IsKeyPressed(ImGuiKey_F3, false)) || downArrowFind || upArrowFind || enterPressedFind) {
                     historyInsert(m_findHistory, m_findHistorySize, m_findHistoryIndex, findWord);
-                    position = findReplaceHandler->FindMatch(&m_textEditor,!shift && !upArrowFind);
-                    count = findReplaceHandler->GetMatches().size();
+                    position = findReplaceHandler->findMatch(&m_textEditor, !shift && !upArrowFind);
+                    count = findReplaceHandler->getMatches().size();
                     updateCount = true;
                     downArrowFind = false;
                     upArrowFind = false;
@@ -898,24 +901,24 @@ namespace hex::plugin::builtin {
         if (m_consoleNeedsUpdate) {
             std::scoped_lock lock(m_logMutex);
 
-            auto lineCount = m_consoleEditor.GetTextLines().size() - 1;
+            auto lineCount = m_consoleEditor.getTextLines().size() - 1;
             if (m_console->size() < lineCount) {
-                m_consoleEditor.SetText("");
+                m_consoleEditor.setText("");
                 lineCount = 0;
             }
 
-            m_consoleEditor.SetCursorPosition({ int(lineCount + 1), 0 });
+            m_consoleEditor.setCursorPosition({int(lineCount + 1), 0});
 
             const auto linesToAdd = m_console->size() - lineCount;
             for (size_t i = 0; i < linesToAdd; i += 1) {
-                m_consoleEditor.InsertText(m_console->at(lineCount + i));
-                m_consoleEditor.InsertText("\n");
+                m_consoleEditor.insertText(m_console->at(lineCount + i));
+                m_consoleEditor.insertText("\n");
             }
 
             m_consoleNeedsUpdate = false;
         }
 
-        m_consoleEditor.Render("##console", size, true);
+        m_consoleEditor.render("##console", size, true);
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImGui::GetStyle().FramePadding.y + 1_scaled);
     }
 
@@ -1207,18 +1210,18 @@ namespace hex::plugin::builtin {
 
         if (ImGui::BeginChild("##debugger", size, true)) {
             const auto &breakpoints = evaluator->getBreakpoints();
-            const auto line = m_textEditor.GetCursorPosition().mLine + 1;
+            const auto line = m_textEditor.getCursorPosition().m_line + 1;
 
             if (!breakpoints.contains(line)) {
                 if (ImGuiExt::IconButton(ICON_VS_DEBUG_BREAKPOINT, ImGuiExt::GetCustomColorVec4(ImGuiCustomCol_ToolbarRed))) {
                     evaluator->addBreakpoint(line);
-                    m_textEditor.SetBreakpoints(breakpoints);
+                    m_textEditor.setBreakpoints(breakpoints);
                 }
                 ImGuiExt::InfoTooltip("hex.builtin.view.pattern_editor.debugger.add_tooltip"_lang);
             } else {
                 if (ImGuiExt::IconButton(ICON_VS_DEBUG_BREAKPOINT_UNVERIFIED, ImGuiExt::GetCustomColorVec4(ImGuiCustomCol_ToolbarRed))) {
                     evaluator->removeBreakpoint(line);
-                    m_textEditor.SetBreakpoints(breakpoints);
+                    m_textEditor.setBreakpoints(breakpoints);
                 }
                 ImGuiExt::InfoTooltip("hex.builtin.view.pattern_editor.debugger.remove_tooltip"_lang);
             }
@@ -1258,10 +1261,10 @@ namespace hex::plugin::builtin {
 
                     (*m_debuggerDrawer)->reset();
                     m_resetDebuggerVariables = false;
-                    m_textEditor.SetCursorPosition(TextEditor::Coordinates(pauseLine.value_or(0) - 1, 0));
+                    m_textEditor.setCursorPosition(TextEditor::Coordinates(pauseLine.value_or(0) - 1, 0));
 
                     if (pauseLine.has_value())
-                        m_textEditor.SetCursorPosition({ int(pauseLine.value() - 1), 0 });
+                        m_textEditor.setCursorPosition({int(pauseLine.value() - 1), 0});
                 }
 
                 const auto &currScope = evaluator->getScope(-m_debuggerScopeIndex);
@@ -1316,7 +1319,7 @@ namespace hex::plugin::builtin {
                     }
                 }
 
-                m_textEditor.SetErrorMarkers(errorMarkers);
+                m_textEditor.setErrorMarkers(errorMarkers);
             } else {
                 for (auto &[name, variable] : *m_patternVariables) {
                     if (variable.outVariable && m_lastEvaluationOutVars->contains(name))
@@ -1484,7 +1487,7 @@ namespace hex::plugin::builtin {
             const bool shiftHeld = ImGui::GetIO().KeyShift;
             ImGui::ColorButton(pattern->getVariableName().c_str(), ImColor(pattern->getColor()));
             ImGui::SameLine(0, 10);
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{} ", pattern->getFormattedName());
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{} ", pattern->getFormattedName());
             ImGui::SameLine(0, 5);
             ImGuiExt::TextFormatted("{}", pattern->getDisplayName());
             ImGui::SameLine();
@@ -1606,7 +1609,7 @@ namespace hex::plugin::builtin {
             auto code = file.readString();
 
             this->evaluatePattern(code, provider);
-            m_textEditor.SetText(code);
+            m_textEditor.setText(code);
             m_sourceCode.set(provider, code);
 
             TaskManager::createBackgroundTask("hex.builtin.task.parsing_pattern"_lang, [this, code, provider](auto&) { this->parsePattern(code, provider); });
@@ -1661,12 +1664,12 @@ namespace hex::plugin::builtin {
         *m_executionDone = false;
 
 
-        m_textEditor.SetErrorMarkers({});
+        m_textEditor.setErrorMarkers({});
         m_console->clear();
         m_consoleNeedsUpdate = true;
 
         m_sectionWindowDrawer.clear();
-        m_consoleEditor.SetText("");
+        m_consoleEditor.setText("");
         m_virtualFiles->clear();
 
         m_accessHistory = {};
@@ -1766,7 +1769,7 @@ namespace hex::plugin::builtin {
     void ViewPatternEditor::registerEvents() {
         RequestPatternEditorSelectionChange::subscribe(this, [this](u32 line, u32 column) {
             const TextEditor::Coordinates coords = { int(line) - 1, int(column) };
-            m_textEditor.SetCursorPosition(coords);
+            m_textEditor.setCursorPosition(coords);
         });
 
         RequestLoadPatternLanguageFile::subscribe(this, [this](const std::fs::path &path) {
@@ -1779,11 +1782,11 @@ namespace hex::plugin::builtin {
 
         RequestSavePatternLanguageFile::subscribe(this, [this](const std::fs::path &path) {
             wolv::io::File file(path, wolv::io::File::Mode::Create);
-            file.writeString(wolv::util::trim(m_textEditor.GetText()));
+            file.writeString(wolv::util::trim(m_textEditor.getText()));
         });
 
         RequestSetPatternLanguageCode::subscribe(this, [this](const std::string &code) {
-            m_textEditor.SetText(code);
+            m_textEditor.setText(code);
             m_sourceCode.set(ImHexApi::Provider::get(), code);
             m_hasUnevaluatedChanges = true;
         });
@@ -1804,12 +1807,12 @@ namespace hex::plugin::builtin {
 
         EventProviderChanged::subscribe(this, [this](prv::Provider *oldProvider, prv::Provider *newProvider) {
             if (oldProvider != nullptr)
-                m_sourceCode.set(oldProvider, m_textEditor.GetText());
+                m_sourceCode.set(oldProvider, m_textEditor.getText());
 
             if (newProvider != nullptr)
-                m_textEditor.SetText(m_sourceCode.get(newProvider));
+                m_textEditor.setText(m_sourceCode.get(newProvider));
             else
-                m_textEditor.SetText("");
+                m_textEditor.setText("");
         });
 
         RequestAddVirtualFile::subscribe(this, [this](const std::fs::path &path, const std::vector<u8> &data, Region region) {
@@ -1833,8 +1836,8 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::appendEditorText(const std::string &text) {
-        m_textEditor.SetCursorPosition(TextEditor::Coordinates { m_textEditor.GetTotalLines(), 0 });
-        m_textEditor.InsertText(hex::format("\n{0}", text));
+        m_textEditor.setCursorPosition(TextEditor::Coordinates{m_textEditor.getTotalLines(), 0});
+        m_textEditor.insertText(hex::format("\n{0}", text));
         m_triggerEvaluation = true;
     }
 
@@ -1859,7 +1862,7 @@ namespace hex::plugin::builtin {
         /* Export Pattern */
         ContentRegistry::Interface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.pattern" }, ICON_VS_FILE_CODE, 7050, Shortcut::None,
                                                 m_exportPatternFile, [this] {
-                                                    return !wolv::util::trim(m_textEditor.GetText()).empty() && ImHexApi::Provider::isValid();
+                                                    return !wolv::util::trim(m_textEditor.getText()).empty() && ImHexApi::Provider::isValid();
                                                 }
         );
 
@@ -2020,7 +2023,7 @@ namespace hex::plugin::builtin {
                 m_sourceCode.set(provider, sourceCode);
 
                 if (provider == ImHexApi::Provider::get())
-                    m_textEditor.SetText(sourceCode);
+                    m_textEditor.setText(sourceCode);
 
                 m_hasUnevaluatedChanges = true;
 
@@ -2028,7 +2031,7 @@ namespace hex::plugin::builtin {
             },
             .store = [this](prv::Provider *provider, const std::fs::path &basePath, const Tar &tar) {
                 if (provider == ImHexApi::Provider::get())
-                    m_sourceCode.set(provider, m_textEditor.GetText());
+                    m_sourceCode.set(provider, m_textEditor.getText());
 
                 const auto &sourceCode = m_sourceCode.get(provider);
 
@@ -2038,7 +2041,7 @@ namespace hex::plugin::builtin {
         });
 
         ShortcutManager::addShortcut(this, Keys::F8 + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.add_breakpoint", [this] {
-            const auto line = m_textEditor.GetCursorPosition().mLine + 1;
+            const auto line = m_textEditor.getCursorPosition().m_line + 1;
             const auto &runtime = ContentRegistry::PatternLanguage::getRuntime();
 
             auto &evaluator = runtime.getInternals().evaluator;
@@ -2050,7 +2053,7 @@ namespace hex::plugin::builtin {
                 evaluator->addBreakpoint(line);
             }
 
-            m_textEditor.SetBreakpoints(breakpoints);
+            m_textEditor.setBreakpoints(breakpoints);
         });
 
         /* Trigger evaluation */

--- a/plugins/ui/source/ui/pattern_drawer.cpp
+++ b/plugins/ui/source/ui/pattern_drawer.cpp
@@ -96,7 +96,7 @@ namespace hex::ui {
 
         void drawTypeNameColumn(const pl::ptrn::Pattern& pattern, const std::string& structureTypeName) {
             ImGui::TableNextColumn();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Keyword)], structureTypeName);
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Keyword)], structureTypeName);
             ImGui::SameLine();
             ImGui::TextUnformatted(pattern.getTypeName().c_str());
         }
@@ -516,7 +516,7 @@ namespace hex::ui {
 
         // Draw type column
         ImGui::TableNextColumn();
-        ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{}", pattern.getFormattedName().empty() ? pattern.getTypeName() : pattern.getFormattedName());
+        ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{}", pattern.getFormattedName().empty() ? pattern.getTypeName() : pattern.getFormattedName());
     }
 
     void PatternDrawer::closeTreeNode(bool inlined) const {
@@ -541,21 +541,21 @@ namespace hex::ui {
         ImGui::TableNextColumn();
 
         if (dynamic_cast<pl::ptrn::PatternBitfieldFieldSigned*>(&pattern) != nullptr) {
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Keyword)], "signed");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Keyword)], "signed");
             ImGui::SameLine();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], pattern.getBitSize() == 1 ? "bit" : "bits");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], pattern.getBitSize() == 1 ? "bit" : "bits");
         } else if (dynamic_cast<pl::ptrn::PatternBitfieldFieldEnum*>(&pattern) != nullptr) {
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Keyword)], "enum");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Keyword)], "enum");
             ImGui::SameLine();
             ImGui::TextUnformatted(pattern.getTypeName().c_str());
         } else if (dynamic_cast<pl::ptrn::PatternBitfieldFieldBoolean*>(&pattern) != nullptr) {
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "bool");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "bool");
             ImGui::SameLine();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "bit");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "bit");
         } else {
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Keyword)], "unsigned");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Keyword)], "unsigned");
             ImGui::SameLine();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], pattern.getBitSize() == 1 ? "bit" : "bits");
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], pattern.getBitSize() == 1 ? "bit" : "bits");
         }
 
         if (!this->isEditingPattern(pattern)) {
@@ -787,7 +787,7 @@ namespace hex::ui {
             drawOffsetColumns(pattern);
             drawSizeColumn(pattern);
             ImGui::TableNextColumn();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{}", pattern.getFormattedName());
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{}", pattern.getFormattedName());
             drawValueColumn(pattern);
             drawCommentColumn(pattern);
         }
@@ -1016,12 +1016,12 @@ namespace hex::ui {
             drawSizeColumn(pattern);
 
             ImGui::TableNextColumn();
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{0}", pattern.getTypeName());
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{0}", pattern.getTypeName());
             ImGui::SameLine(0, 0);
 
             ImGui::TextUnformatted("[");
             ImGui::SameLine(0, 0);
-            ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Number)], "{0}", iterable.getEntryCount());
+            ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Number)], "{0}", iterable.getEntryCount());
             ImGui::SameLine(0, 0);
             ImGui::TextUnformatted("]");
 
@@ -1084,12 +1084,12 @@ namespace hex::ui {
                 ImGui::TableNextColumn();
                 ImGuiExt::TextFormatted("{0} {1}", chunkSize, chunkSize == 1 ? "byte" : "bytes");
                 ImGui::TableNextColumn();
-                ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{0}", pattern.getTypeName());
+                ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::KnownIdentifier)], "{0}", pattern.getTypeName());
                 ImGui::SameLine(0, 0);
 
                 ImGui::TextUnformatted("[");
                 ImGui::SameLine(0, 0);
-                ImGuiExt::TextFormattedColored(TextEditor::GetPalette()[u32(TextEditor::PaletteIndex::Number)], "{0}", endIndex - i);
+                ImGuiExt::TextFormattedColored(TextEditor::getPalette()[u32(TextEditor::PaletteIndex::Number)], "{0}", endIndex - i);
                 ImGui::SameLine(0, 0);
                 ImGui::TextUnformatted("]");
 


### PR DESCRIPTION
There is no code added or removed. All changes are to make Text editor code look more like the rest of ImHex.

- All member variable names that used a convention like in `mFieldVariable` were switched to the common ImHex convention of `m_fieldVariable`.
- All member function names that used pascal case were switched to the common ImHex convention of camel case.
- All int, unsigned int, unsigned long ... were switched to int32_t, uint32_t, uint64_t,... I used those because TextEditor has no access to the ImHex headers where the types are defined.
- Local variable names that were cryptic were given more descriptive ones.
- Other changes include a few fixes from cppCheck mostly for variable scope.

