### PR TITLE
fix: HexII visualisation does not allow hex characters in the edit field

### DIFF
--- a/plugins/builtin/source/content/data_visualizers.cpp
+++ b/plugins/builtin/source/content/data_visualizers.cpp
@@ -81,7 +81,7 @@ namespace hex::plugin::builtin {
             hex::unused(address, startedEditing);
 
             if (size == ByteCount) {
-                return drawDefaultScalarEditingTextBox(address, getFormatString(upperCase), ImGuiExt::getImGuiDataType<u8>(), data, ImGuiInputTextFlags_None);
+                return drawDefaultScalarEditingTextBox(address, getFormatString(upperCase), ImGuiExt::getImGuiDataType<u8>(), data, ImGuiInputTextFlags_CharsHexadecimal);
             } else {
                 return false;
             }


### PR DESCRIPTION
### Problem description
At the moment, attempting to edit files using HexII data visualization is impossible as the editing fields only allow numeric characters but is interpreted as a hex value

### Implementation description
I yoinked the params used for the hex visualization edit field. 

### Screenshots
![image](https://github.com/user-attachments/assets/2d61bf61-9893-4cfb-a2bf-6ff954aef903)

### Additional things
Ideally this should instead accept the format used by HexII, but I have what scientists describe as a skill issue and this at least makes it possible to use HexII without switching back to hex for editing.

