### PR TITLE
fix: fixes for issue #1704.

### DIFF
--- a/lib/libimhex/include/hex/api/achievement_manager.hpp
+++ b/lib/libimhex/include/hex/api/achievement_manager.hpp
@@ -295,7 +295,7 @@ namespace hex {
     };
 
     class AchievementManager {
-        static bool m_initialized;
+        static bool s_initialized;
     public:
         AchievementManager() = delete;
 

--- a/lib/libimhex/include/hex/api/achievement_manager.hpp
+++ b/lib/libimhex/include/hex/api/achievement_manager.hpp
@@ -295,6 +295,7 @@ namespace hex {
     };
 
     class AchievementManager {
+        static bool m_initialized;
     public:
         AchievementManager() = delete;
 

--- a/lib/libimhex/source/api/achievement_manager.cpp
+++ b/lib/libimhex/source/api/achievement_manager.cpp
@@ -196,10 +196,10 @@ namespace hex {
 
 
     constexpr static auto AchievementsFile = "achievements.json";
-    bool AchievementManager::m_initialized = false;
+    bool AchievementManager::s_initialized = false;
 
     void AchievementManager::loadProgress() {
-        if (m_initialized)
+        if (s_initialized)
             return;
         for (const auto &directory : paths::Config.read()) {
             auto path = directory / AchievementsFile;
@@ -230,7 +230,8 @@ namespace hex {
                         }
                     }
                 }
-                m_initialized = true;
+                
+                s_initialized = true;
             } catch (const std::exception &e) {
                 log::error("Failed to load achievements: {}", e.what());
             }
@@ -239,7 +240,7 @@ namespace hex {
     }
 
     void AchievementManager::storeProgress() {
-        if (!m_initialized)
+        if (!s_initialized)
             loadProgress();
         nlohmann::json json;
         for (const auto &[categoryName, achievements] : getAchievements()) {

--- a/lib/libimhex/source/api/achievement_manager.cpp
+++ b/lib/libimhex/source/api/achievement_manager.cpp
@@ -196,8 +196,11 @@ namespace hex {
 
 
     constexpr static auto AchievementsFile = "achievements.json";
+    bool AchievementManager::m_initialized = false;
 
     void AchievementManager::loadProgress() {
+        if (m_initialized)
+            return;
         for (const auto &directory : paths::Config.read()) {
             auto path = directory / AchievementsFile;
 
@@ -227,6 +230,7 @@ namespace hex {
                         }
                     }
                 }
+                m_initialized = true;
             } catch (const std::exception &e) {
                 log::error("Failed to load achievements: {}", e.what());
             }
@@ -235,6 +239,8 @@ namespace hex {
     }
 
     void AchievementManager::storeProgress() {
+        if (!m_initialized)
+            loadProgress();
         nlohmann::json json;
         for (const auto &[categoryName, achievements] : getAchievements()) {
             json[categoryName] = nlohmann::json::object();


### PR DESCRIPTION
 
### Problem description
Loading a file on the command line or using the context menu in windows was triggering an achievement before the achievements file was loaded. This resulted on the achievements.json file to be overwritten with all the achievements reset except for the one to open files.

### Implementation description
This PR fixes the problem by introducing a boolean that is used to check if the file has been loaded.