### PR TITLE
fix: find next and find previous not working on console.

### DIFF
--- a/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
+++ b/lib/third_party/imgui/ColorTextEditor/source/TextEditor.cpp
@@ -150,12 +150,8 @@ std::string TextEditor::GetText(const Coordinates &aStart, const Coordinates &aE
 }
 
 TextEditor::Coordinates TextEditor::SetCoordinates(int aLine, int aColumn) const {
-    if (isEmpty()) {
-        if ((aLine == 0 || aLine == -1) && (aColumn == 0 || aColumn == -1))
-            return Coordinates(0, 0);
-        else
-            return Invalid;
-    }
+    if (isEmpty())
+        return Coordinates(0, 0);
 
     Coordinates result = Coordinates(0, 0);
     auto lineCount = (int)mLines.size();


### PR DESCRIPTION
With only one menu entry and having set it to use the text editor then the console losses that functionality. Since both the console and the text editor are on the same view, it follows that they must share the menu entries. In some cases it is necessary to determine which of the two editors needs to be processed inside the menu entry itself.

Also an error that caused the creation of invalid coordinates when console is still empty was fixed by setting coordinates to 0,0 for empty files. Another problem was that left clicking on the console didn't select the word under the cursor but it does when left clicking on the text editor. Now it works in both.

The menu entries on the console were removed completely and swapped with a call to obtain the default 'edit' menu for the context popup. Also, the console in write-only, so some of the entries like `Paste` or `Replace` must be greyed out.

This PR is only to fix the bugs that exist currently. More work is still needed for: 
1)  Removing the remaining shortcuts and creating new menu entries for them and 
2)  Adding support for `Open` and `Save` in the pattern editor with path tracking.

I tested all combinations of menus and shorcuts with console and pattern editor and there were no problems I could detect.
