### PR TITLE
fix: fixes for issue #1950. 

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -247,6 +247,18 @@ int TextEditor::InsertTextAt(Coordinates & /* inout */ aWhere, const char *aValu
         if (*aValue == '\r') {
             // skip
             ++aValue;
+        } else if (*aValue == '\t') {
+            auto &line = mLines[aWhere.mLine];
+            auto c = GetCharacterColumn(aWhere.mLine, cindex);
+            auto r = c % mTabSize;
+            auto d = mTabSize - r;
+            auto i = d;
+            while (i-- > 0)
+                line.insert(line.begin() + cindex++, Glyph(' ', PaletteIndex::Default));
+
+            cindex += d;
+            aWhere.mColumn += d;
+            aValue++;
         } else if (*aValue == '\n') {
             if (cindex < (int)mLines[aWhere.mLine].size()) {
                 auto &newLine = InsertLine(aWhere.mLine + 1);

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -73,6 +73,8 @@ namespace hex::plugin::builtin {
         }
 
     public:
+        std::string preprocessText(const std::string &code);
+
         struct VirtualFile {
             std::fs::path path;
             std::vector<u8> data;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1654,7 +1654,7 @@ namespace hex::plugin::builtin {
     void ViewPatternEditor::loadPatternFile(const std::fs::path &path, prv::Provider *provider) {
         wolv::io::File file(path, wolv::io::File::Mode::Read);
         if (file.isValid()) {
-            auto code = file.readString();
+            auto code = preprocessText(file.readString());
 
             this->evaluatePattern(code, provider);
             m_textEditor.SetText(code);
@@ -1815,6 +1815,15 @@ namespace hex::plugin::builtin {
         });
     }
 
+    std::string ViewPatternEditor::preprocessText(const std::string &code) {
+        std::string result = wolv::util::replaceStrings(code, "\r\n", "\n");
+        result = wolv::util::replaceStrings(result, "\r", "\n");
+        result = wolv::util::replaceTabsWithSpaces(result, 4);
+        while (result.ends_with('\n'))
+            result.pop_back();
+        return result;
+    }
+
     void ViewPatternEditor::registerEvents() {
         RequestPatternEditorSelectionChange::subscribe(this, [this](u32 line, u32 column) {
             const TextEditor::Coordinates coords = { int(line) - 1, int(column) };
@@ -1835,8 +1844,9 @@ namespace hex::plugin::builtin {
         });
 
         RequestSetPatternLanguageCode::subscribe(this, [this](const std::string &code) {
-            m_textEditor.SetText(code);
-            m_sourceCode.set(ImHexApi::Provider::get(), code);
+            const std::string preprocessed = preprocessText(code);
+            m_textEditor.SetText(preprocessed);
+            m_sourceCode.set(ImHexApi::Provider::get(), preprocessed);
             m_hasUnevaluatedChanges = true;
         });
 
@@ -2081,7 +2091,7 @@ namespace hex::plugin::builtin {
             .basePath = "pattern_source_code.hexpat",
             .required = false,
             .load = [this](prv::Provider *provider, const std::fs::path &basePath, const Tar &tar) {
-                const auto sourceCode = tar.readString(basePath);
+                const auto sourceCode = preprocessText(tar.readString(basePath));
 
                 m_sourceCode.set(provider, sourceCode);
 


### PR DESCRIPTION
This code fixes issue #1950 This PR depends on PR [#27 ](https://github.com/WerWolv/libwolv/pull/27) on libwolv repo


### Problem description
See description of the problem on the issue linked above

### Implementation description
The code in the PR uses function added to the libwolv repository to remove tabs if they exist on the provider. Additionally, any pasted tab on the pattern editor will be translated to spaces automatically. This code was tested successfully using the pattern posted in the issue.

