### PR TITLE
improv: better home shortcut for pattern editor

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -1858,8 +1858,11 @@ void TextEditor::TextEditor::MoveBottom(bool aSelect) {
 void TextEditor::MoveHome(bool aSelect) {
     ResetCursorBlinkTime();
     auto oldPos = mState.mCursorPosition;
-    SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, 0));
-
+    auto &line = mLines[mState.mCursorPosition.mLine];
+    auto home=0;
+    while (isspace(line[home].mChar))
+        home++;
+    SetCursorPosition(Coordinates(mState.mCursorPosition.mLine, home));
     if (mState.mCursorPosition != oldPos) {
         if (aSelect) {
             if (oldPos == mInteractiveStart)


### PR DESCRIPTION
The old home shortcut moved the cursor to column zero of the current line. 
Most editors move cursor to the first non-space character instead.

