### PR TITLE
Implement MIME type support on UNIX systems

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -225,6 +225,7 @@ macro(createPackage)
 
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/share/licenses/imhex)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dist/imhex.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dist/imhex.mime.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/mime/packages RENAME imhex.xml)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/icon.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps RENAME imhex.png)
         downloadImHexPatternsFiles("./share/imhex")
 

--- a/dist/Arch/PKGBUILD
+++ b/dist/Arch/PKGBUILD
@@ -26,5 +26,5 @@ package() {
 
     install -d "$pkgdir/usr/share/imhex"
     cp -r "$srcdir/usr/share/imhex/"{constants,encodings,includes,magic,patterns} "$pkgdir/usr/share/imhex"
-    cp -r "$srcdir/usr/share/"{applications,licenses,pixmaps} "$pkgdir/usr/share"
+    cp -r "$srcdir/usr/share/"{applications,licenses,pixmaps,mime} "$pkgdir/usr/share"
 }

--- a/dist/imhex.desktop
+++ b/dist/imhex.desktop
@@ -9,3 +9,4 @@ StartupNotify=true
 Categories=Development;IDE;
 StartupWMClass=imhex
 Keywords=static-analysis;reverse-engineering;disassembler;disassembly;hacking;forensics;hex-editor;cybersecurity;security;binary-analysis;
+MimeType=application/vnd.imhex.proj;

--- a/dist/imhex.mime.xml
+++ b/dist/imhex.mime.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/vnd.imhex.proj">
+        <comment>ImHex Project</comment>
+        <glob pattern="*.hexproj"/>
+    </mime-type>
+</mime-info>

--- a/dist/rpm/imhex.spec
+++ b/dist/rpm/imhex.spec
@@ -125,6 +125,7 @@ cp -a lib/third_party/xdgpp/LICENSE                                  %{buildroot
 %{_bindir}/imhex-updater
 %{_datadir}/pixmaps/%{name}.png
 %{_datadir}/applications/%{name}.desktop
+%{_datadir}/mime/packages/%{name}.xml
 %{_libdir}/libimhex.so*
 %{_libdir}/%{name}/
 %{_metainfodir}/net.werwolv.%{name}.metainfo.xml


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
This PR addresses issue #491 regarding the inability to open ImHex project files (`.hexproj`) directly from various UNIX Desktop Environments.

_NB: This PR's scope is limited to UNIX systems, as I have no access to MacOS systems and could not find a way to automatically create file associations on Windows._

### Implementation description
<!-- Explain what you did to correct the problem -->
In order for project files to be recognised as such, we need to create a new MIME type. According to [RFC 6838 section 3.2](https://www.rfc-editor.org/rfc/rfc6838#section-3.2), additional application MIME types should be defined with a vendor prefix.
_NB: This is preferred over the deprecated `x-` prefix, although RFC 6838 states that the vendor should be "a well known producer"_

This PR proposes a new mime type for ImHex project files: `application/vnd.imhex.proj`, and associates it with the file format `*.hexproj`.

It also implements small changes in the Arch Linux and RPM builds, in order to correctly ship the MIME XML file during installation.

### Additional things
<!-- Anything else you would like to say -->
The implemented change has been manually tested in the following UNIX systems and graphical environments:
- Arch Linux, with Gnome 47.2
- Arch Linux, with XFCE4
- Fedora 41 Workstation Edition, with Gnome 47.0
- Fedora 41 Plasma, with KDE Plasma 24.08.2
- Ubuntu 22.04.5, with Gnome 42.9

Which tests the functionality of the following build types:
- Arch Linux's `.zst` packages
- Debian `.deb` packages
- RPM packages

For Arch Linux and RPM packages, this has been tested to ensure that post-installation hooks (such as regeneration of the MIME database) is correctly executed (which it is). No further changes than those implemented in the PR are needed.
