### PR TITLE
fix: shortcuts is subviews of pattern editor are duplicated in the main text editor.

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -351,8 +351,7 @@ namespace hex::plugin::builtin {
             oldHeight = height;
             if (g.NavWindow != nullptr) {
                 std::string name =  g.NavWindow->Name;
-                if (name.contains(textEditorView) || name.contains(consoleView))
-                    m_focusedSubWindowName = name;
+                m_focusedSubWindowName = name;
             }
 
             fonts::CodeEditor().push();


### PR DESCRIPTION
The error occurred because only one of two subviews (the text editor or the console) were allowed to report having focus. By extending this functionality to all subviews, each one can use its own set of shortcuts thus fixing the problem.
