### PR TITLE
Fixed a Chinese translate error

### DIFF
--- a/plugins/windows/romfs/lang/zh_CN.json
+++ b/plugins/windows/romfs/lang/zh_CN.json
@@ -3,7 +3,7 @@
     "country": "China",
     "language": "Chinese (Simplified)",
     "translations": {
-        "hex.builtin.setting.general.context_menu_entry": "窗口上下文菜单项",
+        "hex.builtin.setting.general.context_menu_entry": "添加到文件资源管理器右键菜单",
         "hex.builtin.setting.interface.show_resource_usage": "在底部中显示资源使用情况",
         "hex.windows.view.tty_console.auto_scroll": "自动滚动",
         "hex.windows.view.tty_console.baud": "波特率",

--- a/plugins/windows/romfs/lang/zh_TW.json
+++ b/plugins/windows/romfs/lang/zh_TW.json
@@ -3,7 +3,7 @@
     "country": "Taiwan",
     "language": "Chinese (Traditional)",
     "translations": {
-        "hex.builtin.setting.general.context_menu_entry": "視窗內容功能表項目",
+        "hex.builtin.setting.general.context_menu_entry": "加至檔案總管的環境選單",
         "hex.builtin.setting.interface.show_resource_usage": "",
         "hex.windows.view.tty_console.auto_scroll": "自動捲動",
         "hex.windows.view.tty_console.baud": "鮑率",


### PR DESCRIPTION
### Problem description
In current Chinese translation, "Windows context menu entry"  in General settings has been tranlated to 窗口上下文菜单项. and for Traditional Chinese, it's 視窗內容功能表項目 (basically the same).

The previous translations were not conveying the correct meaning associated with the term "Windows context menu entry". They were too literal and did not clearly describe the functionality related to the Windows Explorer context menu. 

"窗口" in Chinese means a physical window, **not the Microsoft Windows OS**. The Windows OS is usually referred to as "微软视窗" (rare) or left as "Windows".

"上下文菜单" is a very "direct" translation of "Context menu" that is hard to understand for most users. Chinese user usually call it "右键菜单", which is "Right-Click Menu".

### Implementation description
I've changed it to 添加到文件资源管理器右键菜单 for Simplified Chinese, and 加至檔案總管的環境選單 for Tranditional Chinese.

