### PR TITLE
Strict weak

### DIFF
--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -160,7 +160,7 @@ namespace hex::plugin::builtin {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
                     result += hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
-                    
+
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -136,17 +136,31 @@ namespace hex::plugin::builtin {
                 "    <code>\n"
                 "        <span class=\"offsetheader\">Hex View&nbsp;&nbsp;00 01 02 03 04 05 06 07&nbsp; 08 09 0A 0B 0C 0D 0E 0F</span>";
 
+            auto html_safe = [](u8 byte) -> std::string {
+                if (!std::isprint(byte))
+                    return ".";
+                char b(byte);
+                if (b==' ') return "&nbsp;";
+                else if (b=='"') return "&quot;";
+                else if (b=='\'') return "&apos;";
+                else if (b=='&') return "&amp;";
+                else if (b=='<') return "&lt;";
+                else if (b=='>') return "&gt;";
+                else return std::string{b};
+            };
+
             auto reader = prv::ProviderReader(provider);
             reader.seek(offset);
             reader.setEndAddress((offset + size) - 1);
 
             u64 address = offset & ~u64(0x0F);
+
             std::string asciiRow;
             for (u8 byte : reader) {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
-                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
-
+                    result += hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
+                    
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {
@@ -165,19 +179,6 @@ namespace hex::plugin::builtin {
                     tagStart = "<span class=\"zerobyte\">";
                     tagEnd = "</span>";
                 }
-
-                auto html_safe = [](u8 byte) -> std::string {
-                    if (!std::isprint(byte))
-                        return ".";
-                    char b(byte);
-                    if (b==' ') return "&nbsp;";
-                    else if (b=='"') return "&quot;";
-                    else if (b=='\'') return "&apos;";
-                    else if (b=='&') return "&amp;";
-                    else if (b=='<') return "&lt;";
-                    else if (b=='>') return "&gt;";
-                    else return std::string{b};
-                };
 
                 result += hex::format("{0}{2:02X}{1} ", tagStart, tagEnd, byte);
                 asciiRow += html_safe(byte);

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -170,7 +170,7 @@ namespace hex::plugin::builtin {
                     if (!std::isprint(byte))
                         return ".";
                     char b(byte);
-                    if (b==' ') return "&nbsp";
+                    if (b==' ') return "&nbsp;";
                     else if (b=='"') return "&quot;";
                     else if (b=='\'') return "&apos;";
                     else if (b=='&') return "&amp;";

--- a/plugins/builtin/source/content/data_formatters.cpp
+++ b/plugins/builtin/source/content/data_formatters.cpp
@@ -134,7 +134,7 @@ namespace hex::plugin::builtin {
                 "        .zerobyte { color:#808080 }\n"
                 "    </style>\n\n"
                 "    <code>\n"
-                "        <span class=\"offsetheader\">Hex View&nbsp&nbsp00 01 02 03 04 05 06 07&nbsp 08 09 0A 0B 0C 0D 0E 0F</span>";
+                "        <span class=\"offsetheader\">Hex View&nbsp;&nbsp;00 01 02 03 04 05 06 07&nbsp; 08 09 0A 0B 0C 0D 0E 0F</span>";
 
             auto reader = prv::ProviderReader(provider);
             reader.seek(offset);
@@ -145,14 +145,14 @@ namespace hex::plugin::builtin {
             for (u8 byte : reader) {
                 if ((address % 0x10) == 0) {
                     result += hex::format("  {}", asciiRow);
-                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp&nbsp<span class=\"hexcolumn\">", address);
+                    result +=  hex::format("<br>\n        <span class=\"offsetcolumn\">{0:08X}</span>&nbsp;&nbsp;<span class=\"hexcolumn\">", address);
 
                     asciiRow.clear();
 
                     if (address == (offset & ~u64(0x0F))) {
                         for (u64 i = 0; i < (offset - address); i++) {
-                            result += "&nbsp&nbsp&nbsp";
-                            asciiRow += "&nbsp";
+                            result += "&nbsp;&nbsp;&nbsp;";
+                            asciiRow += "&nbsp;";
                         }
                         address = offset;
                     }
@@ -166,17 +166,30 @@ namespace hex::plugin::builtin {
                     tagEnd = "</span>";
                 }
 
+                auto html_safe = [](u8 byte) -> std::string {
+                    if (!std::isprint(byte))
+                        return ".";
+                    char b(byte);
+                    if (b==' ') return "&nbsp";
+                    else if (b=='"') return "&quot;";
+                    else if (b=='\'') return "&apos;";
+                    else if (b=='&') return "&amp;";
+                    else if (b=='<') return "&lt;";
+                    else if (b=='>') return "&gt;";
+                    else return std::string{b};
+                };
+
                 result += hex::format("{0}{2:02X}{1} ", tagStart, tagEnd, byte);
-                asciiRow += std::isprint(byte) ? char(byte) : '.';
+                asciiRow += html_safe(byte);
                 if ((address % 0x10) == 0x07)
-                    result += "&nbsp";
+                    result += "&nbsp;";
 
                 address++;
             }
 
             if (address % 0x10 != 0x00)
                 for (u32 i = 0; i < (0x10 - (address % 0x10)); i++)
-                    result += "&nbsp&nbsp&nbsp";
+                    result += "&nbsp;&nbsp;&nbsp;";
             result += asciiRow;
 
             result +=

--- a/plugins/ui/source/ui/pattern_drawer.cpp
+++ b/plugins/ui/source/ui/pattern_drawer.cpp
@@ -1139,7 +1139,7 @@ namespace hex::ui {
     }
 
     bool PatternDrawer::sortPatterns(const ImGuiTableSortSpecs* sortSpecs, const pl::ptrn::Pattern * left, const pl::ptrn::Pattern * right) const {
-        auto result = std::strong_ordering::less;
+        auto result = std::strong_ordering::equal;
 
         if (sortSpecs->Specs->ColumnUserID == ImGui::GetID("name")) {
             result = this->getDisplayName(*left) <=> this->getDisplayName(*right);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
[Bug] ImHex crashes when analysing any PE file #2221

### Implementation description
This is a fix for the ImHex bug "ImHex crashes when analysing any PE file #2221".  The fix requires changes to the Pattern Language and the ImHex UI. Revision would be wise. We want to avoid collateral damage. It's a big code base and I'm new to it and the compilers/build-systems used. And the bug is complex and low-level. I suspect this will fix other random crashes. The problem is caused by two issues:
 - The std::sort algorithm conjuring up garbage due to the sorting criteria not being a strict weak ordering. See  [this](https://github.com/Voultapher/sort-research-rs/blob/main/writeup/sort_safety/text.md) link. 
 - We sort shared_ptr&lt;ptrn::Pattern&gt; by pointer value, and the object is a clone.  In essence we're changing the values as we're sorting.
