### PR TITLE
impr: scroll to beginning of pattern when clicked, not the end

### DIFF
--- a/plugins/ui/include/ui/hex_editor.hpp
+++ b/plugins/ui/include/ui/hex_editor.hpp
@@ -158,7 +158,7 @@ namespace hex::ui {
 
             m_selectionStart = std::clamp<u64>(start, 0, maxAddress);
             m_selectionEnd = std::clamp<u64>(end, 0, maxAddress);
-            m_cursorPosition = m_selectionEnd;
+            m_cursorPosition = m_selectionStart;
 
             if (m_selectionChanged) {
                 auto selection = this->getSelection();


### PR DESCRIPTION
When a pattern is larger than the visible area, the Hex editor will scroll to the end of the pattern when it is clicked. This change makes it scroll to the beginning instead, which is more intuitive for users who expect to see the start of the pattern when they click on it.

### Problem description
When a pattern item is larger than the Hex editor visible area (if pattern item is 40 rows, but Hex editor is 20 rows tall), it scrolls to the end of the pattern item.  I expect to see the beginning of the pattern item.

### Implementation description
Change cursor position to m_selectionStart instead of the end in setSelection().

### Additional things
I don't know what else this will affect.
