### PR TITLE
feat: set breakpoint clion style.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -872,7 +872,7 @@ void TextEditor::SetFocus() {
     ResetCursorBlinkTime();
     EnsureCursorVisible();
     if (!this->mReadOnly) {
-        ImGui::SetKeyboardFocusHere(-1);
+        ImGui::SetKeyboardFocusHere(0);
         mUpdateFocus = false;
     }
 }
@@ -977,6 +977,15 @@ void TextEditor::RenderText(const char *aTitle, const ImVec2 &lineNumbersStartPo
                     space += " ";
                 }
                 std::string lineNoStr = space + std::to_string((int)(lineNo + 1));
+                ImGui::SetCursorScreenPos(ImVec2(lineNumbersStartPos.x, lineStartScreenPos.y));
+                if (ImGui::InvisibleButton(lineNoStr.c_str(),ImVec2(mLineNumberFieldWidth,mCharAdvance.y))) {
+                    if (mBreakpoints.contains(lineNo + 1))
+                        mBreakpoints.erase(lineNo + 1);
+                    else
+                        mBreakpoints.insert(lineNo + 1);
+                    mBreakPointsChanged = true;
+                    JumpToCoords(mState.mCursorPosition);
+                }
                 TextUnformattedColoredAt(ImVec2(mLeftMargin + lineNoStartScreenPos.x, lineStartScreenPos.y), mPalette[(int) PaletteIndex::LineNumber], lineNoStr.c_str());
             }
 


### PR DESCRIPTION
Now that line numbers are not part of the line of code clicking them makes the text editor lose focus. This PR changes that by allowing the user to toggle breakpoints by clicking the field where the line number is located.

Not only will the text editor retain focus when breakpoints are set, but if other parts of ImHex had focus, then it will be transferred to the text editor's current cursor position when the line number field is clicked.

It is also possible to keep the focus where it was and only retain the focus if the text editor was focused when the break point is set. The change is very trivial so if that is preferred I can easily switch it.

