### PR TITLE
Faster pattern picker popup

### DIFF
--- a/plugins/builtin/CMakeLists.txt
+++ b/plugins/builtin/CMakeLists.txt
@@ -50,6 +50,7 @@ add_imhex_plugin(
         source/content/data_information_sections.cpp
 
         source/content/helpers/demangle.cpp
+        source/content/helpers/pattern_description_parser.cpp
 
         source/content/data_processor_nodes/basic_nodes.cpp
         source/content/data_processor_nodes/control_nodes.cpp

--- a/plugins/builtin/include/content/helpers/pattern_description_parser.hpp
+++ b/plugins/builtin/include/content/helpers/pattern_description_parser.hpp
@@ -1,0 +1,15 @@
+#pragma once
+/*
+A standalone hexpat file parser to extract the ‘#pragma description’.
+Used to speed up “Import Pattern File…” in the “Pattern Editor” by avoiding
+having to preprocess every pattern using pattern_language to extract the it.
+*/
+
+#include <optional>
+#include <string>
+
+namespace hex::plugin::builtin {
+
+std::optional<std::string> get_description(std::string buffer);
+
+} // namespace hex::plugin::builtin

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -18,6 +18,7 @@
 
 #include <TextEditor.h>
 #include <popups/popup_file_chooser.hpp>
+#include <content/helpers/pattern_description_parser.hpp>
 
 namespace pl::ptrn { class Pattern; }
 
@@ -352,7 +353,7 @@ namespace hex::plugin::builtin {
 
             ui::PopupNamedFileChooser::open(
                 basePaths, paths, std::vector<hex::fs::ItemFilter>{ { "Pattern File", "hexpat" } }, false,
-                [this, provider](const std::fs::path &path, const std::fs::path &adjustedPath) mutable -> std::string {
+                [this](const std::fs::path &path, const std::fs::path &adjustedPath) mutable -> std::string {
                     auto it = m_patternNames.find(path);
                     if (it != m_patternNames.end()) {
                         return it->second;
@@ -361,15 +362,10 @@ namespace hex::plugin::builtin {
                     const auto fileName = wolv::util::toUTF8String(adjustedPath.filename());
                     m_patternNames[path] = fileName;
 
-                    pl::PatternLanguage runtime;
-                    ContentRegistry::PatternLanguage::configureRuntime(runtime, provider);
-                    runtime.addPragma("description", [&](pl::PatternLanguage &, const std::string &value) -> bool {
-                        m_patternNames[path] = hex::format("{} ({})", value, fileName);
-                        return true;
-                    });
-
                     wolv::io::File file(path, wolv::io::File::Mode::Read);
-                    std::ignore = runtime.preprocessString(file.readString(), pl::api::Source::DefaultSource);
+                    auto desc = get_description(file.readString(1024));
+                    if (desc.has_value())
+                        m_patternNames[path] = hex::format("{} ({})", desc.value(), fileName);
 
                     return m_patternNames[path];
                 },

--- a/plugins/builtin/source/content/helpers/pattern_description_parser.cpp
+++ b/plugins/builtin/source/content/helpers/pattern_description_parser.cpp
@@ -1,0 +1,158 @@
+/*
+A standalone hexpat file parser to extract the ‘#pragma description’.
+Used to speed up “Import Pattern File…” in the “Pattern Editor” by avoiding
+having to preprocess every pattern using pattern_language to extract the it.
+*/
+
+#include <ctype.h>
+#include <string>
+#include <optional>
+
+#include <content/helpers/pattern_description_parser.hpp>
+
+static inline bool IsLineEndChar(char p)
+{
+    return p=='\r' || p=='\n';
+}
+
+// Safe to call if *p==0.
+static inline void SkipLine(const char*& p)
+{
+    if (!*p)
+        return;
+    for (++p; *p && !IsLineEndChar(*p); ++p) {}
+    if (*p)
+        for (++p; *p && IsLineEndChar(*p); ++p) {}
+}
+
+// Skips comments.
+// Also skips '/' (start of a comment) even if it's not a complete comment.
+// We don't care. We're only interested in pragmas, and pragmas don't start
+// with a '/'.
+// NOT safe to call if *p=0!
+static void SkipComment(const char*& p)
+{
+    if (*p != '/')
+        return;
+    ++p;
+    if (!*p)
+        return;
+
+    if (*p=='/') 
+        SkipLine(p); // single-line comment
+    else if (*p=='*') { // multi-line comment
+        for (;;) {
+            for (++p; *p && *p!='*'; ++p) {}
+            if (!*p)
+                return;
+            ++p;
+            if (!*p)
+                return;
+            if (*p =='/') {
+                ++p;
+                return;
+            }
+            else {
+                ++p;
+                if (!*p)
+                    return;
+                continue;
+            }
+        }
+    }
+}
+
+// Returns true if we skipped some spaces, else false.
+// Safe to call if *p==0.
+static inline bool SkipWS(const char*& p)
+{
+    const char* pOrg = p;
+    for (; *p && isspace(*p); ++p) {}
+    return p != pOrg;
+}
+
+// NOT safe to call if *p=0!
+static inline void SkipCommentsAndWS(const char*& p)
+{
+    for (;;) {
+        SkipComment(p);
+        if (!SkipWS(p))
+            break;
+    }
+}
+
+// Returns true if we skipped some spaces, else false.
+// Safe to call if *p==0.
+static inline bool SkipSpacesOnLine(const char*& p)
+{
+    const char* pOrg = p;
+    for (; *p && (*p==' ' || *p=='\t'); ++p) {}
+    return p != pOrg;
+}
+
+// Retrurns true if word is found, else false.
+// Any WS on the same line is also skipped (these must be some).
+// If it returns false p is unaltered.
+// Safe to call if *p==0.
+static inline bool SkipWordIfPresent(const char*& p, const char* pStr)
+{
+    const char* pCopy = p;
+    for (; *pCopy==*pStr; ++pCopy, ++pStr) {} // both pCopy and pStr are NULL terminated
+    if (*pStr)
+        return false;
+    if (!SkipSpacesOnLine(pCopy))
+        return false;
+
+    p = pCopy;
+    return true;
+}
+
+// Find the argument for the pragma.
+// Returns the last char of the argument. Trailing WS is not included.
+// Safe to call if *p==0.
+static const char* FindEndOfPragmaArgument(const char* p)
+{
+    const char *pLastNonWS = p;
+    for (; *p && !IsLineEndChar(*p); ++p) {
+        if (!isspace(*p))
+            pLastNonWS = p;
+    }
+
+    return pLastNonWS;
+}
+
+namespace hex::plugin::builtin {
+
+std::optional<std::string> get_description(std::string buffer)
+{
+    const char *p = buffer.c_str();
+
+    for (;;) {
+        if (!*p)
+            return std::nullopt;
+        SkipCommentsAndWS(p);
+        if (!*p)
+            return std::nullopt;
+
+        if (SkipWordIfPresent(p, "#pragma")) {
+            if (SkipWordIfPresent(p, "description")) {
+                if (!*p)
+                    return std::nullopt;
+                const char* pLast = FindEndOfPragmaArgument(p);
+                return std::string(p, pLast+1);
+            }
+            else {
+                SkipLine(p);
+                if (!*p)
+                    return std::nullopt;
+            }
+        }
+        else {
+            SkipLine(p);
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace hex::plugin::builtin


### PR DESCRIPTION
### Problem description
I’ve found ImHex to be impressively zippy. I’ve no doubt that’s intentional. Why use the GPU to render the UI otherwise?

Opening the pattern file selection popup, however, takes ages (on my system at least). On a release build just over 7 seconds (much worse in debug builds, around 50 seconds!). Enough time for one to wonder if it’s working.

The reason is that ImHex has to preprocess every pattern file to extract the pattern's descriptions.
This PR uses a standalone parser designed just extract the description, and only loads the initial portion of the file when doing so, assuming the description pragma will be near the beginning.

### Implementation description
Pretty much as described above. I won’t blame you if you object to the handwritten parser however. Noxiously fiddly problematic things. That said, some effort at least has been expended to match the behaviour of pattern_language’s parsing.

There's a magic number.

Even so, I suggest you try it out and see the difference. As more and more patterns are added the problem will only get worse and worse.

This is my second attempt at this PR. Rouge files made it into my last attempt. Still leanring how to use git properly. Sorry.