### PR TITLE
fix: include headers necessary to build with llvm

### DIFF
--- a/lib/libimhex/include/hex/helpers/http_requests_native.hpp
+++ b/lib/libimhex/include/hex/helpers/http_requests_native.hpp
@@ -4,6 +4,7 @@
 
     #include <string>
     #include <future>
+    #include <mutex>
 
     #include <hex/helpers/logger.hpp>
     #include <hex/helpers/fmt.hpp>

--- a/main/gui/source/messaging/linux.cpp
+++ b/main/gui/source/messaging/linux.cpp
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/file.h>
 
 #include <hex/helpers/logger.hpp>


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
ImHex fails to build on llvm-based system:
<details> <summary>Error 1</summary>

```
In file included from /home/heather/downloads/ImHex/lib/libimhex/source/helpers/http_requests.cpp:1:
In file included from /home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests.hpp:158:
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:29: error: expected ';' after expression
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |                             ^
      |                             ;
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:18: error: no member named 'scoped_lock' in namespace 'std'; did you mean 'adopt_lock'?
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |             ~~~~~^~~~~~~~~~~
      |                  adopt_lock
/usr/include/c++/v1/__mutex/tag_types.h:35:31: note: 'adopt_lock' declared here
   35 | inline constexpr adopt_lock_t adopt_lock   = adopt_lock_t();
      |                               ^
In file included from /home/heather/downloads/ImHex/lib/libimhex/source/helpers/http_requests.cpp:1:
In file included from /home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests.hpp:158:
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:30: error: use of undeclared identifier 'lock'
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |                              ^
[ 67%] Building CXX object lib/libimhex/CMakeFiles/libimhex.dir/source/helpers/logger.cpp.o
3 errors generated.
gmake[2]: *** [lib/libimhex/CMakeFiles/libimhex.dir/build.make:373: lib/libimhex/CMakeFiles/libimhex.dir/source/helpers/http_requests.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /home/heather/downloads/ImHex/lib/libimhex/source/helpers/http_requests_native.cpp:3:
In file included from /home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests.hpp:158:
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:29: error: expected ';' after expression
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |                             ^
      |                             ;
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:18: error: no member named 'scoped_lock' in namespace 'std'; did you mean 'adopt_lock'?
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |             ~~~~~^~~~~~~~~~~
      |                  adopt_lock
/usr/include/c++/v1/__mutex/tag_types.h:35:31: note: 'adopt_lock' declared here
   35 | inline constexpr adopt_lock_t adopt_lock   = adopt_lock_t();
      |                               ^
In file included from /home/heather/downloads/ImHex/lib/libimhex/source/helpers/http_requests_native.cpp:3:
In file included from /home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests.hpp:158:
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:30: error: use of undeclared identifier 'lock'
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |                              ^
/home/heather/downloads/ImHex/lib/libimhex/include/hex/helpers/http_requests_native.hpp:82:13: error: expression result unused [-Werror,-Wunused-value]
   82 |             std::scoped_lock lock(m_transmissionMutex);
      |             ^~~~~~~~~~~~~~~~
/home/heather/downloads/ImHex/lib/libimhex/source/helpers/http_requests_native.cpp:92:26: note: in instantiation of function template specialization 'hex::HttpRequest::executeImpl<std::vector<unsigned char>>' requested here
   92 |             return this->executeImpl<std::vector<u8>>(response);
      |                          ^
4 errors generated.
gmake[2]: *** [lib/libimhex/CMakeFiles/libimhex.dir/build.make:387: lib/libimhex/CMakeFiles/libimhex.dir/source/helpers/http_requests_native.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:3284: lib/libimhex/CMakeFiles/libimhex.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

</details>

<details> <summary>Error 2</summary>

```
/home/heather/downloads/ImHex/main/gui/source/messaging/linux.cpp:32:25: error: no member named 'write' in the global namespace
   32 |         std::ignore = ::write(fifo, data, dataSize);
      |                       ~~^
/home/heather/downloads/ImHex/main/gui/source/messaging/linux.cpp:33:9: error: use of undeclared identifier 'close'
   33 |         close(fifo);
      |         ^
/home/heather/downloads/ImHex/main/gui/source/messaging/linux.cpp:37:9: error: use of undeclared identifier 'unlink'
   37 |         unlink(CommunicationPipePath);
      |         ^
/home/heather/downloads/ImHex/main/gui/source/messaging/linux.cpp:47:32: error: no member named 'read' in the global namespace
   47 |                 int result = ::read(fifo, buffer.data(), buffer.size());
      |                              ~~^
/home/heather/downloads/ImHex/main/gui/source/messaging/linux.cpp:63:13: error: use of undeclared identifier 'close'
   63 |             close(fifo);
      |             ^
```

</details>


### Implementation description
<!-- Explain what you did to correct the problem -->
Included necessary headers 

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->
None

### Additional things
<!-- Anything else you would like to say -->
None