### PR TITLE
Replaced asserts from TextEditor.cpp

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -203,8 +203,8 @@ void TextEditor::Advance(Coordinates &aCoordinates) const {
 }
 
 void TextEditor::DeleteRange(const Coordinates &aStart, const Coordinates &aEnd) {
-    assert(aEnd >= aStart);
-    assert(!mReadOnly);
+    IM_ASSERT(aEnd >= aStart);
+    IM_ASSERT(!mReadOnly);
 
     // printf("D(%d.%d)-(%d.%d)\n", aStart.mLine, aStart.mColumn, aEnd.mLine, aEnd.mColumn);
 
@@ -293,7 +293,7 @@ int TextEditor::InsertTextAt(Coordinates & /* inout */ aWhere, const char *aValu
 }
 
 void TextEditor::AddUndo(UndoRecord &aValue) {
-    assert(!mReadOnly);
+    IM_ASSERT(!mReadOnly);
     // printf("AddUndo: (@%d.%d) +\'%s' [%d.%d .. %d.%d], -\'%s', [%d.%d .. %d.%d] (@%d.%d)\n",
     //	aValue.mBefore.mCursorPosition.mLine, aValue.mBefore.mCursorPosition.mColumn,
     //	aValue.mAdded.c_str(), aValue.mAddedStart.mLine, aValue.mAddedStart.mColumn, aValue.mAddedEnd.mLine, aValue.mAddedEnd.mColumn,
@@ -581,8 +581,8 @@ bool TextEditor::IsOnWordBoundary(const Coordinates &aAt) const {
 }
 
 void TextEditor::RemoveLine(int aStart, int aEnd) {
-    assert(!mReadOnly);
-    assert(aEnd >= aStart);
+    IM_ASSERT(!mReadOnly);
+    IM_ASSERT(aEnd >= aStart);
 
     ErrorMarkers etmp;
     for (auto &i : mErrorMarkers) {
@@ -614,8 +614,8 @@ void TextEditor::RemoveLine(int aStart, int aEnd) {
 }
 
 void TextEditor::RemoveLine(int aIndex) {
-    assert(!mReadOnly);
-    assert(mLines.size() > 1);
+    IM_ASSERT(!mReadOnly);
+    IM_ASSERT(mLines.size() > 1);
 
     ErrorMarkers etmp;
     for (auto &i : mErrorMarkers) {
@@ -638,7 +638,7 @@ void TextEditor::RemoveLine(int aIndex) {
         mBreakpoints = std::move(btmp);
 
     mLines.erase(mLines.begin() + aIndex);
-    assert(!mLines.empty());
+    IM_ASSERT(!mLines.empty());
 
     mTextChanged = true;
 }
@@ -844,7 +844,7 @@ void TextEditor::Render() {
         mPalette[i] = ImGui::ColorConvertFloat4ToU32(color);
     }
 
-    assert(mLineBuffer.empty());
+    IM_ASSERT(mLineBuffer.empty());
 
     auto contentSize = ImGui::GetCurrentWindowRead()->ContentRegionRect.Max - ImGui::GetWindowPos() - ImVec2(0,mTopMargin);
     auto drawList    = ImGui::GetWindowDrawList();
@@ -894,7 +894,7 @@ void TextEditor::Render() {
             float sstart = -1.0f;
             float ssend  = -1.0f;
 
-            assert(mState.mSelectionStart <= mState.mSelectionEnd);
+            IM_ASSERT(mState.mSelectionStart <= mState.mSelectionEnd);
             if (mState.mSelectionStart <= lineEndCoord)
                 sstart = mState.mSelectionStart > lineStartCoord ? TextDistanceToLineStart(mState.mSelectionStart) : 0.0f;
             if (mState.mSelectionEnd > lineStartCoord)
@@ -1235,7 +1235,7 @@ void TextEditor::SetTextLines(const std::vector<std::string> &aLines) {
 }
 
 void TextEditor::EnterCharacter(ImWchar aChar, bool aShift) {
-    assert(!mReadOnly);
+    IM_ASSERT(!mReadOnly);
 
     UndoRecord u;
 
@@ -1522,7 +1522,7 @@ void TextEditor::InsertText(const char *aValue) {
 }
 
 void TextEditor::DeleteSelection() {
-    assert(mState.mSelectionEnd >= mState.mSelectionStart);
+    IM_ASSERT(mState.mSelectionEnd >= mState.mSelectionStart);
 
     if (mState.mSelectionEnd == mState.mSelectionStart)
         return;
@@ -1562,7 +1562,7 @@ void TextEditor::MoveUp(int aAmount, bool aSelect) {
 }
 
 void TextEditor::MoveDown(int aAmount, bool aSelect) {
-    assert(mState.mCursorPosition.mColumn >= 0);
+    IM_ASSERT(mState.mCursorPosition.mColumn >= 0);
     ResetCursorBlinkTime();
     auto oldPos                  = mState.mCursorPosition;
     mState.mCursorPosition.mLine = std::max(0, std::min((int)mLines.size() - 1, mState.mCursorPosition.mLine + aAmount));
@@ -1629,7 +1629,7 @@ void TextEditor::MoveLeft(int aAmount, bool aSelect, bool aWordMode) {
 
     mState.mCursorPosition = Coordinates(lindex, GetCharacterColumn(lindex, cindex));
 
-    assert(mState.mCursorPosition.mColumn >= 0);
+    IM_ASSERT(mState.mCursorPosition.mColumn >= 0);
     if (aSelect) {
         if (oldPos == mInteractiveStart)
             mInteractiveStart = mState.mCursorPosition;
@@ -1685,7 +1685,7 @@ void TextEditor::MoveRight(int aAmount, bool aSelect, bool aWordMode) {
 
     mState.mCursorPosition = Coordinates(lindex, GetCharacterColumn(lindex, cindex));
 
-    assert(mState.mCursorPosition.mColumn >= 0);
+    IM_ASSERT(mState.mCursorPosition.mColumn >= 0);
     if (aSelect) {
         if (oldPos == mInteractiveEnd)
             mInteractiveEnd = SanitizeCoordinates(mState.mCursorPosition);
@@ -1774,7 +1774,7 @@ void TextEditor::MoveEnd(bool aSelect) {
 
 void TextEditor::Delete() {
     ResetCursorBlinkTime();
-    assert(!mReadOnly);
+    IM_ASSERT(!mReadOnly);
 
     if (isEmpty())
         return;
@@ -1831,7 +1831,7 @@ void TextEditor::Delete() {
 
 void TextEditor::Backspace() {
     ResetCursorBlinkTime();
-    assert(!mReadOnly);
+    IM_ASSERT(!mReadOnly);
 
     if (isEmpty())
         return;
@@ -2016,7 +2016,7 @@ void TextEditor::Redo(int aSteps) {
 
 // the index here is array index so zero based
 void TextEditor::FindReplaceHandler::SelectFound(TextEditor *editor, int index) {
-    assert(index >= 0 && index < mMatches.size());
+    IM_ASSERT(index >= 0 && index < mMatches.size());
     auto selectionStart = mMatches[index].mSelectionStart;
     auto selectionEnd = mMatches[index].mSelectionEnd;
     editor->SetSelection(selectionStart, selectionEnd);
@@ -2868,8 +2868,8 @@ TextEditor::UndoRecord::UndoRecord(
     TextEditor::EditorState &aBefore,
     TextEditor::EditorState &aAfter)
     : mAdded(aAdded), mAddedStart(aAddedStart), mAddedEnd(aAddedEnd), mRemoved(aRemoved), mRemovedStart(aRemovedStart), mRemovedEnd(aRemovedEnd), mBefore(aBefore), mAfter(aAfter) {
-    assert(mAddedStart <= mAddedEnd);
-    assert(mRemovedStart <= mRemovedEnd);
+    IM_ASSERT(mAddedStart <= mAddedEnd);
+    IM_ASSERT(mRemovedStart <= mRemovedEnd);
 }
 
 void TextEditor::UndoRecord::Undo(TextEditor *aEditor) {


### PR DESCRIPTION
All asserts in TextEditor.cpp were replaced with IM_ASSERTs so that if they are hit ImHex won't crash and give a nice popup message instead.
