### PR TITLE
fix: Menu items greyed out when they shouldn't

### DIFF
--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -351,7 +351,8 @@ namespace hex::plugin::builtin {
             oldHeight = height;
             if (g.NavWindow != nullptr) {
                 std::string name =  g.NavWindow->Name;
-                m_focusedSubWindowName = name;
+                if (name.contains(textEditorView) || name.contains(consoleView) || name.contains(variablesView) || name.contains(settingsView) || name.contains(virtualFilesView) || name.contains(debuggerView))
+                    m_focusedSubWindowName = name;
             }
 
             fonts::CodeEditor().push();


### PR DESCRIPTION
Problem was that a recent commit allowed any subview window to become the current subview with focus which also included the context menu popup. The fix is to list all the subviews that can acquire focus so that they are the only ones that will be detected by the menu condition.
