### PR TITLE
fix: fixes for various errors related to shared_from_this.

### DIFF
--- a/plugins/builtin/source/content/pl_builtin_types.cpp
+++ b/plugins/builtin/source/content/pl_builtin_types.cpp
@@ -27,7 +27,8 @@ namespace hex::plugin::builtin {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternEncodedString(*this));
+            return std::make_shared<PatternEncodedString>(*this);
+           // return std::unique_ptr<Pattern>(new PatternEncodedString(*this));
         }
 
         [[nodiscard]] std::string getFormattedName() const override {
@@ -197,8 +198,8 @@ namespace hex::plugin::builtin {
         }
 
 
-        std::unique_ptr<pl::ptrn::Pattern> jsonToPattern(pl::core::Evaluator *evaluator, auto function) {
-            auto object = std::make_unique<pl::ptrn::PatternStruct>(evaluator, 0, 0, 0);
+        std::shared_ptr<pl::ptrn::Pattern> jsonToPattern(pl::core::Evaluator *evaluator, auto function) {
+            auto object = std::make_shared<pl::ptrn::PatternStruct>(evaluator, 0, 0, 0);
             std::vector<std::shared_ptr<pl::ptrn::Pattern>> patterns;
 
             try {
@@ -221,7 +222,7 @@ namespace hex::plugin::builtin {
             const pl::api::Namespace nsHexDec = { "builtin", "hex", "dec" };
 
             /* Json<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Json", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Json", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::parse(data); });
@@ -230,7 +231,7 @@ namespace hex::plugin::builtin {
             });
 
             /* Bson<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Bson", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Bson", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::from_bson(data); });
@@ -239,7 +240,7 @@ namespace hex::plugin::builtin {
             });
 
             /* Cbor<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Cbor", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Cbor", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::from_cbor(data); });
@@ -248,7 +249,7 @@ namespace hex::plugin::builtin {
             });
 
             /* Bjdata<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Bjdata", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Bjdata", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::from_bjdata(data); });
@@ -257,7 +258,7 @@ namespace hex::plugin::builtin {
             });
 
             /* Msgpack<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Msgpack", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Msgpack", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::from_msgpack(data); });
@@ -266,7 +267,7 @@ namespace hex::plugin::builtin {
             });
 
             /* Ubjson<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "Ubjson", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "Ubjson", FunctionParameterCount::exactly(1), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto data = params[0].toBytes();
 
                 auto result = jsonToPattern(evaluator, [&] { return nlohmann::json::from_ubjson(data); });
@@ -276,7 +277,7 @@ namespace hex::plugin::builtin {
 
 
             /* EncodedString<data_pattern> */
-            ContentRegistry::PatternLanguage::addType(nsHexDec, "EncodedString", FunctionParameterCount::exactly(2), [](Evaluator *evaluator, auto params) -> std::unique_ptr<pl::ptrn::Pattern> {
+            ContentRegistry::PatternLanguage::addType(nsHexDec, "EncodedString", FunctionParameterCount::exactly(2), [](Evaluator *evaluator, auto params) -> std::shared_ptr<pl::ptrn::Pattern> {
                 auto bytes = params[0].toBytes();
                 auto encodingDefinition = params[1].toString();
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1495,7 +1495,7 @@ namespace hex::plugin::builtin {
                 };
 
                 TextEditor::ErrorMarkers errorMarkers;
-                if (!(*m_callStack)->empty()) {
+                if (*m_callStack != nullptr && !(*m_callStack)->empty()) {
                     for (const auto &frame : **m_callStack | std::views::reverse) {
                         auto location = frame.node->getLocation();
                         std::string message;
@@ -1735,7 +1735,7 @@ namespace hex::plugin::builtin {
                         const pl::ptrn::Pattern *entry = pattern;
                         while (entry != nullptr) {
                             pathSegments.push_back(entry->getVariableName());
-                            entry = entry->getParent();
+                            entry = entry->getParent().get();
                         }
 
                         for (const auto &segment : pathSegments | std::views::reverse) {
@@ -2270,7 +2270,7 @@ namespace hex::plugin::builtin {
             const auto hoveredRegion = Region { address, size };
             for (const auto &pattern : runtime.getPatternsAtAddress(hoveredRegion.getStartAddress())) {
                 const pl::ptrn::Pattern * checkPattern = pattern;
-                if (auto parent = checkPattern->getParent(); parent != nullptr)
+                if (auto parent = checkPattern->getParent().get(); parent != nullptr)
                     checkPattern = parent;
 
                 result.emplace(checkPattern->getOffset(), checkPattern->getSize());

--- a/plugins/disassembler/source/content/pl_builtin_types.cpp
+++ b/plugins/disassembler/source/content/pl_builtin_types.cpp
@@ -21,7 +21,7 @@ namespace hex::plugin::disasm {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternInstruction(*this));
+            return std::make_shared<PatternInstruction>(*this);
         }
 
         [[nodiscard]] std::string getFormattedName() const override {

--- a/plugins/ui/source/ui/pattern_drawer.cpp
+++ b/plugins/ui/source/ui/pattern_drawer.cpp
@@ -407,7 +407,7 @@ namespace hex::ui {
 
         while (pattern != nullptr) {
             result.emplace_back(pattern->getVariableName());
-            pattern = pattern->getParent();
+            pattern = pattern->getParent().get();
         }
 
         std::reverse(result.begin(), result.end());
@@ -427,7 +427,7 @@ namespace hex::ui {
                 m_jumpToPattern = nullptr;
             }
             else {
-                auto parent = m_jumpToPattern->getParent();
+                pl::ptrn::Pattern *parent = m_jumpToPattern->getParent().get();
                 while (parent != nullptr) {
                     if (&pattern == parent) {
                         ImGui::SetScrollHereY();
@@ -435,7 +435,7 @@ namespace hex::ui {
                         break;
                     }
 
-                    parent = parent->getParent();
+                    parent = parent->getParent().get();
                 }
             }
         }


### PR DESCRIPTION
A while back there were some changes to the pattern language library that changed the way shared_pointers are created using shared_from_this(). Unfortunatelly the changes were not complete and various bugs were created among them 2234, json type not working, unable to export files, static arrays of bitfields,... The cause of the errors was that in class Pattern the member m_parent was left as a raw pointer and it needs to be handled by shared pointers. Also there were some cases in which share pointers were needed but unique pointers were used instead. Both cause crashes when shared_from_this is used on pointers that are not managed by shared_ptr. Another source of errors were infinite loops of clone and reference that caused stack overflow. The fixes include making m_parent a weak pointer, turning unique pointers into shared pointers and moving codefrom the copy constructors into clone to break the infinite loops.These changes are the bare minimum needed to bring the pattern language back to the full functionality that it had before shared_from_this was introduced or at least thats the hope.

