### PR TITLE
Export disassembler results to ASM file

### DIFF
--- a/plugins/disassembler/include/content/views/view_disassembler.hpp
+++ b/plugins/disassembler/include/content/views/view_disassembler.hpp
@@ -41,6 +41,7 @@ namespace hex::plugin::disasm {
         std::vector<Disassembly> m_disassembly;
 
         void disassemble();
+        void exportToFile();
     };
 
 }

--- a/plugins/disassembler/romfs/lang/de_DE.json
+++ b/plugins/disassembler/romfs/lang/de_DE.json
@@ -17,6 +17,8 @@
         "hex.disassembler.view.disassembler.bpf.classic": "Classic",
         "hex.disassembler.view.disassembler.bpf.extended": "Extended",
         "hex.disassembler.view.disassembler.disassemble": "Disassemble",
+        "hex.disassembler.view.disassembler.export": "Exportieren",
+        "hex.disassembler.view.disassembler.export.popup.error": "Der Export zur ASM-Datei ist fehlgeschlagen.",
         "hex.disassembler.view.disassembler.disassembling": "Disassemblen...",
         "hex.disassembler.view.disassembler.disassembly.address": "Adresse",
         "hex.disassembler.view.disassembler.disassembly.bytes": "Byte",

--- a/plugins/disassembler/romfs/lang/en_US.json
+++ b/plugins/disassembler/romfs/lang/en_US.json
@@ -17,6 +17,8 @@
         "hex.disassembler.view.disassembler.bpf.classic": "Classic",
         "hex.disassembler.view.disassembler.bpf.extended": "Extended",
         "hex.disassembler.view.disassembler.disassemble": "Disassemble",
+        "hex.disassembler.view.disassembler.export": "Export to file",
+        "hex.disassembler.view.disassembler.export.popup.error": "Failed to export to ASM file!",
         "hex.disassembler.view.disassembler.disassembling": "Disassembling...",
         "hex.disassembler.view.disassembler.disassembly.address": "Address",
         "hex.disassembler.view.disassembler.disassembly.bytes": "Byte",

--- a/plugins/disassembler/romfs/lang/en_US.json
+++ b/plugins/disassembler/romfs/lang/en_US.json
@@ -17,7 +17,7 @@
         "hex.disassembler.view.disassembler.bpf.classic": "Classic",
         "hex.disassembler.view.disassembler.bpf.extended": "Extended",
         "hex.disassembler.view.disassembler.disassemble": "Disassemble",
-        "hex.disassembler.view.disassembler.export": "Export to file",
+        "hex.disassembler.view.disassembler.export": "Export instructions as...",
         "hex.disassembler.view.disassembler.export.popup.error": "Failed to export to ASM file!",
         "hex.disassembler.view.disassembler.disassembling": "Disassembling...",
         "hex.disassembler.view.disassembler.disassembly.address": "Address",

--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -99,7 +99,7 @@ namespace hex::plugin::disasm {
                 fs::openFileBrowser(fs::DialogMode::Save, {}, [this](const std::fs::path &path) {
                     auto p = path;
                     if (p.extension() != ".asm")
-                        p.replace_filename(std::format("{}{}", p.filename().string(), ".asm"));
+                        p.replace_filename(hex::format("{}{}", p.filename().string(), ".asm"));
                     auto file = wolv::io::File(p, wolv::io::File::Mode::Create);
 
                     if (!file.isValid()) {
@@ -108,8 +108,8 @@ namespace hex::plugin::disasm {
                     }
 
                     // as disassembly code can be quite long, we prefer writing each disassembled instruction to file
-                    for (Disassembly d : m_disassembly) {
-                        file.writeString(std::format("{} {}\n", d.mnemonic, d.operators));
+                    for (const Disassembly& d : m_disassembly) {
+                        file.writeString(hex::format("{} {}\n", d.mnemonic, d.operators));
                     }
                 });
             });

--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -107,9 +107,16 @@ namespace hex::plugin::disasm {
                         return;
                     }
 
-                    // as disassembly code can be quite long, we prefer writing each disassembled instruction to file
+                    // As disassembly code can be quite long, we prefer writing each disassembled instruction to file
                     for (const Disassembly& d : m_disassembly) {
-                        file.writeString(hex::format("{} {}\n", d.mnemonic, d.operators));
+                        // We test for a "bugged" case that should never happen - the instruction should always have a mnemonic
+                        if (d.mnemonic.empty())
+                            continue;
+
+                        if (d.operators.empty())
+                            file.writeString(hex::format("{}\n", d.mnemonic));
+                        else
+                            file.writeString(hex::format("{} {}\n", d.mnemonic, d.operators));
                     }
                 });
             });
@@ -414,14 +421,15 @@ namespace hex::plugin::disasm {
             }
             ImGui::EndDisabled();
 
-            // Draw export to file button
+            // Draw export to file icon button
             ImGui::SameLine();
             ImGui::BeginDisabled(m_disassemblerTask.isRunning() || m_disassembly.empty());
             {
-                if (ImGui::Button("hex.disassembler.view.disassembler.export"_lang))
+                if (ImGuiExt::DimmedIconButton(ICON_VS_EXPORT, ImGui::GetStyleColorVec4(ImGuiCol_Text)))
                     this->exportToFile();
             }
             ImGui::EndDisabled();
+            ImGuiExt::InfoTooltip("hex.disassembler.view.disassembler.export"_lang);
 
             // Draw a spinner if the disassembler is running
             if (m_disassemblerTask.isRunning()) {

--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -6,6 +6,7 @@
 #include <fonts/codicons_font.h>
 
 #include <cstring>
+#include <toasts/toast_notification.hpp>
 
 using namespace std::literals::string_literals;
 
@@ -89,6 +90,29 @@ namespace hex::plugin::disasm {
 
                 cs_close(&capstoneHandle);
             }
+        });
+    }
+
+    void ViewDisassembler::exportToFile() {
+        TaskManager::createTask("hex.ui.common.processing"_lang, TaskManager::NoProgress, [this](auto &) {
+            TaskManager::doLater([this] {
+                fs::openFileBrowser(fs::DialogMode::Save, {}, [this](const std::fs::path &path) {
+                    auto p = path;
+                    if (p.extension() != ".asm")
+                        p.replace_filename(std::format("{}{}", p.filename().string(), ".asm"));
+                    auto file = wolv::io::File(p, wolv::io::File::Mode::Create);
+
+                    if (!file.isValid()) {
+                        ui::ToastError::open("hex.disassembler.view.disassembler.export.popup.error"_lang);
+                        return;
+                    }
+
+                    // as disassembly code can be quite long, we prefer writing each disassembled instruction to file
+                    for (Disassembly d : m_disassembly) {
+                        file.writeString(std::format("{} {}\n", d.mnemonic, d.operators));
+                    }
+                });
+            });
         });
     }
 
@@ -390,9 +414,17 @@ namespace hex::plugin::disasm {
             }
             ImGui::EndDisabled();
 
+            // Draw export to file button
+            ImGui::SameLine();
+            ImGui::BeginDisabled(m_disassemblerTask.isRunning() || m_disassembly.empty());
+            {
+                if (ImGui::Button("hex.disassembler.view.disassembler.export"_lang))
+                    this->exportToFile();
+            }
+            ImGui::EndDisabled();
+
             // Draw a spinner if the disassembler is running
             if (m_disassemblerTask.isRunning()) {
-                ImGui::SameLine();
                 ImGuiExt::TextSpinner("hex.disassembler.view.disassembler.disassembling"_lang);
             }
 


### PR DESCRIPTION

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
This PR implements the feature request #1781, that suggests adding a button to export disassembled instructions into an ASM file.

### Implementation description
This adds a button to export the current disassembled instructions to an ASM file. Said file is suffixed by an `.asm` extension if not specified at file creation.

*Note: the file is written to for every `Disassembly` item in the vector, as it was the easiest and most memory-conservative way of doing it.*

The file creation task is implemented based on IPS patch exports, so it fits the same pattern.
A `ToastError` is raised when the ASM export could not complete successfully.

Translations have been implemented for both `en_US` and `de_DE` for the two new keys:
- `hex.disassembler.view.disassembler.export`: file export button
- `hex.disassembler.view.disassembler.export.popup.error`: error popup text

### Screenshots
The button is disabled when the disassembler is working, or when the disassembly vector is empty.

Here is a complete breakdown of the visual changes:
![image](https://github.com/user-attachments/assets/af0ce701-9d77-45f1-9a5a-90d68d00bb0d)

### Additional things
As expected, the exporter writes every item's `mnemonic` and `operators` to the file, producing an output like this:

`example.asm`
```asm
.byte 0x7f, 0x45, 0x4c, 0x46
andeq r0, r1, r2, lsl #2
andeq r0, r0, r0
andeq r0, r0, r0
eorseq r0, lr, r3
andeq r0, r0, r1
andeq r1, r0, r0, asr #32
andeq r0, r0, r0
andeq r0, r0, r0, asr #32
```