### PR TITLE
fix: Correct behavior of Ctrl-Shift-Left/Right to be closer to other editors

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -1790,7 +1790,7 @@ void TextEditor::MoveLeft(int aAmount, bool aSelect, bool aWordMode) {
         }
     } else
         mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-    SetSelection(mInteractiveStart, mInteractiveEnd, aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
+    SetSelection(mInteractiveStart, mInteractiveEnd);
 
     EnsureCursorVisible();
 }
@@ -1846,7 +1846,7 @@ void TextEditor::MoveRight(int aAmount, bool aSelect, bool aWordMode) {
         }
     } else
         mInteractiveStart = mInteractiveEnd = mState.mCursorPosition;
-    SetSelection(mInteractiveStart, mInteractiveEnd, aSelect && aWordMode ? SelectionMode::Word : SelectionMode::Normal);
+    SetSelection(mInteractiveStart, mInteractiveEnd);
 
     EnsureCursorVisible();
 }


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

Currently, when using <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd><-</kbd>/<kbd>-></kbd> to select a whole word (either ahead or behind the cursor), ImHex has this very weird behavior (inherited from https://github.com/BalazsJako/ImGuiColorTextEdit), where it would select an extra word on the side, as you can see in the Before recording below. This was extremely jarring for me when writing a pattern script (as I regularly use <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>-></kbd> to select a word and instantly start typing over it), so I opted to jump in the code and fix it.

### Implementation description
<!-- Explain what you did to correct the problem -->

`MoveRight` and `MoveLeft` use `SetSelection(..., SelectionMode::Word)` whenever both `Shift` and `Ctrl` are pressed. However, the rest of the `MoveRight`/`MoveLeft` code already takes care of setting up the selection between the previous end of the selection and the new cursor location of the selection, as well as of moving the cursor to the correct location when selecting a word.
Meanwhile, `SelectionMode::Word` tells `SetSelection` to expand the selection on both sides so they are aligned to word boundaries.
In the end, we get a double bug: we can end up selecting stuff before the cursor when moving to the right (which, if you try in any other editor, is not how it works), and we can end up selecting stuff even further away from the cursor when moving to the left.

I searched the code for `MoveRight` and `MoveLeft`, and can confirm that `aSelect && aWordMode` is true only when they are called by the handlers for the Shift-Ctrl-Left/Right shortcuts, so this change should not impact anything else.

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

Before:

[Screencast_20250404_021828.webm](https://github.com/user-attachments/assets/81bc0514-35ad-423b-bb6b-d0f7aa7d06a3)

After:

[Screencast_20250404_022455.webm](https://github.com/user-attachments/assets/5dbcdb48-6db3-454c-b303-395ad03e3f73)

### Additional things
<!-- Anything else you would like to say -->

The pattern language was pretty cool to use, kudos! :sparkles: 
