### PR TITLE
Draft: install include folders of plugins to sdk

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -506,16 +506,16 @@ function(downloadImHexPatternsFiles dest)
 
         # Maybe patterns are cloned to a subdirectory
         if (NOT EXISTS ${imhex_patterns_SOURCE_DIR})
-            set(imhex_patterns_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ImHex-Patterns")        
+            set(imhex_patterns_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ImHex-Patterns")
         endif()
 
         # Or a sibling directory
         if (NOT EXISTS ${imhex_patterns_SOURCE_DIR})
-            set(imhex_patterns_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../ImHex-Patterns")        
+            set(imhex_patterns_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../ImHex-Patterns")
         endif()
     endif ()
 
-    if (NOT EXISTS ${imhex_patterns_SOURCE_DIR}) 
+    if (NOT EXISTS ${imhex_patterns_SOURCE_DIR})
         message(WARNING "Failed to locate ImHex-Patterns repository, some resources will be missing during install!")
     elseif(XCODE)
         # The Xcode build has multiple configurations, which each need a copy of these files
@@ -790,17 +790,20 @@ function(enableUnityBuild TARGET)
     endif ()
 endfunction()
 
-function(generateSDKDirectory)
+function(setSDKPaths)
     if (WIN32)
-        set(SDK_PATH "./sdk")
+        set(SDK_PATH "./sdk" PARENT_SCOPE)
     elseif (APPLE)
-        set(SDK_PATH "${CMAKE_INSTALL_PREFIX}/${BUNDLE_NAME}/Contents/Resources/sdk")
+        set(SDK_PATH "${CMAKE_INSTALL_PREFIX}/${BUNDLE_NAME}/Contents/Resources/sdk" PARENT_SCOPE)
     else()
-        set(SDK_PATH "share/imhex/sdk")
+        set(SDK_PATH "share/imhex/sdk" PARENT_SCOPE)
     endif()
 
-    set(SDK_BUILD_PATH "${CMAKE_BINARY_DIR}/sdk")
+    set(SDK_BUILD_PATH "${CMAKE_BINARY_DIR}/sdk" PARENT_SCOPE)
+endfunction()
 
+function(generateSDKDirectory)
+    setSDKPaths()
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/libimhex DESTINATION "${SDK_PATH}/lib" PATTERN "**/source/*" EXCLUDE)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/external DESTINATION "${SDK_PATH}/lib")
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/third_party/imgui DESTINATION "${SDK_PATH}/lib/third_party" PATTERN "**/source/*" EXCLUDE)

--- a/cmake/modules/ImHexPlugin.cmake
+++ b/cmake/modules/ImHexPlugin.cmake
@@ -29,7 +29,9 @@ macro(add_imhex_plugin)
         endif()
     endif()
 
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "${CMAKE_INSTALL_PREFIX}/${SDK_PATH}/lib/plugins/${IMHEX_PLUGIN_NAME}/")
+    if (IMHEX_PLUGIN_LIBRARY_PLUGIN)
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "${CMAKE_INSTALL_PREFIX}/${SDK_PATH}/lib/plugins/${IMHEX_PLUGIN_NAME}/")
+    endif()
 
     # Define new project for plugin
     project(${IMHEX_PLUGIN_NAME})

--- a/cmake/modules/ImHexPlugin.cmake
+++ b/cmake/modules/ImHexPlugin.cmake
@@ -1,4 +1,5 @@
 macro(add_imhex_plugin)
+    setSDKPaths()
     # Parse arguments
     set(options LIBRARY_PLUGIN)
     set(oneValueArgs NAME IMHEX_VERSION)
@@ -27,6 +28,8 @@ macro(add_imhex_plugin)
             set(IMHEX_PLUGIN_SUFFIX ".hexplug")
         endif()
     endif()
+
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "${CMAKE_INSTALL_PREFIX}/${SDK_PATH}/lib/plugins/${IMHEX_PLUGIN_NAME}/")
 
     # Define new project for plugin
     project(${IMHEX_PLUGIN_NAME})


### PR DESCRIPTION
Partially fixes #2068 .

This assumes the headers are in "include" for all plugins - this is necessary since the INCLUDES argument of add_imhex_plugin may contain paths to third party libs, whose headers should not be copied. 
To fix this I think it is necessary to add a second argument like "PRIVATE_INCLUDES", which is included, but not installed.

With this it possible to append the ui plugin for example:
```
INCLUDES
        $ENV{IMHEX_SDK_PATH}/lib/plugins/ui/
```
and to link against it:
```    
LIBRARIES
        /usr/local/lib/imhex/plugins/ui.hexpluglib
```

In a follow-up in the CMake Template for plugins imho there should be fixed, that:

 - you can include plugin includes relative to the SDK Path
 - you can link plugins relative to the lib path + without the hexpluglib or hexplug extension