### PR TITLE
fix: searching for negative values returns nothing.

### DIFF
--- a/plugins/builtin/source/content/views/view_find.cpp
+++ b/plugins/builtin/source/content/views/view_find.cpp
@@ -465,6 +465,17 @@ namespace hex::plugin::builtin {
         return results;
     }
 
+    template<typename T> T convert_signed_integer( T value, size_t size ) {
+
+        switch (size) {
+            case 1: return static_cast<T>(static_cast<i8>(value));
+            case 2: return static_cast<T>(static_cast<i16>(value));
+            case 4: return static_cast<T>(static_cast<i32>(value));
+            case 8: return static_cast<T>(static_cast<i64>(value));
+            default: return value;
+        }
+    }
+
     std::vector<hex::ContentRegistry::DataFormatter::impl::FindOccurrence> ViewFind::searchValue(Task &task, prv::Provider *provider, Region searchRegion, const SearchSettings::Value &settings) {
         std::vector<Occurrence> results;
 
@@ -500,6 +511,8 @@ namespace hex::plugin::builtin {
                 DecayedType value = 0;
                 reader.read(address, reinterpret_cast<u8*>(&value), size);
                 value = hex::changeEndianness(value, size, settings.endian);
+                if constexpr (std::signed_integral<DecayedType>)
+                    value = convert_signed_integer<DecayedType>(value, size);
 
                 return value >= minValue && value <= maxValue;
             }, min);


### PR DESCRIPTION
This pr aims at fixing for negative values in advanced search for numerical values. For a simple example try searching for -1 for int32_t which is 0xFFFFFFFF. With the changes you can now find -1 for 1,2,4 or 8 byte integers.

Internal types are bigger than or equal to the types selected in the options. Search keys are converted to the bigger type, but the values read from the input file are not. This works ok for positive numbers, but for negatives it needs some casting.

The casting is performed inside a newly added function that takes the value returned by read, the size in bytes of the selected type in the options and a template argument for the 64 bit type the value is stored into.

I have tested positive and negative values for several different sizes of signed integers. Also tested unsigned integers both in the low range (near lowest limit) and in the high range (near largest possible value for that type)