### PR TITLE
Fix doubled Chinese (Simplified) translation

### DIFF
--- a/plugins/script_loader/romfs/lang/zh_CN.json
+++ b/plugins/script_loader/romfs/lang/zh_CN.json
@@ -1,5 +1,5 @@
 {
-    "code": "zh_CN",
+    "code": "zh-CN",
     "country": "China",
     "language": "Chinese (Simplified)",
     "translations": {


### PR DESCRIPTION
### Problem description
As described in issue #1841, there was a duplicate on the `Chinese (Simplified)` translation.
After closer inspection, this came from an i18n file (Script loader, specifically) having a bad ISO code (`zh_CN` instead of the expected `zh-CN`).

This also caused a big impact on end users, as loading the latter (`zh_CN`) would cause the whole UI to be displayed in English (the fallback language), and only the script loader being translated into Chinese.

### Implementation description
Fixed the i18n code in the Script loader file.

### Additional things
Closes issue #1841
