### PR TITLE
fix: ImHex hangs when pressing F5 while in a breakpoint

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1297,7 +1297,6 @@ namespace hex::plugin::builtin {
 
                     (*m_debuggerDrawer)->reset();
                     m_resetDebuggerVariables = false;
-                    m_textEditor.SetCursorPosition(TextEditor::Coordinates(pauseLine.value_or(0) - 1, 0));
 
                     if (pauseLine.has_value())
                         m_textEditor.SetCursorPosition({ int(pauseLine.value() - 1), 0 });
@@ -2372,6 +2371,11 @@ namespace hex::plugin::builtin {
 
         /* Trigger evaluation */
         ShortcutManager::addGlobalShortcut(Keys::F5 + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.run_pattern", [this] {
+            auto &runtime = ContentRegistry::PatternLanguage::getRuntime();
+            if (runtime.isRunning()) {
+                m_breakpointHit = false;
+                runtime.abort();
+            }
             m_triggerAutoEvaluate = true;
         });
 


### PR DESCRIPTION
### Problem description
fix: pressing F5 (start pattern execution ) while being in a break point hangs ImHex.


The reason for hanging ImHex was that the shortcut procedure was not checking if the pattern was already running, and it attempted to start another one. This makes ImHex wait indefinitely for a lock to be released

### Implementation description

To fix the hanging of ImHex we check the runtime for current evaluation and if detected we stop it. In all cases the evaluation is started again.
