### PR TITLE
Added support for AppleClang compiler id

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -504,7 +504,7 @@ function(verifyCompiler)
         message(FATAL_ERROR "ImHex requires Clang 17.0.0 or newer. Please use the latest Clang version.")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         
-    elseif (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    elseif (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
         message(FATAL_ERROR "ImHex can only be compiled with GCC or Clang. ${CMAKE_CXX_COMPILER_ID} is not supported.")
     endif()
 endfunction()


### PR DESCRIPTION
Added support for AppleClang compiler id on Macs. Tested on latest OS and Clang - works well

### Problem description
ImHex build process stops due to failed compiler id check on Macs

### Implementation description
Just added AppleClang to a list of allowed compilers

### Screenshots
N/A

### Additional things
N/A
