### PR TITLE
Add capability to paste as string literal in files

### DIFF
--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -818,6 +818,7 @@
         "hex.builtin.view.hex_editor.menu.edit.jump_to.curr_pattern": "Current Pattern",
         "hex.builtin.view.hex_editor.menu.edit.open_in_new_provider": "Open selection view...",
         "hex.builtin.view.hex_editor.menu.edit.paste": "Paste",
+        "hex.builtin.view.hex_editor.menu.edit.paste_as": "Paste...",
         "hex.builtin.view.hex_editor.menu.edit.paste_all": "Paste all",
         "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Paste all as string",
         "hex.builtin.view.hex_editor.menu.edit.remove": "Remove...",

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -819,6 +819,7 @@
         "hex.builtin.view.hex_editor.menu.edit.open_in_new_provider": "Open selection view...",
         "hex.builtin.view.hex_editor.menu.edit.paste": "Paste",
         "hex.builtin.view.hex_editor.menu.edit.paste_all": "Paste all",
+        "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Paste all as string",
         "hex.builtin.view.hex_editor.menu.edit.remove": "Remove...",
         "hex.builtin.view.hex_editor.menu.edit.resize": "Resize...",
         "hex.builtin.view.hex_editor.menu.edit.select_all": "Select all",

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -1196,17 +1196,20 @@ namespace hex::plugin::builtin {
                                                 ImHexApi::HexEditor::isSelectionValid,
                                                 this);
 
-        /* Paste All */
-        ContentRegistry::Interface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_all" }, ICON_VS_CLIPPY, 1500, CurrentView + CTRLCMD + SHIFT + Keys::V,
+        /* Paste... */
+        ContentRegistry::Interface::addMenuItemSubMenu({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_as" }, ICON_VS_CLIPPY, 1490, []{}, ImHexApi::HexEditor::isSelectionValid);
+
+        /* Paste... > Paste all */
+        ContentRegistry::Interface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_as", "hex.builtin.view.hex_editor.menu.edit.paste_all" }, ICON_VS_CLIPPY, 1500, CurrentView + CTRLCMD + SHIFT + Keys::V,
                                                 [] {
                                                     pasteBytes(ImHexApi::HexEditor::getSelection().value_or( ImHexApi::HexEditor::ProviderRegion(Region { 0, 0 }, ImHexApi::Provider::get())), false, false);
                                                 },
                                                 ImHexApi::HexEditor::isSelectionValid,
                                                 this);
 
-        /* Paste All as text */
-        ContentRegistry::Interface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_all_string" }, ICON_VS_CLIPPY, 1500,
-                                                CurrentView + CTRLCMD + SHIFT + ALT + Keys::V,
+        /* Paste... > Paste all as string */
+        ContentRegistry::Interface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_as", "hex.builtin.view.hex_editor.menu.edit.paste_all_string" }, ICON_VS_SYMBOL_TEXT, 1510,
+                                                Shortcut::None,
                                                 [] {
                                                     pasteBytes(ImHexApi::HexEditor::getSelection().value_or( ImHexApi::HexEditor::ProviderRegion(Region { 0, 0 }, ImHexApi::Provider::get())), false, true);
                                                 },


### PR DESCRIPTION
### Problem description
As suggested in #1904, ImHex could benefit from having the capability of pasting text directly into the editor.
This also complements the "Copy as... ASCII string" capability already implemented in the software.

### Implementation description
A new shortcut called `Paste all as string` (to resemble the naming of the `ASCII string` copy option) now allows to paste plaintext directly.
This shortcut is mapped to the `CTRL + ALT + SHIFT + V` keybind.

Internally, a new flag called `asPlainText` has been added to the `pasteBytes` function, to minimise code changes and streamline code readability.
The buffer is a simple type cast of the clipboard, without any modification applied, which is then handed to the provider's `write` function.

### Screenshots
The new shortcut is visible in the menu, just below the other paste options:
![image](https://github.com/user-attachments/assets/41a2a512-5c39-4984-bab6-114c58266351)
