### PR TITLE
fix: context menus entries greyed out.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -244,7 +244,8 @@ public:
 
 	Coordinates GetCursorPosition() const { return GetActualCursorCoordinates(); }
 	void SetCursorPosition(const Coordinates& aPosition);
-
+    bool raiseContextMenu() { return mRaiseContextMenu; }
+    void clearRaiseContextMenu() { mRaiseContextMenu = false; }
 	inline void SetHandleMouseInputs    (bool aValue){ mHandleMouseInputs    = aValue;}
 	inline bool IsHandleMouseInputsEnabled() const { return mHandleKeyboardInputs; }
 
@@ -502,6 +503,7 @@ private:
 	float mLastClick;
     bool mShowCursor;
     bool mShowLineNumbers;
+    bool mRaiseContextMenu = false;
 
     static const int sCursorBlinkInterval;
     static const int sCursorBlinkOnTime;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -761,10 +761,11 @@ void TextEditor::HandleMouseInputs() {
 
     if (ImGui::IsWindowHovered()) {
         if (!alt) {
-            auto click       = ImGui::IsMouseClicked(0);
-            auto doubleClick = ImGui::IsMouseDoubleClicked(0);
-            auto t           = ImGui::GetTime();
-            auto tripleClick = click && !doubleClick && (mLastClick != -1.0f && (t - mLastClick) < io.MouseDoubleClickTime);
+            auto click         = ImGui::IsMouseClicked(0);
+            auto doubleClick   = ImGui::IsMouseDoubleClicked(0);
+            auto rightClick    = ImGui::IsMouseClicked(1);
+            auto t     = ImGui::GetTime();
+            auto tripleClick   = click && !doubleClick && (mLastClick != -1.0f && (t - mLastClick) < io.MouseDoubleClickTime);
             bool resetBlinking = false;
             /*
             Left mouse button triple click
@@ -818,6 +819,12 @@ void TextEditor::HandleMouseInputs() {
               
                 EnsureCursorVisible();
                 mLastClick = (float)ImGui::GetTime();
+            } else if (rightClick) {
+                mState.mCursorPosition = mInteractiveStart = mInteractiveEnd = ScreenPosToCoordinates(ImGui::GetMousePos());
+                mSelectionMode = SelectionMode::Normal;
+                SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
+                ResetCursorBlinkTime();
+                mRaiseContextMenu = true;
             }
             // Mouse left button dragging (=> update selection)
             else if (ImGui::IsMouseDragging(0) && ImGui::IsMouseDown(0)) {

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -351,8 +351,9 @@ namespace hex::plugin::builtin {
             m_textEditorHoverBox = ImRect(windowPosition,windowPosition+textEditorSize);
             m_consoleHoverBox = ImRect(ImVec2(windowPosition.x,windowPosition.y+textEditorSize.y),windowPosition+availableSize);
             TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.GetFindReplaceHandler();
-            if (ImGui::IsMouseDown(ImGuiMouseButton_Right) && ImGui::IsMouseHoveringRect(m_textEditorHoverBox.Min,m_textEditorHoverBox.Max) && !ImGui::IsMouseDragging(ImGuiMouseButton_Right)) {
+            if (m_textEditor.raiseContextMenu())  {
                 ImGui::OpenPopup("##pattern_editor_context_menu");
+                m_textEditor.clearRaiseContextMenu();
             }
 
             if (ImGui::BeginPopup("##pattern_editor_context_menu")) {
@@ -364,6 +365,8 @@ namespace hex::plugin::builtin {
 
                 ImGui::Separator();
 
+                if (!m_textEditor.HasSelection())
+                    m_textEditor.SelectWordUnderCursor();
                 const bool hasSelection = m_textEditor.HasSelection();
                 if (ImGui::MenuItem("hex.builtin.view.hex_editor.menu.edit.cut"_lang, Shortcut(CTRLCMD + Keys::X).toString().c_str(), false, hasSelection)) {
                     m_textEditor.Cut();
@@ -386,7 +389,7 @@ namespace hex::plugin::builtin {
 
                 ImGui::Separator();
                 // Search and replace entries
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str(),false, m_textEditor.HasSelection())){
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str())){
                     m_replaceMode = false;
                     m_openFindReplacePopUp = true;
                 }
@@ -398,7 +401,7 @@ namespace hex::plugin::builtin {
                 if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find_previous"_lang, Shortcut(SHIFT + Keys::F3).toString().c_str(),false,!findReplaceHandler->GetFindWord().empty()))
                     findReplaceHandler->FindMatch(&m_textEditor,false);
 
-                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace"_lang, Shortcut(CTRLCMD +  Keys::H).toString().c_str(),false,!findReplaceHandler->GetReplaceWord().empty())) {
+                if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.replace"_lang, Shortcut(CTRLCMD +  Keys::H).toString().c_str())) {
                     m_replaceMode = true;
                     m_openFindReplacePopUp = true;
                 }
@@ -921,9 +924,12 @@ namespace hex::plugin::builtin {
 
     void ViewPatternEditor::drawConsole(ImVec2 size) {
         auto findReplaceHandler = m_consoleEditor.GetFindReplaceHandler();
-        if (ImGui::IsMouseDown(ImGuiMouseButton_Right) && ImGui::IsMouseHoveringRect(m_consoleHoverBox.Min,m_consoleHoverBox.Max) && !ImGui::IsMouseDragging(ImGuiMouseButton_Right)) {
+        if (m_consoleEditor.raiseContextMenu()) {
             ImGui::OpenPopup("##console_context_menu");
+            m_consoleEditor.clearRaiseContextMenu();
         }
+        if (!m_consoleEditor.HasSelection())
+            m_consoleEditor.SelectWordUnderCursor();
         const bool hasSelection = m_consoleEditor.HasSelection();
         if (ImGui::BeginPopup("##console_context_menu")) {
             if (ImGui::MenuItem("hex.builtin.view.hex_editor.menu.edit.copy"_lang, Shortcut(CTRLCMD + Keys::C).toString().c_str(), false, hasSelection)) {
@@ -934,7 +940,7 @@ namespace hex::plugin::builtin {
             }
             ImGui::Separator();
             // Search and replace entries
-            if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str(),false, hasSelection)) {
+            if (ImGui::MenuItem("hex.builtin.view.pattern_editor.menu.find"_lang, Shortcut(CTRLCMD + Keys::F).toString().c_str())) {
                 m_openFindReplacePopUp = true;
                 m_replaceMode = false;
             }


### PR DESCRIPTION
Some context menu entries that were available as shortcuts were greyed out. This PR aims to fix them and improve how context menus work for the text editor and the console. The improvements include:
- automatic focus on right click
- automatic selection on right click. If selected text is right-clicked then copy, cut and find will use the selection, if no selection is clicked but there is text were right-clicked, then the word will be selected and used. If right-clicking empty space copy and cut will be greyed out and find will start empty.
- similar functionality now exists for the console as well except the menu has fewer options due to it being read-only.
- added esc to close console context menu
