### PR TITLE
Better top margin handling.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -306,7 +306,7 @@ public:
         auto text = GetText();
         return text.empty() || text == "\n";
     }
-
+    void SetTopLine();
 	void SetTextLines(const std::vector<std::string>& aLines);
 	std::vector<std::string> GetTextLines() const;
 
@@ -586,6 +586,7 @@ private:
     bool mScrollToBottom;
     float mTopMargin;
     float mNewTopMargin;
+    float mOldTopMargin;
     bool mTopMarginChanged=false;
 
 	int mTabSize;
@@ -599,6 +600,8 @@ private:
     float mLongest;
 	float mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
 	int  mLeftMargin;
+    int mTopLine;
+    bool mSetTopLine;
 	bool mCursorPositionChanged;
     bool mBreakPointsChanged;
 	int mColorRangeMin, mColorRangeMax;
@@ -624,10 +627,10 @@ private:
 	uint64_t mStartTime;
 	std::vector<std::string> mDefines;
     TextEditor *mSourceCodeEditor=nullptr;
-    float m_linesAdded = 0;
-    float m_savedScrollY = 0;
-    float m_pixelsAdded = 0;
-    float m_shiftedScrollY = 0;
+    float mSavedScrollY = 0;
+    float mShiftedScrollY = 0;
+    float mScrollY = 0;
+    int mNumberOfLinesDisplayed;
 	float mLastClick;
     bool mShowCursor;
     bool mShowLineNumbers;


### PR DESCRIPTION
The top margin changes when popups block some portion on the screen. Previously it was implemented adding blank lines at the bottom which created problems if the windows was scrolled all the way to the bottom and the popups were issued. The newer implementation doesn't use spaces and simply resets the top of the window to be higher making the popup interaction with the window more natural (no text disappears on the lines the popup overlaps the text). changes can be identified form the variables mTopMargin,mOldTopMargin and mNewTopMargin.

Unfortunately those changes revealed problems in cursor navigation that needed to be addressed. Namely, the window will scroll up and down on the line before last/second line at the top and similar problems for the left and right. Those changes correspond to the function EnsureCUrsorVisible()

Fixing those reveled yet more problems with scrolling past the end of the file using the keyboard which required adding some more variables and functions to support the correct handling, You find those changes in the function MoveDown.

I also renamed some variables that had the wrong casing and fixed the pasting but that is missing one line.
