### PR TITLE
fix: Set LZMA decompressor memory limit to 1GiB fixed

### DIFF
--- a/plugins/decompress/source/content/pl_functions.cpp
+++ b/plugins/decompress/source/content/pl_functions.cpp
@@ -155,7 +155,8 @@ namespace hex::plugin::decompress {
                 auto &section = evaluator->getSection(params[1].toUnsigned());
 
                 lzma_stream stream = LZMA_STREAM_INIT;
-                if (lzma_auto_decoder(&stream, 0x10000, LZMA_IGNORE_CHECK) != Z_OK) {
+                constexpr int64_t memlimit = 0x40000000;  // 1GiB
+                if (lzma_auto_decoder(&stream, memlimit, LZMA_IGNORE_CHECK) != LZMA_OK) {
                     return false;
                 }
 
@@ -179,8 +180,8 @@ namespace hex::plugin::decompress {
 
                     if (res == LZMA_MEMLIMIT_ERROR) {
                         auto usage = lzma_memusage(&stream);
-                        lzma_memlimit_set(&stream, usage);
-                        res = lzma_code(&stream, LZMA_RUN);
+                        evaluator->getConsole().log(pl::core::LogConsole::Level::Warning, fmt::format("lzma_decompress memory usage {} bytes would exceed the limit ({} bytes), aborting", usage, memlimit));
+                        return false;
                     }
 
                     if (res != LZMA_OK)


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

See #2033 (`hex::dec::lzma_decompress` reports an error when decompressing a small buffer).

### Implementation description
<!-- Explain what you did to correct the problem -->

Set the LZMA decompressor memory limit to 1GiB fixed. Print a warning when exceeded, and abort with returning `false`.

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

Normal result when decompressing a small buffer

![image](https://github.com/user-attachments/assets/5b9e6b07-464e-41f6-bdc7-f5b1cd351069)

Warning message when `memlimit` is exceeded: (Set to 64B here for a demo)
> W: lzma_decompress memory usage 1114168 bytes would exceed the limit (64 bytes), aborting

![image](https://github.com/user-attachments/assets/04abf3ef-1d29-4846-bb41-214695c7d09c)

### Additional things
<!-- Anything else you would like to say -->

Is the warning wording OK? I'm not a native English speaker so please change it if you want to.