### PR TITLE
fix: fixes for issue #2084

### DIFF
--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -24,12 +24,12 @@ namespace pl::ptrn { class Pattern; }
 namespace hex::plugin::builtin {
 
 
-    constexpr static auto textEditorView    = "/Pattern editor_";
+    constexpr static auto textEditorView    = "/##pattern_editor_";
     constexpr static auto consoleView       = "/##console_";
     constexpr static auto variablesView     = "/##env_vars_";
     constexpr static auto settingsView      = "/##settings_";
     constexpr static auto sectionsView      = "/##sections_table_";
-    constexpr static auto virtualFilesView  = "/Virtual File Tree_";
+    constexpr static auto virtualFilesView  = "/##Virtual_File_Tree_";
     constexpr static auto debuggerView      = "/##debugger_";
 
     class PatternSourceCode {

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -341,7 +341,7 @@ namespace hex::plugin::builtin {
             }
 
             ImGui::PushFont(fonts::CodeEditor());
-            m_textEditor.Render("hex.builtin.view.pattern_editor.name"_lang, textEditorSize, false);
+            m_textEditor.Render("##pattern_editor", textEditorSize, false);
             ImGui::PopFont();
 
             m_textEditorHoverBox = ImRect(windowPosition,windowPosition+textEditorSize);


### PR DESCRIPTION
Fixes issue #2084 

Error in text editor prevented using shortcuts when language other than English was chosen. 

The code was mistakenly using localized name to test which window had focus a execute the shortcut. 

Fixed it by switching the name of the child window to the constant value used to check the windows focused identity.
