### PR TITLE
Feat: Added clickable links to error messages.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -154,7 +154,7 @@ public:
     public:
         CursorChangeBox()=default;
         explicit CursorChangeBox(const ImRect &box) : ActionableBox(box) {
-            setCallback( [this]() {
+            setCallback([]() {
                 ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
             });
         }
@@ -183,7 +183,7 @@ public:
     public:
         ErrorHoverBox()=default;
         ErrorHoverBox(const ImRect &box, const Coordinates &pos,const char *errorText) : ActionableBox(box), mPos(pos), mErrorText(errorText) {
-            setCallback( [this]() {
+            setCallback([this]() {
                 ImGui::BeginTooltip();
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.2f, 0.2f, 1.0f));
                 ImGui::Text("Error at line %d:", mPos.mLine);

--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -190,7 +190,7 @@ public:
                 ImGui::PopStyleColor();
                 ImGui::Separator();
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.2f, 1.0f));
-                ImGui::Text("%s", mErrorText.c_str());
+                ImGui::TextUnformatted(mErrorText.c_str());
                 ImGui::PopStyleColor();
                 ImGui::EndTooltip();
                 }
@@ -262,7 +262,11 @@ public:
     void ClearCursorBoxes() {
         mCursorBoxes.clear();
     }
-
+    void ClearActionables() {
+        ClearErrorMarkers();
+        ClearGotoBoxes();
+        ClearCursorBoxes();
+    }
 
     struct Selection {
         Coordinates mStart;
@@ -311,6 +315,12 @@ public:
     class FindReplaceHandler;
 
 public:
+    void AddClickableText(std::string text) {
+        mClickableText.push_back(text);
+    }
+    void ClearClickableText() {
+        mClickableText.clear();
+    }
     FindReplaceHandler *GetFindReplaceHandler() { return &mFindReplaceHandler; }
 	int GetTotalLines() const { return (int)mLines.size(); }
 	bool IsOverwrite() const { return mOverwrite; }
@@ -597,6 +607,8 @@ private:
 	float mLastClick;
     bool mShowCursor;
     bool mShowLineNumbers;
+
+    std::vector<std::string>  mClickableText;
 
     static const int sCursorBlinkInterval;
     static const int sCursorBlinkOnTime;

--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <regex>
 #include "imgui.h"
+#include "imgui_internal.h"
 
 class TextEditor
 {
@@ -132,12 +133,73 @@ public:
 	using Identifiers = std::unordered_map<std::string, Identifier>;
 	using Keywords = std::unordered_set<std::string> ;
     using ErrorMarkers = std::map<Coordinates, std::pair<uint32_t ,std::string>>;
-    using ErrorHoverBoxes = std::map<Coordinates, std::pair<ImVec2,ImVec2>>;
     using Breakpoints = std::unordered_set<uint32_t>;
     using Palette = std::array<ImU32, (uint32_t)PaletteIndex::Max>;
     using Char = uint8_t ;
 
-	struct Glyph
+    class ActionableBox {
+
+        ImRect mBox;
+    public:
+        ActionableBox()=default;
+        explicit ActionableBox(const ImRect &box) : mBox(box) {}
+        std::function<void()> mCallback;
+        virtual bool trigger() {
+            return ImGui::IsMouseHoveringRect(mBox.Min,mBox.Max);
+        }
+        void setCallback(const std::function<void()> &callback) { mCallback = callback; }
+    };
+
+    class CursorChangeBox : public ActionableBox {
+    public:
+        CursorChangeBox()=default;
+        explicit CursorChangeBox(const ImRect &box) : ActionableBox(box) {
+            setCallback( [this]() {
+                ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+            });
+        }
+    };
+
+    class ErrorGotoBox : public ActionableBox {
+        Coordinates mPos;
+    public:
+        ErrorGotoBox()=default;
+        ErrorGotoBox(const ImRect &box, const Coordinates &pos, TextEditor *editor) : ActionableBox(box), mPos(pos) {
+            setCallback( [this,editor]() {
+                editor->JumpToCoords(mPos);
+            });
+        }
+        bool trigger() override {
+            return ActionableBox::trigger() && ImGui::IsMouseClicked(0);
+        }
+    };
+
+    using ErrorGotoBoxes = std::map<Coordinates, ErrorGotoBox>;
+    using CursorBoxes = std::map<Coordinates, CursorChangeBox>;
+
+    class ErrorHoverBox : public ActionableBox {
+        Coordinates mPos;
+        std::string mErrorText;
+    public:
+        ErrorHoverBox()=default;
+        ErrorHoverBox(const ImRect &box, const Coordinates &pos,const char *errorText) : ActionableBox(box), mPos(pos), mErrorText(errorText) {
+            setCallback( [this]() {
+                ImGui::BeginTooltip();
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.2f, 0.2f, 1.0f));
+                ImGui::Text("Error at line %d:", mPos.mLine);
+                ImGui::PopStyleColor();
+                ImGui::Separator();
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.2f, 1.0f));
+                ImGui::Text("%s", mErrorText.c_str());
+                ImGui::PopStyleColor();
+                ImGui::EndTooltip();
+                }
+            );
+        }
+    };
+    using ErrorHoverBoxes = std::map<Coordinates, ErrorHoverBox>;
+
+    struct Glyph
 	{
 		Char mChar;
 		PaletteIndex mColorIndex = PaletteIndex::Default;
@@ -188,6 +250,19 @@ public:
 		static const LanguageDefinition& AngelScript();
 		static const LanguageDefinition& Lua();
 	};
+    void ClearErrorMarkers() {
+        mErrorMarkers.clear();
+        mErrorHoverBoxes.clear();
+    }
+
+    void ClearGotoBoxes() {
+        mErrorGotoBoxes.clear();
+    }
+
+    void ClearCursorBoxes() {
+        mCursorBoxes.clear();
+    }
+
 
     struct Selection {
         Coordinates mStart;
@@ -210,6 +285,8 @@ public:
 
 	void Render(const char* aTitle, const ImVec2& aSize = ImVec2(), bool aBorder = false);
 	void SetText(const std::string& aText);
+    void JumpToLine(int line);
+    void JumpToCoords(const Coordinates &coords);
 	std::string GetText() const;
     bool isEmpty() const {
         auto text = GetText();
@@ -221,12 +298,26 @@ public:
 
 	std::string GetSelectedText() const;
 	std::string GetCurrentLineText()const;
+
+    std::string GetLineText(int line)const;
+    void SetSourceCodeEditor(TextEditor *editor) { mSourceCodeEditor = editor; }
+    TextEditor *GetSourceCodeEditor() {
+        if(mSourceCodeEditor!=nullptr)
+            return mSourceCodeEditor;
+        return this;
+    }
+
+
     class FindReplaceHandler;
 
 public:
     FindReplaceHandler *GetFindReplaceHandler() { return &mFindReplaceHandler; }
 	int GetTotalLines() const { return (int)mLines.size(); }
 	bool IsOverwrite() const { return mOverwrite; }
+    void setFocusAtCoords(const Coordinates &coords) {
+        mFocusAtCoords = coords;
+        mUpdateFocus = true;
+    }
     void SetOverwrite(bool aValue) { mOverwrite = aValue; }
 
 	void SetReadOnly(bool aValue);
@@ -244,7 +335,8 @@ public:
 
 	Coordinates GetCursorPosition() const { return GetActualCursorCoordinates(); }
 	void SetCursorPosition(const Coordinates& aPosition);
-
+    Coordinates mFocusAtCoords;
+    bool mUpdateFocus = false;
 	inline void SetHandleMouseInputs    (bool aValue){ mHandleMouseInputs    = aValue;}
 	inline bool IsHandleMouseInputsEnabled() const { return mHandleKeyboardInputs; }
 
@@ -490,11 +582,14 @@ private:
 	Breakpoints mBreakpoints;
 	ErrorMarkers mErrorMarkers;
     ErrorHoverBoxes mErrorHoverBoxes;
+    ErrorGotoBoxes mErrorGotoBoxes;
+    CursorBoxes mCursorBoxes;
 	ImVec2 mCharAdvance;
 	Coordinates mInteractiveStart, mInteractiveEnd;
 	std::string mLineBuffer;
 	uint64_t mStartTime;
 	std::vector<std::string> mDefines;
+    TextEditor *mSourceCodeEditor=nullptr;
     float m_linesAdded = 0;
     float m_savedScrollY = 0;
     float m_pixelsAdded = 0;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -971,10 +971,18 @@ void TextEditor::Render() {
             // Render goto buttons
             auto lineText = GetLineText(lineNo);
             Coordinates gotoKey = Coordinates(lineNo + 1, 0);
-            bool type1 = lineText.find("E: <Source Code>:") == 0;
-            bool type2 = lineText.find("E:   -->   in <Source Code>:") == 0;
-            if (type1 || type2) {
-                std::string errorLineColumn = type1 ? lineText.substr(17) : lineText.substr(28);
+            std::string errorLineColumn;
+            bool found = false;
+            for (auto text : mClickableText) {
+                if (lineText.find(text) == 0) {
+                    errorLineColumn = lineText.substr(text.size());
+                    if (!errorLineColumn.empty()) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (found) {
                 int currLine = 0, currColumn = 0;
                 if (auto idx = errorLineColumn.find(":"); idx != std::string::npos) {
                     auto errorLine = errorLineColumn.substr(0, idx);

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -214,6 +214,7 @@ namespace hex::plugin::builtin {
         m_consoleEditor.SetReadOnly(true);
         m_consoleEditor.SetShowCursor(false);
         m_consoleEditor.SetShowLineNumbers(false);
+        m_consoleEditor.SetSourceCodeEditor(&m_textEditor);
 
         this->registerEvents();
         this->registerMenuItems();
@@ -1747,8 +1748,12 @@ namespace hex::plugin::builtin {
         m_runningEvaluators += 1;
         m_executionDone.get(provider) = false;
 
-
-        m_textEditor.SetErrorMarkers({});
+        m_textEditor.ClearErrorMarkers();
+        m_textEditor.ClearGotoBoxes();
+        m_textEditor.ClearCursorBoxes();
+        m_consoleEditor.ClearErrorMarkers();
+        m_consoleEditor.ClearGotoBoxes();
+        m_consoleEditor.ClearCursorBoxes();
         m_console.get(provider).clear();
         m_consoleNeedsUpdate = true;
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -215,6 +215,12 @@ namespace hex::plugin::builtin {
         m_consoleEditor.SetShowCursor(false);
         m_consoleEditor.SetShowLineNumbers(false);
         m_consoleEditor.SetSourceCodeEditor(&m_textEditor);
+        std::string sourcecode = pl::api::Source::DefaultSource;
+        std::string error = "E: ";
+        std::string end = ":";
+        std::string arrow = "  -->   in ";
+        m_consoleEditor.AddClickableText(error + sourcecode + end);
+        m_consoleEditor.AddClickableText(error + arrow + sourcecode + end);
 
         this->registerEvents();
         this->registerMenuItems();
@@ -1748,12 +1754,9 @@ namespace hex::plugin::builtin {
         m_runningEvaluators += 1;
         m_executionDone.get(provider) = false;
 
-        m_textEditor.ClearErrorMarkers();
-        m_textEditor.ClearGotoBoxes();
-        m_textEditor.ClearCursorBoxes();
-        m_consoleEditor.ClearErrorMarkers();
-        m_consoleEditor.ClearGotoBoxes();
-        m_consoleEditor.ClearCursorBoxes();
+        m_textEditor.ClearActionables();
+
+        m_consoleEditor.ClearActionables();
         m_console.get(provider).clear();
         m_consoleNeedsUpdate = true;
 


### PR DESCRIPTION
Errors printed in the console can be clicked to have the cursor jump to the source code line where the error is at. 

The mouse cursor changes its shape to indicate which parts of the error message can be clicked on the console. When the cursor jumps, the text editor takes the focus away from the console and it scrolls the window to make the line with the error is visible if it isn't. This code uses the function created for the go-to PR but adds code to switch focus to the target. When the codes are merged please keep both the part that jumps the cursor and the part that sets the focus.
