### PR TITLE
fix: No scrolling on jumping to error source.

### DIFF
--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -22,7 +22,7 @@ namespace hex::ui {
         setCursorPosition(coords);
         ensureCursorVisible();
 
-        setFocusAtCoords(coords);
+        setFocusAtCoords(coords, true);
     }
 
     void TextEditor::moveToMatchedBracket(bool select) {


### PR DESCRIPTION
When I implemented the changes to allow creating breakpoints without losing focus in the pattern editor and without forcing it to scroll to the cursor position I broke the code that ensures the cursor is visible after being moved to the source code that caused the error. All I needed to do is to explicitly set the argument because the default is to not scroll to the cursor when focus is given to the pattern editor
