### PR TITLE
Update view_disassembler.cpp

### DIFF
--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -126,9 +126,9 @@ namespace hex::plugin::disasm {
                             continue;
 
                         if (instruction.operators.empty())
-                            file.writeString(hex::format("0x{0:X}   {}\n", instruction.address, instruction.mnemonic));
+                            file.writeString(hex::format("0x{:X}   {}\n", instruction.address, instruction.mnemonic));
                         else
-                            file.writeString(hex::format("0x{0:X}   {} {}\n", instruction.address, instruction.mnemonic, instruction.operators));                    }
+                            file.writeString(hex::format("0x{:X}   {} {}\n", instruction.address, instruction.mnemonic, instruction.operators));                    }
                 });
             });
         });

--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -126,10 +126,9 @@ namespace hex::plugin::disasm {
                             continue;
 
                         if (instruction.operators.empty())
-                            file.writeString(hex::format("{}\n", instruction.mnemonic));
+                            file.writeString(hex::format("0x{0:X}   {}\n", instruction.address, instruction.mnemonic));
                         else
-                            file.writeString(hex::format("{} {}\n", instruction.mnemonic, instruction.operators));
-                    }
+                            file.writeString(hex::format("0x{0:X}   {} {}\n", instruction.address, instruction.mnemonic, instruction.operators));                    }
                 });
             });
         });


### PR DESCRIPTION
Disassembled code doesn't make much sense without addresses because jump instructions don't know which line to go to.