### PR TITLE
fix: imported patterns used for inheritance were not highlighted.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -257,10 +257,12 @@ void TextEditor::DeleteRange(const Coordinates &aStart, const Coordinates &aEnd)
         auto &firstLine = mLines[start.mLine];
         auto &lastLine  = mLines[end.mLine];
 
-        if (startIndex < (int)firstLine.size())
+        if (startIndex <= (int)firstLine.size())
             firstLine.erase(firstLine.begin() + startIndex, -1);
-        if (endIndex < (int)lastLine.size())
+        if (endIndex <= (int)lastLine.size())
             lastLine.erase(lastLine.begin(), endIndex);
+        else
+            lastLine.erase(lastLine.begin(), -1);
 
         if (!lastLine.empty()) {
             firstLine.insert(firstLine.end(), lastLine.begin(), lastLine.end());

--- a/plugins/builtin/include/content/text_highlighting/pattern_language.hpp
+++ b/plugins/builtin/include/content/text_highlighting/pattern_language.hpp
@@ -74,9 +74,11 @@ namespace hex::plugin::builtin {
         Scopes m_globalTokenRange;
 
         VariableMap m_UDTVariables;
+        VariableMap m_ImportedUDTVariables;
         VariableMap m_functionVariables;
         Variables m_globalVariables;
 
+        std::map<std::string, std::vector<Token>> m_parsedImports;
         std::map<std::string,std::string> m_attributeFunctionArgumentType;
         std::map<std::string,std::string> m_typeDefMap;
         std::map<std::string,std::string> m_typeDefInvMap;
@@ -157,6 +159,8 @@ namespace hex::plugin::builtin {
          * @brief Entry point to syntax highlighting
          */
         void highlightSourceCode();
+        void processSource();
+        void clearVariables();
 
         /**
         * @brief Syntax highlighting from parser


### PR DESCRIPTION
The problem was that imported files didn't have token sequences to obtain the UDT variables. The fix was to create maps from the file name to the token sequence and then process each imported file to obtain all the variables needed. Function variables are skipped since they can be part of the code.
There are also some minor code style corrections and a fix in the text editor where the last line of a selection was not being deleted.
