### PR TITLE
improv: removing tabs

### DIFF
--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -1958,7 +1958,7 @@ namespace hex::plugin::builtin {
             m_lines.clear();
 
         if (m_text.empty())
-            m_text =  m_viewPatternEditor->getTextEditor().PreprocessText(m_viewPatternEditor->getTextEditor().GetText());
+            m_text =  m_viewPatternEditor->getTextEditor().GetText();
 
         m_lines = hex::splitString(m_text, "\n");
         m_lines.push_back("");
@@ -2252,7 +2252,7 @@ namespace hex::plugin::builtin {
         auto lastToken = m_tokens.back();
         m_tokens.push_back(lastToken);
 
-        m_text = m_viewPatternEditor->getTextEditor().PreprocessText( m_viewPatternEditor->getTextEditor().GetText());
+        m_text = m_viewPatternEditor->getTextEditor().GetText();
 
         if (m_text.empty() || m_text == "\n")
             return;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1741,7 +1741,7 @@ namespace hex::plugin::builtin {
     void ViewPatternEditor::loadPatternFile(const std::fs::path &path, prv::Provider *provider) {
         wolv::io::File file(path, wolv::io::File::Mode::Read);
         if (file.isValid()) {
-            auto code = file.readString();
+            auto code = wolv::util::preprocessText(file.readString());
 
             this->evaluatePattern(code, provider);
             m_textEditor.get(provider).SetText(code, true);
@@ -1940,7 +1940,7 @@ namespace hex::plugin::builtin {
 
         RequestSetPatternLanguageCode::subscribe(this, [this](const std::string &code) {
             auto provider = ImHexApi::Provider::get();
-            m_textEditor.get(provider).SetText(code);
+            m_textEditor.get(provider).SetText(wolv::util::preprocessText(code));
             m_sourceCode.get(provider) = code;
             m_hasUnevaluatedChanges.get(provider) = true;
             m_textHighlighter.m_needsToUpdateColors = false;
@@ -1990,7 +1990,7 @@ namespace hex::plugin::builtin {
             }
 
             if (newProvider != nullptr) {
-                m_textEditor.get(newProvider).SetText(m_sourceCode.get(newProvider));
+                m_textEditor.get(newProvider).SetText(wolv::util::preprocessText(m_sourceCode.get(newProvider)));
                 m_textEditor.get(newProvider).SetCursorPosition(m_cursorPosition.get(newProvider));
                 TextEditor::Selection selection = m_selection.get(newProvider);
                 m_textEditor.get(newProvider).SetSelection(selection.mStart, selection.mEnd);
@@ -2136,7 +2136,7 @@ namespace hex::plugin::builtin {
             wolv::io::File file(path, wolv::io::File::Mode::Read);
 
             if (file.isValid()) {
-                RequestSetPatternLanguageCode::post(file.readString());
+                RequestSetPatternLanguageCode::post(wolv::util::preprocessText(file.readString()));
                 return true;
             } else {
                 return false;
@@ -2226,7 +2226,7 @@ namespace hex::plugin::builtin {
             .basePath = "pattern_source_code.hexpat",
             .required = false,
             .load = [this](prv::Provider *provider, const std::fs::path &basePath, const Tar &tar) {
-                const auto sourceCode = tar.readString(basePath);
+                const auto sourceCode = wolv::util::preprocessText(tar.readString(basePath));
 
                 m_sourceCode.get(provider) = sourceCode;
 


### PR DESCRIPTION
These changes are part of an effort aimed at removing tabs from ImHex that started some time ago. Here text preprocessing is removed from all the places were it was done before and moved to the places where files are read that go in the pattern editor with two notable exceptions. 
1) Pattern import reads patterns in order to present a list that can be filtered.That can safely ignore preprocessing since only needs to get information needed to filter. 
2) The pattern editor can incorporate text from the clipboard so that needs to be preprocessed as well. 

find/replace is unable to add tabs or carriage returns so this should cover all angles.
