### PR TITLE
fix: Missing runtime error markers

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -952,12 +952,11 @@ void TextEditor::Render() {
                 auto color  = GetGlyphColor(glyph);
                 bool underwaved = false;
                 ErrorMarkers::iterator errorIt;
-                if (mErrorMarkers.size() > 0) {
-                    errorIt = mErrorMarkers.find(Coordinates(lineNo+1,i));
-                    if (errorIt != mErrorMarkers.end()) {
-                        underwaved = true;
-                    }
+
+                if (errorIt = mErrorMarkers.find(Coordinates(lineNo+1,i+1)); errorIt != mErrorMarkers.end()) {
+                    underwaved = true;
                 }
+
                 if ((color != prevColor || glyph.mChar == '\t' || glyph.mChar == ' ') && !mLineBuffer.empty()) {
                     const ImVec2 newOffset(textScreenPos.x + bufferOffset.x, textScreenPos.y + bufferOffset.y);
                     drawList->AddText(newOffset, prevColor, mLineBuffer.c_str());
@@ -966,10 +965,13 @@ void TextEditor::Render() {
                     mLineBuffer.clear();
                 }
                 if (underwaved) {
-                    auto textStart = TextDistanceToLineStart(Coordinates(lineNo, i-1)) + mTextStart;
+                    auto textStart = TextDistanceToLineStart(Coordinates(lineNo, i)) + mTextStart;
                     auto begin = ImVec2(lineStartScreenPos.x + textStart, lineStartScreenPos.y);
-                    auto end = Underwaves(begin, errorIt->second.first, mPalette[(int32_t) PaletteIndex::ErrorMarker]);
-                    mErrorHoverBoxes[Coordinates(lineNo+1,i)]=std::make_pair(begin,end);
+                    auto errorLength = errorIt->second.first;
+                    if (errorLength == 0)
+                        errorLength = line.size() - i - 1;
+                    auto end = Underwaves(begin, errorLength, mPalette[(int32_t) PaletteIndex::ErrorMarker]);
+                    mErrorHoverBoxes[Coordinates(lineNo+1,i+1)]=std::make_pair(begin,end);
                 }
 
                 prevColor = color;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1354,6 +1354,11 @@ namespace hex::plugin::builtin {
                             errorMarkers[key] = std::make_pair(location.length, message);
                         }
                     }
+                } else {
+                    if (m_lastEvaluationError->has_value()) {
+                        auto key = TextEditor::Coordinates((*m_lastEvaluationError)->line, 0);
+                        errorMarkers[key] = std::make_pair(0,processMessage((*m_lastEvaluationError)->message));
+                    }
                 }
 
                 if (!m_lastCompileError->empty()) {


### PR DESCRIPTION
### Problem description
Moving error markers to be underwaved created s couple of errors: 
- Markers that were 1 char long and located at the end of the line didn't show on text editor. 
- Markers that had zero length or no stack trace didn't show on text editor.

### Implementation description

- The first error was caused by an off by one error in the column index. 
- There was no implementation for errors that had no location or zero length. Now errors with no location will be shown at the beginning of the line where they occur. Errors with zero length will be marked from their location to the end of the line, therefore, errors with no stack trace will be marked from the beginning to the end of the line.
