### PR TITLE
impr: show external frames when using std::stacktrace backend

### DIFF
--- a/lib/trace/source/stacktrace.cpp
+++ b/lib/trace/source/stacktrace.cpp
@@ -21,6 +21,13 @@ namespace {
 #if defined(HEX_HAS_STD_STACKTRACE) && __has_include(<stacktrace>)
 
     #include <stacktrace>
+    
+    #if __has_include(<dlfcn.h>)
+
+        #include <filesystem>
+        #include <dlfcn.h>
+
+    #endif
 
     namespace hex::trace {
 
@@ -34,10 +41,35 @@ namespace {
             auto stackTrace = std::stacktrace::current();
 
             for (const auto &entry : stackTrace) {
-                if (entry.source_line() == 0 && entry.source_file().empty())
+                if (entry.source_line() == 0 && entry.source_file().empty()) {
+    #if __has_include(<dlfcn.h>)
+                    Dl_info info = {};
+                    dladdr(reinterpret_cast<const void*>(entry.native_handle()), &info);
+
+                    std::string description;
+
+                    auto path = info.dli_fname != nullptr ? std::optional<std::filesystem::path>{info.dli_fname} : std::nullopt;
+                    auto filePath = path ? path->string() : "??";
+                    auto fileName = path ? path->filename().string() : "";
+
+                    if (info.dli_sname != nullptr) {
+                        description = tryDemangle(info.dli_sname);
+                        if (info.dli_saddr != reinterpret_cast<const void*>(entry.native_handle())) {
+                            auto symOffset = entry.native_handle() - reinterpret_cast<uintptr_t>(info.dli_saddr);
+                            description += std::format("+0x{:x}", symOffset);
+                        }
+                    } else {
+                        auto rvaOffset = entry.native_handle() - reinterpret_cast<uintptr_t>(info.dli_fbase);
+                        description = std::format("{}+0x{:08x}", fileName, rvaOffset);
+                    }
+
+                    result.emplace_back(filePath, description, 0);
+    #else
                     result.emplace_back("", "??", 0);
-                else
+    #endif
+                } else {
                     result.emplace_back(entry.source_file(), entry.description(), entry.source_line());
+                }
             }
 
             return { result, "std::stacktrace" };


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
`std::stacktrace` backend in `hex::trace` does not show frames for external libraries.

### Implementation description
If `dlfcn.h` is available, use `dladdr` to retrieve external symbol information.

### Screenshots
Before:
```
[02:33:46] [FATAL] [main | Main]               Printing stacktrace using implementation 'std::stacktrace'
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/lib/trace/source/stacktrace.cpp:34) | hex::trace::getStackTrace()
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:75) | printStackTrace
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:125) | hex::crash::handleCrash(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:211) | operator()
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/lib/third_party/imgui/backend/source/imgui_impl_glfw.cpp:844) | ImGui_ImplGlfw_UpdateMouseData
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:353) | hex::Window::frameBegin()
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:241) | hex::Window::fullFrame()
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:297) | hex::Window::loop()
[02:33:46] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/init/run/native.cpp:43) | hex::init::runImHex()
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:46] [FATAL] [main | Main]                 () | ??
[02:33:47] [FATAL] [main | Main]                 () | ??
[02:33:47] [FATAL] [main | Main]                 () | ??
```

After:
```
[02:30:19] [FATAL] [main | Main]               Printing stacktrace using implementation 'std::stacktrace'
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/lib/trace/source/stacktrace.cpp:41) | hex::trace::getStackTrace()
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:75) | printStackTrace
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:125) | hex::crash::handleCrash(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/crash_handlers.cpp:211) | operator()
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | libc.so.6+0x00019bef
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | libc.so.6+0x00073c2c
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | gsignal+0x1d
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | abort+0x25
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | libc.so.6+0x00001638
[02:30:19] [FATAL] [main | Main]                 (/lib64/libglfw.so.3) | libglfw.so.3+0x00002275
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/lib/third_party/imgui/backend/source/imgui_impl_glfw.cpp:844) | ImGui_ImplGlfw_UpdateMouseData
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:353) | hex::Window::frameBegin()
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:241) | hex::Window::fullFrame()
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/window/window.cpp:297) | hex::Window::loop()
[02:30:19] [FATAL] [main | Main]                 (/home/mochaa/ghq/github.com/WerWolv/ImHex/main/gui/source/init/run/native.cpp:43) | hex::init::runImHex()
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | libc.so.6+0x000035b4
[02:30:19] [FATAL] [main | Main]                 (/lib64/libc.so.6) | __libc_start_main+0x87
[02:30:19] [FATAL] [main | Main]                 (./build/imhex) | imhex+0x0000cd94
[02:30:19] [FATAL] [main | Main]                 (??) | +0xffffffffffffffff
```

### Additional things
None