### PR TITLE
fix: horizontal scrollbar missing in console

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
+++ b/lib/third_party/imgui/ColorTextEditor/include/TextEditor.h
@@ -298,6 +298,9 @@ public:
     void SetLongestLineLength(size_t line) {
         mLongestLineLength = line;
     }
+    size_t GetLongestLineLength() const {
+        return mLongestLineLength;
+    }
 	std::string GetText() const;
     bool isEmpty() const {
         auto text = GetText();
@@ -383,6 +386,7 @@ public:
 
 	void InsertText(const std::string& aValue);
 	void InsertText(const char* aValue);
+    void AppendLine(const std::string &aValue);
 
 	void MoveUp(int aAmount = 1, bool aSelect = false);
 	void MoveDown(int aAmount = 1, bool aSelect = false);
@@ -547,7 +551,7 @@ private:
 	Coordinates SanitizeCoordinates(const Coordinates& aValue) const;
 	void Advance(Coordinates& aCoordinates) const;
 	void DeleteRange(const Coordinates& aStart, const Coordinates& aEnd);
-	int InsertTextAt(Coordinates& aWhere, const char* aValue);
+	int InsertTextAt(Coordinates& aWhere, const std::string &aValue);
 	void AddUndo(UndoRecord& aValue);
 	Coordinates ScreenPosToCoordinates(const ImVec2& aPosition) const;
 	Coordinates FindWordStart(const Coordinates& aFrom) const;

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -261,6 +261,7 @@ namespace hex::plugin::builtin {
         PerProvider<TextEditor::Coordinates> m_consoleCursorPosition;
         PerProvider<TextEditor::Selection> m_selection;
         PerProvider<TextEditor::Selection> m_consoleSelection;
+        PerProvider<size_t> m_consoleLongestLineLength;
         PerProvider<TextEditor::Breakpoints> m_breakpoints;
         PerProvider<std::optional<pl::core::err::PatternLanguageError>> m_lastEvaluationError;
         PerProvider<std::vector<pl::core::err::CompileError>> m_lastCompileError;


### PR DESCRIPTION
The recent changes to the text editor to fix the longest line length problems broke the console horizontal scrollbar. The code that displays the console editor was more complicated that it needed be, and it had the bad side effect of resetting the cursor which prevented horizontal scrolling. Adding a function that appends lines to the text editor fixes all problems and makes the code clearer. To accommodate for strings containing zeros, the  code that inserts text was changed to print a '.' when zeros are encountered thus keeping the line length the same.

