### PR TITLE
fix: console selects word on click.

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1006,8 +1006,6 @@ namespace hex::plugin::builtin {
             RequestOpenPopup::post("hex.builtin.menu.edit");
             m_consoleEditor.get(provider).ClearRaiseContextMenu();
         }
-        if (!m_consoleEditor.get(provider).HasSelection())
-            m_consoleEditor.get(provider).SelectWordUnderCursor();
 
         if (m_consoleCursorNeedsUpdate.get(provider)) {
             m_consoleEditor.get(provider).SetFocusAtCoords(m_consoleCursorPosition.get(provider));


### PR DESCRIPTION
The problem was that the console was calling select word under cursor when no selection was done. Fixed by removing the call.

