### PR TITLE
fix: re-enable C/C++ languages in CMake

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -307,6 +307,9 @@ endfunction()
 macro(configureCMake)
     message(STATUS "Configuring ImHex v${IMHEX_VERSION}")
 
+    # Enable C and C++ languages
+    enable_language(C CXX)
+
     set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "Enable position independent code for all targets" FORCE)
 
     # Configure use of recommended build tools


### PR DESCRIPTION
For some reason removing this line made the Ubuntu and AppImage packages increase in size significantly (68.2 MB  -> 110 MB for Ubuntu, 97.2 MB -> 138 MB for AppImage)

I didn't get the time to investigate properly why