### PR TITLE
Fix code scanning alert no. 223: Multiplication result converted to larger type

### DIFF
--- a/plugins/visualizers/source/content/pl_visualizers/sound.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/sound.cpp
@@ -56,7 +56,7 @@ namespace hex::plugin::visualizers {
                     }
 
                     ma_copy_pcm_frames(pOutput, waveData.data() + index, frameCount, device->playback.format, device->playback.channels);
-                    index += frameCount * device->playback.channels;
+                    index += static_cast<u64>(frameCount) * device->playback.channels;
                 };
 
                 ma_device_init(nullptr, &deviceConfig, &audioDevice);


### PR DESCRIPTION
Fixes [https://github.com/WerWolv/ImHex/security/code-scanning/223](https://github.com/WerWolv/ImHex/security/code-scanning/223)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be achieved by casting one of the operands to `u64` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

We will modify the line `index += frameCount * device->playback.channels;` to cast `frameCount` to `u64` before the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
