### PR TITLE
fix: Reset cursor blink on move

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -756,7 +756,7 @@ void TextEditor::HandleMouseInputs() {
             auto doubleClick = ImGui::IsMouseDoubleClicked(0);
             auto t           = ImGui::GetTime();
             auto tripleClick = click && !doubleClick && (mLastClick != -1.0f && (t - mLastClick) < io.MouseDoubleClickTime);
-
+            bool resetBlinking = false;
             /*
             Left mouse button triple click
             */
@@ -769,7 +769,7 @@ void TextEditor::HandleMouseInputs() {
                 }
 
                 mLastClick = -1.0f;
-                ResetCursorBlinkTime();
+                resetBlinking=true;
             }
 
             /*
@@ -787,7 +787,7 @@ void TextEditor::HandleMouseInputs() {
                 }
 
                 mLastClick = (float)ImGui::GetTime();
-                ResetCursorBlinkTime();
+                resetBlinking=true;
             }
 
             /*
@@ -805,8 +805,8 @@ void TextEditor::HandleMouseInputs() {
                     mSelectionMode = SelectionMode::Normal;
                 }
                 SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
-                ResetCursorBlinkTime();
-
+                resetBlinking=true;
+                EnsureCursorVisible();
                 mLastClick = (float)ImGui::GetTime();
             }
             // Mouse left button dragging (=> update selection)
@@ -814,8 +814,10 @@ void TextEditor::HandleMouseInputs() {
                 io.WantCaptureMouse    = true;
                 mState.mCursorPosition = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
                 SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
-                ResetCursorBlinkTime();
+                resetBlinking=true;
             }
+            if (resetBlinking)
+                ResetCursorBlinkTime();
         }
     }
 }
@@ -1515,6 +1517,7 @@ void TextEditor::DeleteSelection() {
 }
 
 void TextEditor::MoveUp(int aAmount, bool aSelect) {
+    ResetCursorBlinkTime();
     auto oldPos                  = mState.mCursorPosition;
     mState.mCursorPosition.mLine = std::max(0, mState.mCursorPosition.mLine - aAmount);
     if (oldPos != mState.mCursorPosition) {
@@ -1537,6 +1540,7 @@ void TextEditor::MoveUp(int aAmount, bool aSelect) {
 
 void TextEditor::MoveDown(int aAmount, bool aSelect) {
     assert(mState.mCursorPosition.mColumn >= 0);
+    ResetCursorBlinkTime();
     auto oldPos                  = mState.mCursorPosition;
     mState.mCursorPosition.mLine = std::max(0, std::min((int)mLines.size() - 1, mState.mCursorPosition.mLine + aAmount));
 
@@ -1563,6 +1567,7 @@ static bool IsUTFSequence(char c) {
 }
 
 void TextEditor::MoveLeft(int aAmount, bool aSelect, bool aWordMode) {
+    ResetCursorBlinkTime();
     if (mLines.empty())
         return;
 
@@ -1617,6 +1622,7 @@ void TextEditor::MoveLeft(int aAmount, bool aSelect, bool aWordMode) {
 }
 
 void TextEditor::MoveRight(int aAmount, bool aSelect, bool aWordMode) {
+    ResetCursorBlinkTime();
     auto oldPos = mState.mCursorPosition;
 
     if (mLines.empty() || oldPos.mLine >= mLines.size())
@@ -1658,6 +1664,7 @@ void TextEditor::MoveRight(int aAmount, bool aSelect, bool aWordMode) {
 }
 
 void TextEditor::MoveTop(bool aSelect) {
+    ResetCursorBlinkTime();
     auto oldPos = mState.mCursorPosition;
     SetCursorPosition(Coordinates(0, 0));
 
@@ -1672,6 +1679,7 @@ void TextEditor::MoveTop(bool aSelect) {
 }
 
 void TextEditor::TextEditor::MoveBottom(bool aSelect) {
+    ResetCursorBlinkTime();
     auto oldPos = GetCursorPosition();
     auto newPos = Coordinates((int)mLines.size() - 1, 0);
     SetCursorPosition(newPos);
@@ -1684,6 +1692,7 @@ void TextEditor::TextEditor::MoveBottom(bool aSelect) {
 }
 
 void TextEditor::MoveHome(bool aSelect) {
+    ResetCursorBlinkTime();
     auto oldPos = mState.mCursorPosition;
     SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, 0));
 
@@ -1704,6 +1713,7 @@ void TextEditor::MoveHome(bool aSelect) {
 }
 
 void TextEditor::MoveEnd(bool aSelect) {
+    ResetCursorBlinkTime();
     auto oldPos = mState.mCursorPosition;
     SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, GetLineMaxColumn(oldPos.mLine)));
 
@@ -1724,6 +1734,7 @@ void TextEditor::MoveEnd(bool aSelect) {
 }
 
 void TextEditor::Delete() {
+    ResetCursorBlinkTime();
     assert(!mReadOnly);
 
     if (mLines.empty())
@@ -1775,6 +1786,7 @@ void TextEditor::Delete() {
 }
 
 void TextEditor::Backspace() {
+    ResetCursorBlinkTime();
     assert(!mReadOnly);
 
     if (mLines.empty())


### PR DESCRIPTION
### Problem description
When this feature was implemented the text editor handled all the keyboard input so the blink reset function could be called in one place for all the key presses. Now that shortcuts are done in the shortcut manager we need to reset the blink state inside all the functions that can affect cursor movement. 

### Implementation description
 Every function that moves the cursor now calls the blink state reset function at the very start. There may be more functions that need this that haven't been merged but git should show merging conflicts so it should be easy to deal with.

