### PR TITLE
fix: unable to display models if indices are not contiguous in the input file

### DIFF
--- a/plugins/visualizers/romfs/lang/en_US.json
+++ b/plugins/visualizers/romfs/lang/en_US.json
@@ -15,6 +15,7 @@
         "hex.visualizers.pl_visualizer.3d.error_message_colors": "Colors",
         "hex.visualizers.pl_visualizer.3d.error_message_normals": "Normals",
         "hex.visualizers.pl_visualizer.3d.error_message_uv_coords": "Texture Coordinates",
+        "hex.visualizers.pl_visualizer.3d.error_message_invalid_index_pattern": "Error: Cannot determine index type size",
         "hex.visualizers.pl_visualizer.3d.error_message_index_count": "Error: Index count must be a multiple of 3",
         "hex.visualizers.pl_visualizer.3d.error_message_invalid_indices": "Error: Indices must be between 0 and the number of vertices minus one. Invalid indices: ",
         "hex.visualizers.pl_visualizer.3d.error_message_for_vertex_count": " for {} vertices",

--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -923,7 +923,13 @@ namespace hex::plugin::visualizers {
 
         auto *iterable = dynamic_cast<pl::ptrn::IIterable*>(indicesPattern.get());
         if (iterable != nullptr && iterable->getEntryCount() > 0) {
-            const auto &content = iterable->getEntry(0);
+            auto content = iterable->getEntry(0);
+            while (content->getSize() == 0) {
+                auto children = content->getChildren();
+                if (children.size() == 0)
+                    throw std::runtime_error("hex.visualizers.pl_visualizer.3d.error_message_invalid_index_pattern"_lang.get());
+                content = static_cast<const std::shared_ptr<pl::ptrn::Pattern>>(children.begin()->second);
+            }
             if (content->getSize() == 1) {
                 s_indexType = IndexType::U8;
                 processRendering<u8>(verticesPattern, indicesPattern, normalsPattern, colorsPattern, uvPattern);


### PR DESCRIPTION
If you tried to collect the indices using addressof like stl pattern collects vertices you get a small square for visualizer and no error message. The changes here are able to extract the indices if they can be extracted and give an error message if they can't.

