### PR TITLE
fix: macos builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,6 +345,9 @@ jobs:
         restore-keys: ${{ runner.os }}${{ matrix.suffix }}-ccache
         max-size: 1G
 
+    - name: Set Xcode version
+      run: sudo xcode-select -s /Library/Developer/CommandLineTools
+
     - name: ⬇️ Install dependencies
       env:
         # Make brew not display useless errors


### PR DESCRIPTION
Found post on s.o. about c++ headers not being found when using llvm clang installed using homebrew [here](https://stackoverflow.com/questions/77250743/mac-xcode-g-cannot-compile-even-a-basic-c-program-issues-with-standard-libr) and when I tested the proposed solution in my imhex fork the macos x86 builds were able to complete.