### PR TITLE
fix: empty documents have no cursor.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -877,7 +877,7 @@ void TextEditor::Render() {
         buf[0] = '\0';
     mTextStart = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, buf, nullptr, nullptr).x + mLeftMargin;
 
-    if (!isEmpty()) {
+    if (lineNo <= lineMax) {
         float spaceSize = ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, " ", nullptr, nullptr).x;
 
         while (lineNo <= lineMax) {


### PR DESCRIPTION
Even if focus is given to the pattern editor the cursor will not show until the editor contains printable chars.

### Problem description
 I was using the wrong condition to enter the loop that skipped the default empty document.

### Implementation description
 The fix was to check if there are lines of text that need to be processed even if they are empty.