### PR TITLE
Update rpm ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -940,19 +940,15 @@ jobs:
       matrix:
         include:
           - name: Fedora
-            mock_release: rawhide
             release_num: rawhide
             mock_config: fedora-rawhide
           - name: Fedora
-            mock_release: f42
             release_num: 42
             mock_config: fedora-42
           - name: Fedora
-            mock_release: f41
             release_num: 41
             mock_config: fedora-41
           - name: RHEL-AlmaLinux
-            mock_release: epel9
             release_num: 9
             mock_config: "alma+epel-9"
 
@@ -960,7 +956,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: "almalinux:9"
+      image: "almalinux:10"
       options: --privileged --pid=host --security-opt apparmor=unconfined
 
     permissions:
@@ -969,10 +965,10 @@ jobs:
 
     steps:
       # This, together with the `--pid=host --security-opt apparmor=unconfined` docker options is required to allow
-      # fedpkg to work inside a Docker container running on Ubuntu again.
+      # mock to work inside a Docker container running on Ubuntu again.
       # GitHub seems to have enabled AppArmor on their Ubuntu CI runners which limits Docker in ways that cause
       # programs inside it to fail.
-      # Without this, fedpkg will throw the unhelpful error message 'Insufficient Rights'
+      # Without this, mock will throw the unhelpful error message 'Insufficient Rights'
       # This step uses nsenter to execute commands on the host that disable AppArmor entirely.
       - name: 🛡️ Disable AppArmor on Host
         run: |
@@ -995,15 +991,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /var/cache/dnf
-          key: dnf-ccache-${{ matrix.mock_release }}-${{ github.run_id }}
-          restore-keys: dnf-ccache-${{ matrix.mock_release }}
+          key: dnf-ccache-${{ matrix.mock_config }}-${{ github.run_id }}
+          restore-keys: dnf-ccache-${{ matrix.mock_config }}
 
       - name: ⬇️ Update all packages and install dependencies
         run: |
           set -x
           dnf upgrade -y
           dnf install -y \
-          fedpkg         \
+          mock           \
           ccache
 
       - name: ⬇️ Install .NET
@@ -1014,8 +1010,8 @@ jobs:
       - name: 📜 Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.mock_release }}-rpm-${{ github.run_id }}
-          restore-keys: ${{ matrix.mock_release }}-rpm
+          key: ${{ matrix.mock_config }}-rpm-${{ github.run_id }}
+          restore-keys: ${{ matrix.mock_config }}-rpm
           max-size: 1G
 
       - name: 📜 Set version variable
@@ -1032,11 +1028,11 @@ jobs:
           -e 's/IMHEX_OFFLINE_BUILD=ON/IMHEX_OFFLINE_BUILD=OFF/g'                     \
           -e '/IMHEX_OFFLINE_BUILD=OFF/a -D IMHEX_PATTERNS_PULL_MASTER=ON \\'         \
           -e '/BuildRequires:  cmake/a BuildRequires:  git-core'                      \
-          -e '/%files/a %{_datadir}/%{name}/'                                         \
+          -e '/%files/a %{_datadir}/imhex/'                                           \
           $GITHUB_WORKSPACE/ImHex/dist/rpm/imhex.spec
 
       - name: 📜 Fix ccache on EL9
-        if: matrix.mock_release == 'epel9'
+        if: matrix.mock_config == 'alma+epel-9'
         run: sed -i '/\. \/opt\/rh\/gcc-toolset-14\/enable/a PATH=/usr/lib64/ccache:$PATH' $GITHUB_WORKSPACE/ImHex/dist/rpm/imhex.spec
 
       - name: 🟩 Copy spec file to build root
@@ -1055,11 +1051,11 @@ jobs:
       # Fedora cmake build (in imhex.spec)
       - name: 📦 Build RPM
         run: |
-          fedpkg --path $GITHUB_WORKSPACE --release ${{ matrix.mock_release }} mockbuild --enable-network -N --root $GITHUB_WORKSPACE/mock.cfg extra_args -- -v
+          mock -r ${{ matrix.mock_config }}-x86_64 --enable-network -N -v --spec $GITHUB_WORKSPACE/imhex.spec --sources $GITHUB_WORKSPACE --resultdir $GITHUB_WORKSPACE/results
 
       - name: 🟩 Move and rename finished RPM
         run: |
-          mv $GITHUB_WORKSPACE/results_imhex/${{ env.IMHEX_VERSION }}/*/imhex-${{ env.IMHEX_VERSION }}-0.*.x86_64.rpm \
+          mv $GITHUB_WORKSPACE/results/imhex-${{ env.IMHEX_VERSION }}-0.*.x86_64.rpm \
           $GITHUB_WORKSPACE/imhex-${{ env.IMHEX_VERSION }}-${{ matrix.name }}-${{ matrix.release_num }}-x86_64.rpm
 
       - name: 🗝️ Generate build provenance attestations

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -346,10 +346,6 @@ macro(createPackage)
 
         # install AppStream file
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dist/net.werwolv.ImHex.metainfo.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo)
-
-        # install symlink for the old standard name
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dist/net.werwolv.ImHex.metainfo.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo RENAME net.werwolv.imhex.appdata.xml)
-
     endif()
 
     if (APPLE)

--- a/dist/rpm/imhex.spec
+++ b/dist/rpm/imhex.spec
@@ -6,7 +6,7 @@ Release:        0%{?dist}
 Summary:        A hex editor for reverse engineers and programmers
 
 License:        GPL-2.0-only AND Zlib AND MIT AND Apache-2.0
-# imhex is gplv2.  capstone is custom.  nativefiledialog is Zlib.
+# imhex is gplv2.  capstone is custom.
 # see license dir for full breakdown
 URL:            https://imhex.werwolv.net/
 # We need the archive with deps bundled
@@ -16,7 +16,6 @@ BuildRequires:  cmake
 BuildRequires:  desktop-file-utils
 BuildRequires:  dbus-devel
 BuildRequires:  file-devel
-BuildRequires:  fontconfig-devel
 BuildRequires:  freetype-devel
 BuildRequires:  fmt-devel
 BuildRequires:  gcc-c++
@@ -25,33 +24,41 @@ BuildRequires:  libglvnd-devel
 BuildRequires:  glfw-devel
 BuildRequires:  json-devel
 BuildRequires:  libcurl-devel
-BuildRequires:  llvm-devel
-BuildRequires:  mbedtls-devel
-BuildRequires:  yara-devel
-BuildRequires:  nativefiledialog-extended-devel
-BuildRequires:  dotnet-sdk-8.0
+BuildRequires:  libarchive-devel
 BuildRequires:  libzstd-devel
 BuildRequires:  zlib-devel
 BuildRequires:  bzip2-devel
 BuildRequires:  xz-devel
+BuildRequires:  llvm-devel
+BuildRequires:  mbedtls-devel
+BuildRequires:  yara-devel
+BuildRequires:  nativefiledialog-extended-devel
+BuildRequires:  lz4-devel
 BuildRequires:  libssh2-devel
-%if 0%{?rhel}
+%if 0%{?rhel} == 9
 BuildRequires:  gcc-toolset-14
 %endif
+%if 0%{?fedora} || 0%{?rhel} > 9
+BuildRequires:  capstone-devel
+%endif
+BuildRequires:  lunasvg-devel
+
 
 Provides:       bundled(gnulib)
-Provides:       bundled(capstone) = 5.0-rc2
-Provides:       bundled(imgui)
+%if 0%{?rhel} == 10
+Provides:       bundled(capstone) = 5.0.1
+%endif
+Provides:       bundled(imgui) = 1.90.8
 Provides:       bundled(libromfs)
 Provides:       bundled(microtar)
+Provides:       bundled(libpl) = %{version}
 Provides:       bundled(xdgpp)
+# working on packaging this, bundling for now as to now delay updates
+Provides:       bundled(miniaudio) = 0.11.11
 
-# ftbfs on these arches.  armv7hl might compile when capstone 5.x
-# is released upstream and we can build against it
 # [7:02 PM] WerWolv: We're not supporting 32 bit anyways soooo
 # [11:38 AM] WerWolv: Officially supported are x86_64 and aarch64
-ExclusiveArch:  x86_64 %{arm64} ppc64le
-
+ExclusiveArch:  x86_64 %{arm64}
 
 %description
 ImHex is a Hex Editor, a tool to display, decode and analyze binary data to
@@ -65,16 +72,33 @@ displayed, a disassembler, diffing support, bookmarks and much much more. At the
 same time ImHex is completely free and open source under the GPLv2 language.
 
 
+%package devel
+Summary:        Development files for %{name}
+License:        GPL-2.0-only
+%description devel
+%{summary}
+
+
 %prep
-%autosetup -n ImHex
+%autosetup -n ImHex -p1
 # remove bundled libs we aren't using
-rm -rf lib/third_party/{fmt,nlohmann_json,yara}
+rm -rf lib/third_party/{curl,fmt,llvm,nlohmann_json,yara}
+%if 0%{?fedora} || 0%{?rhel} > 9
+rm -rf lib/third_party/capstone
+%endif
+
+# rhel 9 doesn't support all of the new appstream metainfo tags
+%if 0%{?rhel} && 0%{?rhel} < 10
+sed -i -e '/url type="vcs-browser"/d' \
+	-e '/url type="contribute"/d' \
+	dist/net.werwolv.ImHex.metainfo.xml
+%endif
 
 %build
-%if 0%{?rhel}
+%if 0%{?rhel} == 9
 . /opt/rh/gcc-toolset-14/enable
 %set_build_flags
-CXXFLAGS+=" -std=gnu++23"
+CXXFLAGS+=" -std=gnu++2b"
 %endif
 %cmake \
  -D CMAKE_BUILD_TYPE=Release             \
@@ -82,23 +106,30 @@ CXXFLAGS+=" -std=gnu++23"
  -D IMHEX_OFFLINE_BUILD=ON               \
  -D USE_SYSTEM_NLOHMANN_JSON=ON          \
  -D USE_SYSTEM_FMT=ON                    \
+ -D USE_SYSTEM_CURL=ON                   \
+ -D USE_SYSTEM_LLVM=ON                   \
+%if 0%{?fedora} || 0%{?rhel} > 9
+ -D USE_SYSTEM_CAPSTONE=ON               \
+%endif
+ -D USE_SYSTEM_LUNASVG=ON                \
  -D USE_SYSTEM_YARA=ON                   \
  -D USE_SYSTEM_NFD=ON                    \
- -D IMHEX_USE_GTK_FILE_PICKER=ON         \
- -D IMHEX_BUNDLE_DOTNET=OFF              \
-# when capstone >= 5.x is released we should be able to build against \
-# system libs of it \
-# -D USE_SYSTEM_CAPSTONE=ON
+ -D IMHEX_ENABLE_UNIT_TESTS=ON           \
+%if 0%{?rhel}
+ -D IMHEX_BUILD_HARDENING=OFF
+%endif
+# disable built-in build hardening because it is already
+# done in rhel buildroots.  adding the flags again from
+# upstream generates build errors
 
 %cmake_build
 
 
 %check
-%if 0%{?rhel}
-. /opt/rh/gcc-toolset-14/enable
-%set_build_flags
-CXXFLAGS+=" -std=gnu++23"
-%endif
+# build binaries required for tests
+%cmake_build --target unit_tests
+%ctest --exclude-regex '(Helpers/StoreAPI|Helpers/TipsAPI|Helpers/ContentAPI)'
+# Helpers/*API exclude tests that require network access
 
 
 %install
@@ -106,15 +137,16 @@ CXXFLAGS+=" -std=gnu++23"
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 # this is a symlink for the old appdata name that we don't need
-rm -f %{buildroot}%{_metainfodir}/net.werwolv.%{name}.appdata.xml
+rm -f %{buildroot}%{_metainfodir}/net.werwolv.ImHex.appdata.xml
 
 # AppData
-appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/net.werwolv.%{name}.metainfo.xml
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/net.werwolv.ImHex.metainfo.xml
 
 # install licenses
-cp -a lib/third_party/nativefiledialog/LICENSE                       %{buildroot}%{_datadir}/licenses/%{name}/nativefiledialog-LICENSE
+%if 0%{?rhel} == 9
 cp -a lib/third_party/capstone/LICENSE.TXT                           %{buildroot}%{_datadir}/licenses/%{name}/capstone-LICENSE
 cp -a lib/third_party/capstone/suite/regress/LICENSE                 %{buildroot}%{_datadir}/licenses/%{name}/capstone-regress-LICENSE
+%endif
 cp -a lib/third_party/microtar/LICENSE                               %{buildroot}%{_datadir}/licenses/%{name}/microtar-LICENSE
 cp -a lib/third_party/xdgpp/LICENSE                                  %{buildroot}%{_datadir}/licenses/%{name}/xdgpp-LICENSE
 
@@ -123,11 +155,15 @@ cp -a lib/third_party/xdgpp/LICENSE                                  %{buildroot
 %license %{_datadir}/licenses/%{name}/
 %doc README.md
 %{_bindir}/imhex
-%{_bindir}/imhex-updater
-%{_datadir}/pixmaps/%{name}.svg
+%{_datadir}/pixmaps/%{name}.*
 %{_datadir}/applications/%{name}.desktop
-%{_datadir}/mime/packages/%{name}.xml
-%{_libdir}/libimhex.so*
+%{_libdir}/libimhex.so.*
 %{_libdir}/%{name}/
-/usr/lib/debug/%{_libdir}/*.debug
-%{_metainfodir}/net.werwolv.%{name}.metainfo.xml
+%{_metainfodir}/net.werwolv.ImHex.metainfo.xml
+%exclude %{_bindir}/imhex-updater
+%{_datadir}/mime/packages/%{name}.xml
+
+
+%files devel
+%{_libdir}/libimhex.so
+%{_datadir}/%{name}/sdk/


### PR DESCRIPTION
Gets RPM builds back in sync with Fedora/EPEL and changes to mock instead of fedpkg (slight efficiency improvement since fedpkg is a wrapper around mock).