### PR TITLE
Improved scrolling

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -576,7 +576,7 @@ private:
 
 	void HandleKeyboardInputs();
 	void HandleMouseInputs();
-	void Render();
+	void RenderText(const char *aTitle, const ImVec2 &lineNumbersStartPos, const ImVec2 &textEditorSize);
 
 	float mLineSpacing = 1.0F;
 	Lines mLines;
@@ -597,6 +597,7 @@ private:
 	bool mScrollToTop = false;
 	bool mTextChanged = false;
 	bool mColorizerEnabled = true;
+    float mLineNumberFieldWidth = 0.0F;
     float mLongest = 0.0F;
 	float mTextStart = 20.0F;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
 	int  mLeftMargin = 10;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -1237,7 +1237,7 @@ void TextEditor::Render(const char *aTitle, const ImVec2 &aSize, bool aBorder) {
     mLongest        = GetLongestLineLength() * mCharAdvance.x;
     bool scroll_x = mLongest > textEditorSize.x;
     bool scroll_y = mLines.size() > 1;
-    if (scroll_y)
+    if (!aBorder && scroll_y)
         textEditorSize.x -= scrollBarSize;
     ImGui::SetCursorScreenPos(ImVec2(position.x + mLineNumberFieldWidth, position.y));
     ImGuiChildFlags childFlags  = aBorder ? ImGuiChildFlags_Borders : ImGuiChildFlags_None;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -1166,7 +1166,10 @@ void TextEditor::RenderText(const char *aTitle, const ImVec2 &lineNumbersStartPo
     if (!mIgnoreImGuiChild)
         ImGui::BeginChild(aTitle);
 
-    ImGui::Dummy(ImVec2(mLongest, (globalLineMax - lineMax - 2) * mCharAdvance.y + ImGui::GetCurrentWindow()->InnerClipRect.GetHeight()));
+    if (mShowLineNumbers)
+        ImGui::Dummy(ImVec2(mLongest, (globalLineMax - lineMax - 2) * mCharAdvance.y + ImGui::GetCurrentWindow()->InnerClipRect.GetHeight()));
+    else
+        ImGui::Dummy(ImVec2(mLongest, (globalLineMax - 1 - lineMax + GetPageSize() - 1) * mCharAdvance.y));
 
     if (mScrollToCursor)
         EnsureCursorVisible();
@@ -3062,7 +3065,7 @@ void TextEditor::EnsureCursorVisible() {
 }
 
 int TextEditor::GetPageSize() const {
-    auto height = ImGui::GetWindowHeight() - mTopMargin;
+    auto height = ImGui::GetCurrentWindow()->InnerClipRect.GetHeight() - mTopMargin - ImGui::GetStyle().FramePadding.y;
     return (int)floor(height / mCharAdvance.y);
 }
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -322,23 +322,22 @@ namespace hex::plugin::builtin {
         if (ImHexApi::Provider::isValid() && provider->isAvailable()) {
             static float height = 0;
             static bool dragging = false;
-
-            const auto availableSize = ImGui::GetContentRegionAvail();
+            const ImGuiContext& g = *GImGui;
+            if (g.CurrentWindow->Appearing)
+                return;
+            const auto availableSize = g.CurrentWindow->Size;
             const auto windowPosition = ImGui::GetCursorScreenPos();
             auto textEditorSize = availableSize;
             textEditorSize.y *= 3.5 / 5.0;
             textEditorSize.y -= ImGui::GetTextLineHeightWithSpacing();
-            textEditorSize.y += height;
+            textEditorSize.y = std::clamp(textEditorSize.y + height,200.0F, availableSize.y-200.0F);
 
-            if (availableSize.y > 1)
-                textEditorSize.y = std::clamp(textEditorSize.y, 1.0F, std::max(1.0F, availableSize.y - ImGui::GetTextLineHeightWithSpacing() * 3));
-            const ImGuiContext& g = *GImGui;
             if (g.NavWindow != nullptr) {
                 std::string name =  g.NavWindow->Name;
                 if (name.contains(textEditorView) || name.contains(consoleView))
                     m_focusedSubWindowName = name;
             }
-            m_textEditor.Render("hex.builtin.view.pattern_editor.name"_lang, textEditorSize, true);
+            m_textEditor.Render("hex.builtin.view.pattern_editor.name"_lang, textEditorSize, false);
             m_textEditorHoverBox = ImRect(windowPosition,windowPosition+textEditorSize);
             m_consoleHoverBox = ImRect(ImVec2(windowPosition.x,windowPosition.y+textEditorSize.y),windowPosition+availableSize);
             TextEditor::FindReplaceHandler *findReplaceHandler = m_textEditor.GetFindReplaceHandler();


### PR DESCRIPTION
Two major improvements:
1) see through scrollbars when not hovered.
2) un-scrollable line numbers.

Also enlarged display region by eliminating padding. There is still a problem with lines jumping when the scrollbar is dragged but it is limited to one line and probably due to floating point error for scroll bar number. It is much less noticeable than the previous jumping which could involve several pages.
