### PR TITLE
fix: typing `t<` on pattern editor spams the log infinitely

### DIFF
--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -331,9 +331,11 @@ namespace hex::plugin::builtin {
         i32 skipCountLimit =
                 increment > 0 ? std::min(maxSkipCount, (i32) tokenCount - 1 - tokenId) : std::min(maxSkipCount, tokenId);
         next(increment);
+        skipCountLimit -= increment;
 
         if (peek(delimiter[0])) {
             next(increment);
+            skipCountLimit -= increment;
             while (skipCount < skipCountLimit) {
 
                 if (peek(delimiter[1])) {


### PR DESCRIPTION
The error was caused when the search for the closing delimiter extended past the last token in the sequence, which happened because the initial increments before the loop starts were not being accounted for in the loop ending condition. This was fixed by decrementing the limit of possible steps to account for the initial steps taken.