### PR TITLE
fix: console scroll jumping.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -307,6 +307,7 @@ public:
         return text.empty() || text == "\n";
     }
     void SetTopLine();
+    void SetScrollY();
 	void SetTextLines(const std::vector<std::string>& aLines);
 	std::vector<std::string> GetTextLines() const;
 
@@ -406,7 +407,7 @@ public:
 	void Cut();
 	void Paste();
 	void Delete();
-    int32_t GetPageSize() const;
+    float GetPageSize() const;
 
 	ImVec2 &GetCharAdvance() { return mCharAdvance; }
 
@@ -600,8 +601,8 @@ private:
     float mLineNumberFieldWidth = 0.0F;
     float mLongest = 0.0F;
 	float mTextStart = 20.0F;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
-	int  mLeftMargin = 10;
-    int mTopLine = 0;
+	float  mLeftMargin = 10.0;
+    float mTopLine = 0.0F;
     bool mSetTopLine = false;
 	bool mCursorPositionChanged = false;
     bool mBreakPointsChanged = false;
@@ -631,7 +632,9 @@ private:
     float mSavedScrollY = 0;
     float mShiftedScrollY = 0;
     float mScrollY = 0;
-    int mNumberOfLinesDisplayed = 0;
+    float mScrollYIncrement = 0.0F;
+    bool mSetScrollY = false;
+    float mNumberOfLinesDisplayed = 0;
 	float mLastClick = -1.0F;
     bool mShowCursor = true;
     bool mShowLineNumbers = true;

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -1015,6 +1015,8 @@
         "hex.builtin.view.pattern_editor.shortcut.move_word_right": "Move Cursor One Word to the Right",
         "hex.builtin.view.pattern_editor.shortcut.move_up": "Move Cursor One Line Up",
         "hex.builtin.view.pattern_editor.shortcut.move_down": "Move Cursor One Line Down",
+        "hex.builtin.view.pattern_editor.shortcut.move_pixel_up": "Move Cursor One Pixel Up",
+        "hex.builtin.view.pattern_editor.shortcut.move_pixel_down": "Move Cursor One Pixel Down",
         "hex.builtin.view.pattern_editor.shortcut.move_page_up": "Move Cursor One Page Up",
         "hex.builtin.view.pattern_editor.shortcut.move_page_down": "Move Cursor One Page Down",
         "hex.builtin.view.pattern_editor.shortcut.move_home": "Move Cursor to the Start of the Line",

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2513,6 +2513,11 @@ namespace hex::plugin::builtin {
                 editor->MoveUp(1, false);
         });
 
+        ShortcutManager::addShortcut(this, ALT + Keys::Up + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_up", [this] {
+            if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
+                editor->MoveUp(-1, false);
+        });
+
         ShortcutManager::addShortcut(this, Keys::PageUp + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_page_up", [this] {
             if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
                 editor->MoveUp(editor->GetPageSize()-4, false);
@@ -2521,6 +2526,11 @@ namespace hex::plugin::builtin {
         ShortcutManager::addShortcut(this, Keys::Down + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_down", [this] {
             if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
                 editor->MoveDown(1, false);
+        });
+
+        ShortcutManager::addShortcut(this, ALT+ Keys::Down + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_down", [this] {
+            if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
+                editor->MoveDown(-1, false);
         });
 
         ShortcutManager::addShortcut(this, Keys::PageDown + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_page_down", [this] {

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2513,7 +2513,7 @@ namespace hex::plugin::builtin {
                 editor->MoveUp(1, false);
         });
 
-        ShortcutManager::addShortcut(this, ALT + Keys::Up + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_up", [this] {
+        ShortcutManager::addShortcut(this, ALT + Keys::Up + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_pixel_up", [this] {
             if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
                 editor->MoveUp(-1, false);
         });
@@ -2528,7 +2528,7 @@ namespace hex::plugin::builtin {
                 editor->MoveDown(1, false);
         });
 
-        ShortcutManager::addShortcut(this, ALT+ Keys::Down + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_down", [this] {
+        ShortcutManager::addShortcut(this, ALT+ Keys::Down + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.move_pixel_down", [this] {
             if (auto editor = getEditorFromFocusedWindow(); editor != nullptr)
                 editor->MoveDown(-1, false);
         });


### PR DESCRIPTION
Some issues related to the padding added to scroll past the end for console that has padding added. 
Added a shortcut to scroll editors one pixel at a time.
 Fixed whole lines always drawn at the top even if scroll value is chosen so that only a portion of the top line is visible. This caused errors in horizontal scrolling. 
Fixed Ctrl-F Ctrl-G and Ctrl-H messing the editor display. 
Fixed the end of the line could not be clicked with mouse 
Fixed line numbers and their lines could be displayed at different heights. 
Made numbers that represented lines floats instead of integers to allow partial line display.
