### PR TITLE
fix: fixes for pattern language dissassembler support

### DIFF
--- a/plugins/disassembler/include/content/helpers/disassembler.hpp
+++ b/plugins/disassembler/include/content/helpers/disassembler.hpp
@@ -97,16 +97,16 @@ namespace hex::plugin::disasm {
         // string has to be in the form of `arch;option1,option2,option3,no-option4`
         // Not all results might make sense for capstone
         static std::pair<cs_arch, cs_mode> stringToSettings(std::string_view string) {
-            const auto archSeparator = string.find_first_of(';');
+            const auto vectorString = wolv::util::splitString(std::string(string), ";");
 
             std::string_view archName;
             std::string_view options;
-            if (archSeparator == std::string_view::npos) {
-                archName = wolv::util::trim(string);
+            if (vectorString.size() == 1) {
+                archName = wolv::util::trim(vectorString[0]);
                 options = "";
             } else {
-                archName = wolv::util::trim(string.substr(0, archSeparator - 1));
-                options = wolv::util::trim(string.substr(archSeparator + 1));
+                archName = wolv::util::trim(vectorString[0]);
+                options = wolv::util::trim(vectorString[1]);
             }
 
             u32 arch = {};
@@ -171,15 +171,8 @@ namespace hex::plugin::disasm {
             else
                 throw std::runtime_error("Invalid disassembler architecture");
 
-            while (!options.empty()) {
-                std::string_view option;
-                auto separatorPos = options.find_first_of(',');
-                if (separatorPos == std::string_view::npos)
-                    option = options;
-                else
-                    option = options.substr(0, separatorPos - 1);
-
-                options.remove_prefix(option.size() + 1);
+            auto optionsVector = wolv::util::splitString(std::string(options), ",");
+            for (std::string_view option : optionsVector) {
                 option = wolv::util::trim(option);
 
                 bool shouldAdd = true;

--- a/plugins/disassembler/include/content/helpers/disassembler.hpp
+++ b/plugins/disassembler/include/content/helpers/disassembler.hpp
@@ -99,14 +99,13 @@ namespace hex::plugin::disasm {
         static std::pair<cs_arch, cs_mode> stringToSettings(std::string_view string) {
             const auto vectorString = wolv::util::splitString(std::string(string), ";");
 
-            std::string_view archName;
-            std::string_view options;
-            if (vectorString.size() == 1) {
-                archName = wolv::util::trim(vectorString[0]);
-                options = "";
-            } else {
-                archName = wolv::util::trim(vectorString[0]);
+            std::string archName;
+            std::string options;
+            archName = wolv::util::trim(vectorString[0]);
+            if (vectorString.size() != 1) {
                 options = wolv::util::trim(vectorString[1]);
+            } else {
+                options = "";
             }
 
             u32 arch = {};
@@ -114,10 +113,11 @@ namespace hex::plugin::disasm {
 
             if (archName.ends_with("be") || archName.ends_with("eb")) {
                 mode |= CS_MODE_BIG_ENDIAN;
-                archName.remove_suffix(2);
+                archName.pop_back();
+                archName.pop_back();
             } else if (archName.ends_with("le") || archName.ends_with("el")) {
-                mode |= CS_MODE_LITTLE_ENDIAN;
-                archName.remove_suffix(2);
+                archName.pop_back();
+                archName.pop_back();
             }
 
             if (equalsIgnoreCase(archName, "arm")) {

--- a/plugins/disassembler/source/content/pl_builtin_types.cpp
+++ b/plugins/disassembler/source/content/pl_builtin_types.cpp
@@ -52,6 +52,10 @@ namespace hex::plugin::disasm {
             return m_instructionString;
         }
 
+       [[nodiscard]] std::string toString() override {
+             return m_instructionString;
+        }
+
     private:
         std::string m_instructionString;
     };


### PR DESCRIPTION
Following the documentation (which is not being updated for this type) on using  `hex::type::Instruction` fails to produce any patterns regardless of how you format the string that is passed to capstone to select architecture and options. 

The error is traced back to mishandling the input string so that the correct parts are not selected properly. Rather than manually selecting the parts of the input string from the result of find it is much simpler to use splitString() (which uses find internally) and does all the work for us with fewer chances for errors.

There are still problems. The resulting string for the  formatter doesn't return the disassembled instruction and prints the variable name with the @ used to place it. To view the instruction you need to unseal the pattern and open the child which then shows the instruction. That only happens after this fix has been applied.
