### PR TITLE
fix: prevent crash by using a fallback value with bad std::clamp arguments.

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -336,7 +336,7 @@ namespace hex::plugin::builtin {
             textEditorSize.y *= 3.5F / 5.0F;
             textEditorSize.y -= ImGui::GetTextLineHeightWithSpacing();
             if (200.0F > availableSize.y - 200.0F) {
-                textEditorSize.y = 200.0F;
+                textEditorSize.y = std::clamp(textEditorSize.y + height, availableSize.y - 200.0F, 200.0F);
             } else {
                 textEditorSize.y = std::clamp(textEditorSize.y + height, 200.0F, availableSize.y - 200.0F);
             }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -335,7 +335,11 @@ namespace hex::plugin::builtin {
             auto textEditorSize = availableSize;
             textEditorSize.y *= 3.5F / 5.0F;
             textEditorSize.y -= ImGui::GetTextLineHeightWithSpacing();
-            textEditorSize.y = std::clamp(textEditorSize.y + height, 200.0F, availableSize.y - 200.0F);
+            if (200.0F > availableSize.y - 200.0F) {
+                textEditorSize.y = 200.0F;
+            } else {
+                textEditorSize.y = std::clamp(textEditorSize.y + height, 200.0F, availableSize.y - 200.0F);
+            }
 
             if (g.NavWindow != nullptr) {
                 std::string name =  g.NavWindow->Name;


### PR DESCRIPTION
### Problem description
When ImHex is built in such a way that the std has asserts activated, the program crashes if the pattern editor is too short. This is the crash log: [imhex.log](https://github.com/user-attachments/files/19954966/imhex.log). As you can see, an assert is triggered in a call to `std::clamp`.

### Implementation description
I'm almost sure the crash is caused by the call to `std::clamp` in `ViewPatternEditor::drawContent()`: if `textEditorSize.y`
is less than `400.0F` the min value is greater than the max value, which is undefined behavior. I changed the code so that `200.0F` is used as a fallback when that is the case.

### Additional things
I didn't build and test the change locally because at the moment I don't have the time.