### PR TITLE
fix: Console editor missed printed output.

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1079,7 +1079,7 @@ namespace hex::plugin::builtin {
                 skipNewLine = false;
                 content += m_console->at(lineCount + i);
             }
-            m_consoleEditor.SetText(content);
+            m_consoleEditor.InsertText(content);
 
             m_consoleNeedsUpdate = false;
         }


### PR DESCRIPTION
This change is to fix a bug reported in discord by berkus and Naheulf about the console missing output lines. The bug was caused by using SetText which replaces the existing text with the text in the argument.

To fix it use InsertText which puts the text at the current cursor position that was already set to the end of the current contents.

Code was tested with pattern used to reproduce the bug and seemed to work when evaluated repeatedly.
