### PR TITLE
use machine headers to auto select on arch

### DIFF
--- a/plugins/builtin/source/content/providers/process_memory_provider.cpp
+++ b/plugins/builtin/source/content/providers/process_memory_provider.cpp
@@ -9,8 +9,8 @@
 #elif defined(OS_MACOS)
     #include <mach/mach_types.h>
     #include <mach/message.h>
-    #include <mach/arm/kern_return.h>
-    #include <mach/arm/vm_types.h>
+    #include <mach/machine/kern_return.h>
+    #include <mach/machine/vm_types.h>
     #include <mach/vm_map.h>
     #include <mach-o/dyld_images.h>
     #include <libproc.h>


### PR DESCRIPTION
Fixes https://github.com/WerWolv/ImHex/issues/1807

### Problem description

Build fails for MacOS x86-64 due to using a wrong architecture header.

### Implementation description

Used the headers for mach that auto select the correct architecture.

### Additional things

This is being used in https://github.com/NixOS/nixpkgs/pull/330303 as a patch
