### PR TITLE
fix: Saving layout now picks the first path in the list

### DIFF
--- a/lib/libimhex/source/api/layout_manager.cpp
+++ b/lib/libimhex/source/api/layout_manager.cpp
@@ -43,28 +43,26 @@ namespace hex {
 
         std::fs::path layoutPath;
         for (const auto &path : paths::Layouts.write()) {
-            if (fs::isPathWritable(path)) {
-                size_t outSize = 0;
-                const char* iniData = ImGui::SaveIniSettingsToMemory(&outSize);
+            size_t outSize = 0;
+            const char* iniData = ImGui::SaveIniSettingsToMemory(&outSize);
 
-                layoutPath = path / fileName;
-                wolv::io::File file = wolv::io::File(layoutPath, wolv::io::File::Mode::Write);
-                if (!file.isValid()) {
-                    log::warn("Failed to save layout '{}'. Could not open file '{}', continuing with next path", name, layoutPath.c_str());
-                    file.close();
-                    continue;
-                }
-                size_t written = file.writeBuffer((const u8*) iniData, outSize);
-                if (written != outSize) {
-                    log::warn("Failed to save layout '{}'. Could not write file '{}', continuing with next path", name, layoutPath.c_str());
-                    file.close();
-                    continue;
-                }
+            layoutPath = path / fileName;
+            wolv::io::File file = wolv::io::File(layoutPath, wolv::io::File::Mode::Write);
+            if (!file.isValid()) {
+                log::warn("Failed to save layout '{}'. Could not open file '{}', continuing with next path", name, layoutPath.c_str());
                 file.close();
-                log::info("Layout '{}' saved to '{}'", name, layoutPath.c_str());
-                LayoutManager::reload();
-                return;
+                continue;
             }
+            size_t written = file.writeBuffer((const u8*) iniData, outSize);
+            if (written != outSize) {
+                log::warn("Failed to save layout '{}'. Could not write file '{}', continuing with next path", name, layoutPath.c_str());
+                file.close();
+                continue;
+            }
+            file.close();
+            log::info("Layout '{}' saved to '{}'", name, layoutPath.c_str());
+            LayoutManager::reload();
+            return;
         }
         log::error("Failed to save layout '{}'. No writable path found", name);
     }

--- a/lib/libimhex/source/api/layout_manager.cpp
+++ b/lib/libimhex/source/api/layout_manager.cpp
@@ -50,16 +50,13 @@ namespace hex {
             wolv::io::File file = wolv::io::File(layoutPath, wolv::io::File::Mode::Write);
             if (!file.isValid()) {
                 log::warn("Failed to save layout '{}'. Could not open file '{}', continuing with next path", name, layoutPath.c_str());
-                file.close();
                 continue;
             }
             size_t written = file.writeBuffer((const u8*) iniData, outSize);
             if (written != outSize) {
                 log::warn("Failed to save layout '{}'. Could not write file '{}', continuing with next path", name, layoutPath.c_str());
-                file.close();
                 continue;
             }
-            file.close();
             log::info("Layout '{}' saved to '{}'", name, layoutPath.c_str());
             LayoutManager::reload();
             return;

--- a/lib/libimhex/source/api/layout_manager.cpp
+++ b/lib/libimhex/source/api/layout_manager.cpp
@@ -40,16 +40,13 @@ namespace hex {
         fileName = wolv::util::replaceStrings(fileName, " ", "_");
         std::ranges::transform(fileName, fileName.begin(), tolower);
         fileName += ".hexlyt";
-
-        std::fs::path layoutPath;
-        for (const auto &path : paths::Layouts.write()) {
-            layoutPath = path / fileName;
-        }
-
-        if (layoutPath.empty()) {
+        
+        std::vector<std::fs::path> writablePaths = paths::Layouts.write();
+        if (writablePaths.empty()) {
             log::error("Failed to save layout '{}'. No writable path found", name);
             return;
         }
+        std::fs::path layoutPath = writablePaths.front() / fileName;
 
         const auto pathString = wolv::util::toUTF8String(layoutPath);
         ImGui::SaveIniSettingsToDisk(pathString.c_str());


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Saving a layout using the "Workspace -> Layout -> Save Layout ..." button saved to the last writable path in the list that can be found in the "Help -> About" menu. Instead, it should write to the first working path encountered.

### Implementation description
Getting all of the writable paths, then picking the first one.

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
