### PR TITLE
[Feature] Add Base64 paste decoding (Fixes #2317)

### DIFF
--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -872,6 +872,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste.popup.button.selection": "Paste only over selection",
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "Paste all",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Paste all as string",
+     "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string": "Paste all as decoded base64 string",
     "hex.builtin.view.hex_editor.menu.edit.remove": "Remove...",
     "hex.builtin.view.hex_editor.menu.edit.resize": "Resize...",
     "hex.builtin.view.hex_editor.menu.edit.select_all": "Select all",

--- a/plugins/builtin/romfs/lang/fr_FR.json
+++ b/plugins/builtin/romfs/lang/fr_FR.json
@@ -834,6 +834,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste.popup.button.selection": "Coller uniquement sur la sélection",
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "Coller tout",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Coller tout en tant que chaîne",
+    "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string":"Coller tout comme chaîne base64 décodée",
     "hex.builtin.view.hex_editor.menu.edit.remove": "Supprimer...",
     "hex.builtin.view.hex_editor.menu.edit.resize": "Redimensionner...",
     "hex.builtin.view.hex_editor.menu.edit.select_all": "Sélectionner tout",

--- a/plugins/builtin/romfs/lang/pl_PL.json
+++ b/plugins/builtin/romfs/lang/pl_PL.json
@@ -836,6 +836,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste.popup.button.selection": "Wklej tylko nad zaznaczeniem",
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "Wklej wszystko",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Wklej wszystko jako string",
+    "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string": "Wklej wszystko jako zdekodowany ciąg base64",
     "hex.builtin.view.hex_editor.menu.edit.remove": "Usuń...",
     "hex.builtin.view.hex_editor.menu.edit.resize": "Zmień rozmiar...",
     "hex.builtin.view.hex_editor.menu.edit.select_all": "Zaznacz wszystko",

--- a/plugins/builtin/romfs/lang/uk_UA.json
+++ b/plugins/builtin/romfs/lang/uk_UA.json
@@ -825,6 +825,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste.popup.button.selection": "Вставити тільки над виділеним фрагментом",
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "Вставити все",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Вставити все як рядок",
+    "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string": "Вставити все як декодований рядок base64",
     "hex.builtin.view.hex_editor.menu.edit.remove": "Видалити...",
     "hex.builtin.view.hex_editor.menu.edit.set_base": "Встановити початкову адресу...",
     "hex.builtin.view.hex_editor.menu.edit.set_page_size": "Встановити кількість рядків...",

--- a/plugins/builtin/romfs/lang/zh_CN.json
+++ b/plugins/builtin/romfs/lang/zh_CN.json
@@ -838,6 +838,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste.popup.button.selection": "仅覆盖选区",
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "粘贴全部",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "全部作为字符串粘贴",
+    "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string":"粘贴所有内容为解码后的Base64字符串",
     "hex.builtin.view.hex_editor.menu.edit.remove": "删除……",
     "hex.builtin.view.hex_editor.menu.edit.resize": "修改大小……",
     "hex.builtin.view.hex_editor.menu.edit.select_all": "全选",

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -856,7 +856,53 @@ namespace hex::plugin::builtin {
         ImGui::SetClipboardText(result.c_str());
     }
 
-    static void pasteBytes(const Region &selection, bool selectionCheck, bool asPlainText) {
+    bool isValidBase64(const std::string &input) {
+        if (input.empty() || input.size() % 4 != 0)
+        {
+            log::info("Empty base64 string or check the padding: {}", input );
+            return false;
+        }
+        for (char c : input) {
+            if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '+' || c == '/' || c == '=' || c == '\n' || c == '\r'))
+            {   
+              log::info("Invalid Base64 string: {}", input);
+              return false;
+            }   
+        }
+        return true;
+    }
+
+    std::vector<u8> decodeBase64(const std::string &input) {
+
+        if(!isValidBase64(input)){
+            return {};
+        }
+
+        static constexpr char sDecodingTable[] ="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::vector<u8> output;
+        int val = 0, valb = -8;
+
+        for (char c : input) {
+            if (c == '=' || c == '\n' || c == '\r') 
+                 break; 
+
+            const char *p = std::strchr(sDecodingTable, c);
+
+            if (!p) 
+                continue;
+            
+            val = (val << 6) + (p - sDecodingTable);
+            valb += 6;
+            if (valb >= 0) {
+                output.push_back(u8((val >> valb) & 0xFF));
+                valb -= 8;
+            }
+        }
+       
+       return output;
+    }
+
+    static void pasteBytes(const Region &selection, bool selectionCheck, bool asPlainText, bool asBase64=false) {
         auto provider = ImHexApi::Provider::get();
         if (provider == nullptr)
             return;
@@ -866,7 +912,10 @@ namespace hex::plugin::builtin {
             return;
 
         std::vector<u8> buffer;
-        if (asPlainText) {
+         if(asBase64){
+           buffer = decodeBase64(clipboard);
+        }
+        else if (asPlainText) {
             // Directly reinterpret clipboard as an array of bytes
             std::string cp = clipboard;
             buffer = std::vector<u8>(cp.begin(), cp.end());
@@ -1547,6 +1596,20 @@ namespace hex::plugin::builtin {
                                                 [] {
                                                     pasteBytes(ImHexApi::HexEditor::getSelection().value_or( ImHexApi::HexEditor::ProviderRegion(Region { 0, 0 }, ImHexApi::Provider::get())), false, true);
                                                 },
+                                                ImHexApi::HexEditor::isSelectionValid,
+                                                this);
+
+                                                     /* Paste... > Paste all as decoded base64 string */
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_as", "hex.builtin.view.hex_editor.menu.edit.paste_all_decoded_base64_string" }, ICON_VS_BLANK, 1520,
+                                                Shortcut::None,
+                                                [] {
+                                                        pasteBytes(
+                                                            ImHexApi::HexEditor::getSelection().value_or(ImHexApi::HexEditor::ProviderRegion(Region { 0, 0 }, ImHexApi::Provider::get())),
+                                                            false,
+                                                            false,   
+                                                            true     
+                                                        );
+                                                    },
                                                 ImHexApi::HexEditor::isSelectionValid,
                                                 this);
 


### PR DESCRIPTION

### Problem description
Ability to paste Base64 with autodetection of base64 when pasting or under the paste as dropdown.

### Implementation description
I have added an option `Paste all as decoded base64 string` under the `Paste as` option. 
I have modified the function `pasteBytes()` in `plugins/builtin/source/content/views/view_hex_editor.cpp` and added two functions `isValidBase64()` and `decodeBase64()`.
It checks if the copied string is empty or its length a multiple of 4 (because a valid base64 string is multiple of 4 or padded with = to satisfy the condition).
Then it `decodeBase64` function is called and decoded output is pasted.
For eg, `aGVsbG8gd29ybGQ=` -> this string is present in my clipboard, I am attaching the screenshot.

### Screenshots
<img width="780" height="109" alt="image" src="https://github.com/user-attachments/assets/99f49184-30b4-465b-819b-c031cb927e50" />

<img width="780" height="109" alt="image" src="https://github.com/user-attachments/assets/f70e968f-300a-4604-bab2-fd5aacfec083" />



