### PR TITLE
fix: find jumps to wrong location.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -629,7 +629,6 @@ private:
 	uint64_t mStartTime = 0;
 	std::vector<std::string> mDefines;
     TextEditor *mSourceCodeEditor = nullptr;
-    float mSavedScrollY = 0;
     float mShiftedScrollY = 0;
     float mScrollY = 0;
     float mScrollYIncrement = 0.0F;

--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -1179,8 +1179,6 @@ void TextEditor::RenderText(const char *aTitle, const ImVec2 &lineNumbersStartPo
 
     if (mTopMarginChanged) {
         mTopMarginChanged = false;
-        if (mTopMargin == 0)
-            mSavedScrollY = ImGui::GetScrollY();
         auto window = ImGui::GetCurrentWindow();
         auto maxScroll = window->ScrollMax.y;
         if (maxScroll > 0) {
@@ -1196,10 +1194,8 @@ void TextEditor::RenderText(const char *aTitle, const ImVec2 &lineNumbersStartPo
 
             if (mNewTopMargin > mTopMargin)
                 mShiftedScrollY = oldScrollY + pixelCount;
-            else if (mNewTopMargin > 0)
-                mShiftedScrollY = oldScrollY - pixelCount;
             else
-                mShiftedScrollY = mSavedScrollY;
+                mShiftedScrollY = oldScrollY - pixelCount;
             ImGui::SetScrollY(mShiftedScrollY);
             mTopMargin = mNewTopMargin;
         }


### PR DESCRIPTION
After successfully finding matches and setting the cursor to them, the screen would jump to the original window location upon closing the window.

The error was caused by the wrong assumption that the scroll location should be restored when window is closed. Instead, the right amount of scrolling needs to be calculated to account for the window no longer covering part of the text editor. Unused variable was discarded.

Another unrelated error is that the history of search names cannot be accessed which will be addressed at a later PR.

