### PR TITLE
build: msvc uninitialized variables.

### DIFF
--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -985,7 +985,7 @@ namespace hex {
             glfwWindowHint(GLFW_MAXIMIZED, initialWindowProperties->maximized);
         }
 
-        int monitorX, monitorY;
+        int monitorX = 0, monitorY = 0;
         int monitorWidth = std::numeric_limits<int>::max(), monitorHeight = std::numeric_limits<int>::max();
         GLFWmonitor *monitor = glfwGetPrimaryMonitor();
         if (monitor != nullptr) {


### PR DESCRIPTION
msvc build failing because of a warning treated as an error for variables being used without initializing even though they are being loaded as references.