### PR TITLE
Fixes for breakpoints

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -133,7 +133,7 @@ public:
 	using Keywords = std::unordered_set<std::string> ;
     using ErrorMarkers = std::map<Coordinates, std::pair<uint32_t ,std::string>>;
     using ErrorHoverBoxes = std::map<Coordinates, std::pair<ImVec2,ImVec2>>;
-    using Breakpoints = std::unordered_set<int32_t>;
+    using Breakpoints = std::unordered_set<uint32_t>;
     using Palette = std::array<ImU32, (uint32_t)PaletteIndex::Max>;
     using Char = uint8_t ;
 
@@ -199,6 +199,7 @@ public:
 	static void SetPalette(const Palette& aValue);
 
 	void SetErrorMarkers(const ErrorMarkers& aMarkers) { mErrorMarkers = aMarkers; }
+    Breakpoints &GetBreakpoints() { return mBreakpoints; }
 	void SetBreakpoints(const Breakpoints& aMarkers) { mBreakpoints = aMarkers; }
     ImVec2 Underwaves( ImVec2 pos, uint32_t nChars, ImColor color= ImGui::GetStyleColorVec4(ImGuiCol_Text), const ImVec2 &size_arg= ImVec2(0, 0));
 
@@ -223,6 +224,8 @@ public:
 	bool IsReadOnly() const { return mReadOnly; }
 	bool IsTextChanged() const { return mTextChanged; }
 	bool IsCursorPositionChanged() const { return mCursorPositionChanged; }
+    bool IsBreakpointsChanged() const { return mBreakPointsChanged; }
+    void ClearBreakpointsChanged() { mBreakPointsChanged = false; }
 
     void SetShowCursor(bool aValue) { mShowCursor = aValue; }
     void SetShowLineNumbers(bool aValue) { mShowLineNumbers = aValue; }
@@ -461,6 +464,7 @@ private:
 	float mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
 	int  mLeftMargin;
 	bool mCursorPositionChanged;
+    bool mBreakPointsChanged;
 	int mColorRangeMin, mColorRangeMax;
 	SelectionMode mSelectionMode;
 	bool mHandleKeyboardInputs;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -580,12 +580,17 @@ void TextEditor::RemoveLine(int aStart, int aEnd) {
     mErrorMarkers = std::move(etmp);
 
     Breakpoints btmp;
-    for (auto i : mBreakpoints) {
-        if (i >= aStart && i <= aEnd)
-            continue;
-        btmp.insert(i >= aStart ? i - 1 : i);
+    for (auto breakpoint : mBreakpoints) {
+        if (breakpoint <= aStart || breakpoint >= aEnd) {
+            if (breakpoint >= aEnd) {
+                btmp.insert(breakpoint - 1);
+                mBreakPointsChanged = true;
+            } else
+                btmp.insert(breakpoint);
+        }
     }
-    mBreakpoints = std::move(btmp);
+    if (mBreakPointsChanged)
+        mBreakpoints = std::move(btmp);
     if (aStart == 0 && aEnd == (int32_t)mLines.size() - 1)
         mLines.erase(mLines.begin() + aStart, mLines.end());
     else
@@ -608,12 +613,15 @@ void TextEditor::RemoveLine(int aIndex) {
     mErrorMarkers = std::move(etmp);
 
     Breakpoints btmp;
-    for (auto i : mBreakpoints) {
-        if (i == aIndex)
-            continue;
-        btmp.insert(i >= aIndex ? i - 1 : i);
+    for (auto breakpoint : mBreakpoints) {
+        if (breakpoint > aIndex) {
+            btmp.insert(breakpoint - 1);
+            mBreakPointsChanged = true;
+        }else
+            btmp.insert(breakpoint);
     }
-    mBreakpoints = std::move(btmp);
+    if (mBreakPointsChanged)
+        mBreakpoints = std::move(btmp);
 
     mLines.erase(mLines.begin() + aIndex);
     assert(!mLines.empty());
@@ -630,9 +638,15 @@ TextEditor::Line &TextEditor::InsertLine(int aIndex) {
     mErrorMarkers = std::move(etmp);
 
     Breakpoints btmp;
-    for (auto i : mBreakpoints)
-        btmp.insert(i >= aIndex ? i + 1 : i);
-    mBreakpoints = std::move(btmp);
+    for (auto breakpoint : mBreakpoints) {
+        if (breakpoint >= aIndex) {
+            btmp.insert(breakpoint + 1);
+            mBreakPointsChanged = true;
+        } else
+            btmp.insert(breakpoint);
+    }
+    if (mBreakPointsChanged)
+        mBreakpoints = std::move(btmp);
 
     return result;
 }

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -249,6 +249,7 @@ namespace hex::plugin::builtin {
         std::mutex m_logMutex;
 
         PerProvider<TextEditor::Coordinates>  m_cursorPosition;
+        PerProvider<std::unordered_set<u32>> m_breakpoints;
         PerProvider<std::optional<pl::core::err::PatternLanguageError>> m_lastEvaluationError;
         PerProvider<std::vector<pl::core::err::CompileError>> m_lastCompileError;
         PerProvider<std::vector<const pl::core::ast::ASTNode*>> m_callStack;


### PR DESCRIPTION
WARNING: this PR won't compile unless [PR 132 from pattern language repository](https://github.com/WerWolv/PatternLanguage/pull/132)  is merged first. Some changes here are shared by at least another PR to this repository but there should not be any conflicts as the shared changes are identical.

### Problem description
fix: Editing patterns with breakpoints sets behaves unexpectedly. As a simple example, set a breakpoint and insert a blank line somewhere before the breakpoint location. The breakpoint will appear to move but in reality it hasn't. To see this set another breakpoint elsewhere in the file and the old one will be displayed where it is really located at.

The reason for this and many other problems with breakpoints is that currently ImHex keeps two set of breakpoints in text editor and in evaluator that are independent of each other, ie, changes to one don't affect the other. This PR aims at synchronizing the two sets through the per provider breakpoints that exist in view pattern editor.

### Implementation description

It accomplishes this by making the text editor version of breakpoints the principal source of vectors and the ones in evaluator the effective version. The first allows one to modify the text around and at the breakpoint and notify others that the changes have induced changes in the breakpoint locations. The effective breakpoints allow the insertion and deletion of breakpoints.

View pattern editor is where breakpoints are updated. It receives notifications from text editor about changes and then makes sure the version in evaluator is updated with those changes. View pattern editor also manages breakpoint addition and deletion so before making changes it gets a copy of the current ones from text editor, sets the ones in evaluator, uses the evaluator functions to add or delete breakpoints and finally sets the text editor version with the new version.
