### PR TITLE
fix: segment numbers are still being cutoff.

### DIFF
--- a/plugins/ui/source/ui/hex_editor.cpp
+++ b/plugins/ui/source/ui/hex_editor.cpp
@@ -598,7 +598,7 @@ namespace hex::ui {
                     m_provider == nullptr ? 0 :
                     CharacterSize.x * std::max(
                         fmt::formatted_size("{:08X}: ", ((m_scrollPosition + m_visibleRowCount) * bytesPerRow) + m_provider->getBaseAddress() + m_provider->getCurrentPageAddress()),
-                        m_separatorStride == 0 ? 0 : fmt::formatted_size("{} {}", "hex.ui.common.segment"_lang, m_scrollPosition + m_visibleRowCount * bytesPerRow + m_provider->getBaseAddress() + m_provider->getCurrentPageAddress() / m_separatorStride)
+                        m_separatorStride == 0 ? 0 : fmt::formatted_size("{} {}", "hex.ui.common.segment"_lang, (m_scrollPosition + m_visibleRowCount) * bytesPerRow + m_provider->getBaseAddress() + m_provider->getCurrentPageAddress() / m_separatorStride)
                     )
                 );
                 ImGui::TableSetupColumn("");


### PR DESCRIPTION
I noticed that an earlier fix was missing parenthesis, so I checked a file of a big size and used a segment size of 1 and only 3 digits were being displayed in spite of needing 6.
