### PR TITLE
Allow Section window resizing

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1327,7 +1327,7 @@ namespace hex::plugin::builtin {
 
                         m_sectionWindowDrawer[patternProvider] = [this, id, patternProvider, dataProvider, hexEditor, patternDrawer = std::make_shared<ui::PatternDrawer>(), &runtime]() mutable {
                             hexEditor.setProvider(dataProvider.get());
-                            hexEditor.draw(480_scaled);
+                            hexEditor.draw(ImGui::GetContentRegionAvail().y * 0.7);
                             patternDrawer->setSelectionCallback([&](const pl::ptrn::Pattern *pattern) {
                                 hexEditor.setSelection(Region { pattern->getOffset(), pattern->getSize() });
                             });
@@ -1342,7 +1342,7 @@ namespace hex::plugin::builtin {
                             }();
 
                             if (*m_executionDone)
-                                patternDrawer->draw(patterns, &runtime, 150_scaled);
+                                patternDrawer->draw(patterns, &runtime, ImGui::GetContentRegionAvail().y);
                         };
                     }
                     ImGui::SetItemTooltip("%s", "hex.builtin.view.pattern_editor.sections.view"_lang.get());
@@ -1468,7 +1468,7 @@ namespace hex::plugin::builtin {
         auto open = m_sectionWindowDrawer.contains(provider);
         if (open) {
             ImGui::SetNextWindowSize(scaled(ImVec2(600, 700)), ImGuiCond_Appearing);
-            if (ImGui::Begin("hex.builtin.view.pattern_editor.section_popup"_lang, &open, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+            if (ImGui::Begin("hex.builtin.view.pattern_editor.section_popup"_lang, &open, ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
                 m_sectionWindowDrawer[provider]();
             }
             ImGui::End();


### PR DESCRIPTION
### Problem description
While working with the section view, I noticed the window wasn't resizable.

### Implementation description
This simply removes the `ImGuiWindowFlags_NoResize` flag, and then when drawing the section window sets the hex editor to 70% of the available window, leaving 30% to the pattern data. This is not ideal, but I think before a full rewrite of the section window system this would probably be a simple change to make it a lot more usable.

### Screenshots
![image](https://github.com/user-attachments/assets/55a9f2f5-6eba-436e-b8bb-8a3a78f80d08)
