### PR TITLE
build: Find regex component of Boost explicitly

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -829,7 +829,7 @@ macro(addBundledLibraries)
     endif()
 
     if (USE_SYSTEM_BOOST)
-        find_package(Boost REQUIRED)
+        find_package(Boost REQUIRED CONFIG COMPONENTS regex)
         set(BOOST_LIBRARIES Boost::regex)
     else()
         add_subdirectory(${THIRD_PARTY_LIBS_FOLDER}/boost ${CMAKE_CURRENT_BINARY_DIR}/boost EXCLUDE_FROM_ALL)


### PR DESCRIPTION
'Boost::regex' could not be found unless regex is specified explicitly on some systems.

cf. https://github.com/AOSC-Dev/aosc-os-abbs/pull/9798
cc. @chenx97

### Problem description
> Target "libimhex" links to: Boost::regex but the target was not found.
when building ImHex with system Boost.

### Implementation description
Add `COMPONENETS regex` to require regex library explicitly.
