### PR TITLE
improv: VScode like scrolling

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -559,6 +559,7 @@ private:
 	int GetCharacterColumn(int aLine, int aIndex) const;
 	int GetLineCharacterCount(int aLine) const;
     int Utf8CharsToBytes(const Coordinates &aCoordinates) const;
+    int GetLongestLineLength() const;
     unsigned long long GetLineByteCount(int aLine) const;
 	int GetStringCharacterCount(std::string str) const;
 	int GetLineMaxColumn(int aLine) const;
@@ -595,6 +596,7 @@ private:
 	bool mScrollToTop;
 	bool mTextChanged;
 	bool mColorizerEnabled;
+    float mLongest;
 	float mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
 	int  mLeftMargin;
 	bool mCursorPositionChanged;


### PR DESCRIPTION
I have implemented a fix that makes the scrollbars behave like they do in VScode. Vertically you can scroll past the end of the file until only the last line can be seen at the top. The horizontal bar behaves as if every line was the same length which is the length of the longest line in the file. Not only this creates a better user experience, but it also fixes the annoying flicker that occurs when scrolling through large files. Also, I have switched all the old draw calls to render text to regular TextUnformatted calls which adds extra stability to the resulting display.

To implement the behavior I added a dummy widget with the desired dimensions.
