### PR TITLE
feat: made undo work when importing pattern.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -263,7 +263,6 @@ int TextEditor::InsertTextAt(Coordinates & /* inout */ aWhere, const char *aValu
             while (i-- > 0)
                 line.insert(line.begin() + cindex++, Glyph(' ', PaletteIndex::Default));
 
-            cindex += d;
             aWhere.mColumn += d;
             aValue++;
         } else if (*aValue == '\n') {
@@ -1288,24 +1287,28 @@ void TextEditor::Render(const char *aTitle, const ImVec2 &aSize, bool aBorder) {
 }
 
 void TextEditor::SetText(const std::string &aText) {
+    UndoRecord u;
+    u.mBefore = mState;
+    u.mRemoved = GetText();
+    u.mRemovedStart = Coordinates(0, 0);
+    u.mRemovedEnd = Coordinates((int)mLines.size()-1, GetLineMaxColumn((int)mLines.size()-1));
     mLines.resize(1);
     mLines[0].clear();
     std::string text = PreprocessText(aText);
     for (auto chr : text) {
-        if (chr == '\r') {
-            // ignore the carriage return character
-        } else if (chr == '\n')
+        if (chr == '\n')
             mLines.push_back(Line());
-        else {
+        else
             mLines.back().push_back(Glyph(chr, PaletteIndex::Default));
-        }
     }
-
+    u.mAdded = text;
+    u.mAddedStart = Coordinates(0, 0);
+    u.mAddedEnd = Coordinates((int)mLines.size()-1, GetLineMaxColumn((int)mLines.size()-1));
     mTextChanged = true;
     mScrollToTop = true;
-
-    mUndoBuffer.clear();
-    mUndoIndex = 0;
+    u.mAfter = mState;
+    if (!mReadOnly)
+        AddUndo(u);
 
     Colorize();
 }


### PR DESCRIPTION
A user complained that they imported a file by accident when they meant to export it and as a result had trouble recovering the changes they were trying to save. Auto-save saved the day but there is no reason for not being able to undo changes after importing a pattern.

In fact, the previous implementation treated importing a pattern as a reset on the editor instance which actually erased all previous undo entries. Importing now is treated as a normal editing operation where the entire file is replaced with the imported pattern.
Since all imports use AddText it was easy to add an undo entry to that function while removing the part where the previous undo records were being deleted. 

Care is taken to add the preprocessed version of the imported file to the undo buffer so that unwanted chars don't sneak in. A bug was found in the handling of a tab char as well but hopefully it wont need to be used anymore.
