### PR TITLE
HTML export incorrectly consolidates consecutive spaces. 

### DIFF
--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -160,7 +160,7 @@ namespace hex::plugin::builtin {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
                     result += hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
-                    
+
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -136,17 +136,31 @@ namespace hex::plugin::builtin {
                 "    <code>\n"
                 "        <span class=\"offsetheader\">Hex View&nbsp;&nbsp;00 01 02 03 04 05 06 07&nbsp; 08 09 0A 0B 0C 0D 0E 0F</span>";
 
+            auto html_safe = [](u8 byte) -> std::string {
+                if (!std::isprint(byte))
+                    return ".";
+                char b(byte);
+                if (b==' ') return "&nbsp;";
+                else if (b=='"') return "&quot;";
+                else if (b=='\'') return "&apos;";
+                else if (b=='&') return "&amp;";
+                else if (b=='<') return "&lt;";
+                else if (b=='>') return "&gt;";
+                else return std::string{b};
+            };
+
             auto reader = prv::ProviderReader(provider);
             reader.seek(offset);
             reader.setEndAddress((offset + size) - 1);
 
             u64 address = offset & ~u64(0x0F);
+
             std::string asciiRow;
             for (u8 byte : reader) {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
-                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
-
+                    result += hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
+                    
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {
@@ -165,19 +179,6 @@ namespace hex::plugin::builtin {
                     tagStart = "<span class=\"zerobyte\">";
                     tagEnd = "</span>";
                 }
-
-                auto html_safe = [](u8 byte) -> std::string {
-                    if (!std::isprint(byte))
-                        return ".";
-                    char b(byte);
-                    if (b==' ') return "&nbsp;";
-                    else if (b=='"') return "&quot;";
-                    else if (b=='\'') return "&apos;";
-                    else if (b=='&') return "&amp;";
-                    else if (b=='<') return "&lt;";
-                    else if (b=='>') return "&gt;";
-                    else return std::string{b};
-                };
 
                 result += hex::format("{0}{2:02X}{1} ", tagStart, tagEnd, byte);
                 asciiRow += html_safe(byte);

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -170,7 +170,7 @@ namespace hex::plugin::builtin {
                     if (!std::isprint(byte))
                         return ".";
                     char b(byte);
-                    if (b==' ') return "&nbsp";
+                    if (b==' ') return "&nbsp;";
                     else if (b=='"') return "&quot;";
                     else if (b=='\'') return "&apos;";
                     else if (b=='&') return "&amp;";

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -134,7 +134,7 @@ namespace hex::plugin::builtin {
                 "        .zerobyte { color:#808080 }\n"
                 "    </style>\n\n"
                 "    <code>\n"
-                "        <span class=\"offsetheader\">Hex View&nbsp&nbsp00 01 02 03 04 05 06 07&nbsp 08 09 0A 0B 0C 0D 0E 0F</span>";
+                "        <span class=\"offsetheader\">Hex View&nbsp;&nbsp;00 01 02 03 04 05 06 07&nbsp; 08 09 0A 0B 0C 0D 0E 0F</span>";
 
             auto reader = prv::ProviderReader(provider);
             reader.seek(offset);
@@ -145,14 +145,14 @@ namespace hex::plugin::builtin {
             for (u8 byte : reader) {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
-                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp&nbsp<span class=\"hexcolumn\">", address);
+                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
 
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {
                         for (u64 i = 0; i < (offset - address); i++) {
-                            result += "&nbsp&nbsp&nbsp";
-                            asciiRow += "&nbsp";
+                            result += "&nbsp;&nbsp;&nbsp;";
+                            asciiRow += "&nbsp;";
                         }
                         address = offset;
                     }
@@ -166,17 +166,30 @@ namespace hex::plugin::builtin {
                     tagEnd = "</span>";
                 }
 
+                auto html_safe = [](u8 byte) -> std::string {
+                    if (!std::isprint(byte))
+                        return ".";
+                    char b(byte);
+                    if (b==' ') return "&nbsp";
+                    else if (b=='"') return "&quot;";
+                    else if (b=='\'') return "&apos;";
+                    else if (b=='&') return "&amp;";
+                    else if (b=='<') return "&lt;";
+                    else if (b=='>') return "&gt;";
+                    else return std::string{b};
+                };
+
                 result += hex::format("{0}{2:02X}{1} ", tagStart, tagEnd, byte);
-                asciiRow += std::isprint(byte) ? char(byte) : '.';
+                asciiRow += html_safe(byte);
                 if ((address % 0x10) == 0x07)
-                    result += "&nbsp";
+                    result += "&nbsp;";
 
                 address++;
             }
 
             if (address % 0x10 != 0x00)
                 for (u32 i = 0; i < (0x10 - (address % 0x10)); i++)
-                    result += "&nbsp&nbsp&nbsp";
+                    result += "&nbsp;&nbsp;&nbsp;";
             result += asciiRow;
 
             result +=


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
HTML export incorrectly consolidates consecutive spaces in the ASCII section.

### Implementation description
Altered the HTML export function to correctly handle character entities. Since HTML will consolidate consecutive spaces, I used the non-breaking space entity in the ASCII section.

### Screenshots
![Hex editor](https://github.com/user-attachments/assets/ca6efab4-66b7-4baf-b4eb-622762f1a26e)
![Exported](https://github.com/user-attachments/assets/4149fddd-7474-4756-90e4-cea82e230991)

