### PR TITLE
Limit max file size to load into RAM by the physical RAM size

### DIFF
--- a/lib/libimhex/CMakeLists.txt
+++ b/lib/libimhex/CMakeLists.txt
@@ -42,6 +42,7 @@ set(LIBIMHEX_SOURCES
         source/helpers/keys.cpp
         source/helpers/udp_server.cpp
         source/helpers/scaling.cpp
+        source/helpers/ram.cpp
 
         source/test/tests.cpp
 
@@ -63,6 +64,7 @@ if (APPLE)
     set(LIBIMHEX_SOURCES ${LIBIMHEX_SOURCES}
             source/helpers/utils_macos.m
             source/helpers/macos_menu.m
+            source/helpers/ram.cpp
     )
 endif ()
 

--- a/lib/libimhex/include/hex/helpers/ram.hpp
+++ b/lib/libimhex/include/hex/helpers/ram.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <hex.hpp>
+
+namespace hex {
+    u64 getPhysicalRAM();
+}

--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -396,7 +396,15 @@ namespace hex {
 
             void SliderDataSize::load(const nlohmann::json &data) {
                 if (data.is_number_integer()) {
-                    m_value = data.get<u64>();
+                    u64 value = data.get<u64>();
+
+                    if (value < m_min) {
+                        m_value = m_min;
+                    } else if (value > m_max) {
+                        m_value = m_max;
+                    } else {
+                        m_value = value;
+                    }
                 } else {
                     log::warn("Invalid data type loaded from settings for slider!");
                 }

--- a/lib/libimhex/source/helpers/ram.cpp
+++ b/lib/libimhex/source/helpers/ram.cpp
@@ -1,0 +1,45 @@
+#include <hex/helpers/ram.hpp>
+
+#if defined(OS_WINDOWS)
+    #include <windows.h>
+#elif defined(OS_MACOS)
+    #include <sys/types.h>
+    #include <sys/sysctl.h>
+#elif defined(OS_LINUX)
+    #include <fstream>
+#endif
+
+namespace hex {
+    u64 getPhysicalRAM() {
+        #if defined(OS_WINDOWS)
+            MEMORYSTATUSEX status;
+            status.dwLength = sizeof(status);
+            if (GlobalMemoryStatusEx(&status)) {
+                return status.ullTotalPhys;
+            }
+            return 0;
+
+        #elif defined(OS_MACOS)
+            int64_t mem;
+            size_t len = sizeof(mem);
+            if (sysctlbyname("hw.memsize", &mem, &len, nullptr, 0) == 0) {
+                return mem;
+            }
+            return 0;
+
+        #elif defined(OS_LINUX)
+            std::ifstream meminfo("/proc/meminfo");
+            std::string line;
+            while (std::getline(meminfo, line)) {
+                if (line.starts_with("MemTotal:")) {
+                    std::string value = line.substr(9);
+                    return std::stoll(value) * 1024; // kB to bytes
+                }
+            }
+            return 0;
+
+        #else
+            return 0;
+        #endif
+    }
+}

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -12,6 +12,7 @@
 
 #include <hex/helpers/http_requests.hpp>
 #include <hex/helpers/utils.hpp>
+#include <hex/helpers/ram.hpp>
 
 #include <imgui.h>
 #include <hex/ui/imgui_imhex_extensions.h>
@@ -757,7 +758,7 @@ namespace hex::plugin::builtin {
             ContentRegistry::Settings::add<Widgets::Checkbox>("hex.builtin.setting.general", "", "hex.builtin.setting.general.show_tips", false);
             ContentRegistry::Settings::add<Widgets::Checkbox>("hex.builtin.setting.general", "", "hex.builtin.setting.general.save_recent_providers", true);
             ContentRegistry::Settings::add<AutoBackupWidget>("hex.builtin.setting.general", "", "hex.builtin.setting.general.auto_backup_time");
-            ContentRegistry::Settings::add<Widgets::SliderDataSize>("hex.builtin.setting.general", "", "hex.builtin.setting.general.max_mem_file_size", 512_MiB, 0_bytes, 32_GiB, 1_MiB)
+            ContentRegistry::Settings::add<Widgets::SliderDataSize>("hex.builtin.setting.general", "", "hex.builtin.setting.general.max_mem_file_size", 512_MiB, 0_bytes, getPhysicalRAM(), 1_MiB)
                 .setTooltip("hex.builtin.setting.general.max_mem_file_size.desc");
             ContentRegistry::Settings::add<Widgets::SliderInteger>("hex.builtin.setting.general", "hex.builtin.setting.general.patterns", "hex.builtin.setting.general.pattern_data_max_filter_items", 128, 32, 1024);
 


### PR DESCRIPTION
I find it rather limiting to have the upper limit for the setting of a file size that can be loaded into RAM to be hard-coded as 32 Gb. That's for example how it's done in VirtualBox - the Base Memory slider is limited by the amount of installed physical RAM:

<img width="1560" height="1027" alt="Screenshot_20250927_234050" src="https://github.com/user-attachments/assets/ffcea224-5307-477d-9242-da949792c8f2" />

I really liked this approach, so I implemented it in this PR:

<img width="1590" height="911" alt="Screenshot_20250927_234311" src="https://github.com/user-attachments/assets/e07b7bbf-33ff-40e2-974f-41c8df1d53aa" />

I was also considering changing the slider to show the percentage of the usable RAM instead of the absolute value, so if more RAM is added later, the upper-limit value will be automatically recomputed accordingly, but decided to stick with the simpler approach.