### PR TITLE
Fix 2330

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,18 @@ ImHex is written in C++ and usually uses the latest compiler and standard librar
 ### Structure
 
 - `main`: Contains the main application code
-    - Important to understand here is that the main ImHex application is basically just an empty shell. 
+    - Important to understand here is that the main ImHex application is basically just an empty shell.
     - All it does is create a Window and a OpenGL context using GLFW, load all available plugins, properly configure ImGui and render it to the screen.
     - Everything else is done inside of plugins. ImHex comes with a few plugins by default, most notably the `builtin` plugin which contains the majority of the application code.
     - In most cases, this code doesn't need to be modified. Most features should be self-contained inside a plugin.
 - `lib`
     - `libimhex`: Contains all helper utilities as well as various APIs for plugins to interact with ImHex.
         - The library's main purpose is for Dependency Inversion. The ImHex main application as well as libimhex do not know about the existence of plugins at build time. Plugins and the main application instead link against libimhex and use it as a common API to interact with each other.
-        - Since libimhex is a doesn't know about the existence of plugins, it cannot depend on any of them. This includes localizations and things that get registered by plugins after launch.
+        - Since libimhex itself doesn't know about the existence of plugins, it cannot depend on any of them. This includes localizations and things that get registered by plugins after launch.
         - Even if the builtin plugin is technically always available, it is still a plugin and should be treated that way.
         - All important APIs can be found in the `hex/api` include directory and are documented in the respective header file.
     - `external`: All libraries that need custom patches or aren't typically available in package managers go into here.
-        - If you'd like to add new features to the Pattern language, please make a PR to https://github.com/WerWolv/PatternLanguage instead. ImHex usually depends on the latest commit of the master branch of this repo. 
+        - If you'd like to add new features to the Pattern language, please make a PR to https://github.com/WerWolv/PatternLanguage instead. ImHex usually depends on the latest commit of the master branch of this repo.
 - `plugins`
     - `builtin`: The builtin plugin. Contains the majority of the application code.
         - It's the heart of ImHex's functionality. It contains most of the default views, providers, etc. so if you want to add new functionality to ImHex, this is the place to start.

--- a/plugins/builtin/romfs/assets/screenshot_descriptions.json
+++ b/plugins/builtin/romfs/assets/screenshot_descriptions.json
@@ -1,7 +1,7 @@
 {
     "3d_visualizer.png": {
         "title": "Advanced Data Visualizers",
-        "description": "After analyzing data using the pattern language, it's often useful to visualize parts of that data. ImHex provides a variety of visualizers that can be used to visualize different types of data right in the editor.\n\nAvailable visualizers include a 3D model viewer, RGBA and Image decoder, a audio player, line and scatter plots and many more!"
+        "description": "After analyzing data using the pattern language, it's often useful to visualize parts of that data. ImHex provides a variety of visualizers that can be used to visualize different types of data right in the editor.\n\nAvailable visualizers include a 3D model viewer, RGBA and Image decoder, an audio player, line and scatter plots and many more!"
     },
     "bookmarks.png": {
         "title": "Bookmarks",


### PR DESCRIPTION
Fix a typo in `screenshot_descriptions.json` reported in #2330. While I was presented with the contributing doc, I came across another typo that's fixed in the second commit.