### PR TITLE
fix: Banner window scaling

### DIFF
--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -615,7 +615,7 @@ namespace hex {
 
             const auto windowPos = ImHexApi::System::getMainWindowPosition();
             float startY = windowPos.y + ImGui::GetTextLineHeight() + ((ImGui::GetTextLineHeight() + (ImGui::GetStyle().FramePadding.y * 2.0F)) * (onWelcomeScreen ? 1 : 2));
-            const auto height = 30_scaled;
+            const auto height = ImGui::GetTextLineHeightWithSpacing() * 1.5f;
 
             // Offset banner based on the size of the title bar. On macOS it's slightly taller
             #if defined(OS_MACOS)

--- a/plugins/ui/include/banners/banner_button.hpp
+++ b/plugins/ui/include/banners/banner_button.hpp
@@ -15,7 +15,10 @@ namespace hex::ui {
         void drawContent() override {
             const std::string buttonText = Lang(m_buttonText);
             const auto buttonSize = ImGui::CalcTextSize(buttonText.c_str());
-
+            const auto iconSize = ImGui::CalcTextSize(m_icon);
+            const auto textHeight = std::max(ImGui::CalcTextSize(Lang(m_message)).y, iconSize.y);
+            const auto textOffset = (ImGui::GetWindowHeight() - textHeight) / 2;
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + textOffset);
             ImGui::TextUnformatted(m_icon);
             ImGui::SameLine(0, 10_scaled);
 

--- a/plugins/ui/include/banners/banner_icon.hpp
+++ b/plugins/ui/include/banners/banner_icon.hpp
@@ -11,6 +11,9 @@ namespace hex::ui {
                 : Banner(color), m_icon(icon), m_message(std::move(message)) { }
 
         void drawContent() override {
+            auto textHeight = std::max(ImGui::CalcTextSize(Lang(m_message)).y, ImGui::CalcTextSize(m_icon).y);
+            auto textOffset = (ImGui::GetWindowHeight() - textHeight) / 2;
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + textOffset);
             ImGui::TextUnformatted(m_icon);
             ImGui::SameLine(0, 10_scaled);
             ImGui::TextUnformatted(Lang(m_message));


### PR DESCRIPTION
The banner windows did not scale with the fonts resulting in cropped text when font size was made bigger than normal.
fixed by ensuring the window is big enough and then making sure text is centered in the y-axis.