### PR TITLE
build: Move back to upstream edlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
     ignore = dirty
 [submodule "lib/third_party/edlib"]
 	path = lib/third_party/edlib
-	url = https://github.com/blawrence-ont/edlib
+	url = https://github.com/Martinsos/edlib
 	ignore = dirty
 [submodule "lib/third_party/lunasvg"]
 	path = lib/third_party/lunasvg


### PR DESCRIPTION
### Problem description
The current edlib submodule references a commit that's not present in <https://github.com/blawrence-ont/edlib>. This throws off submodule initialization and makes building an ImHex Flatpak using upstream Git HEAD require some nasty Git bodges.

### Implementation description
Switching to <https://github.com/Martinsos/edlib> in `.gitmodules` is all that is necessary, since <https://github.com/Martinsos/edlib/commit/0ddc23ea06abd95ab6227442acb4c27bd7607b68> properly exists.

### Screenshots
_This section was intentionally left blank._

### Additional things
For those curious, I'm currently working around this by manually appending
```gitconfig
[url "https://github.com/Martinsos/edlib"]
	insteadOf = "https://github.com/blawrence-ont/edlib"
```
to `${flatpak_builder_state}/git/https_github.com_blawrence-ont_edlib/config` after `flatpak-builder` has cloned the repository and failed. I know this is a brittle solution.