### PR TITLE
fix: Always order recent providers

### DIFF
--- a/plugins/builtin/source/content/recent.cpp
+++ b/plugins/builtin/source/content/recent.cpp
@@ -202,9 +202,8 @@ namespace hex::plugin::builtin::recent {
                     };
 
                     // Do not add entry twice
-                    if (alreadyAddedProviders.contains(entry))
+                    if (!alreadyAddedProviders.insert(entry).second)
                         continue;
-                    alreadyAddedProviders.insert(entry);
 
                     s_recentEntries.push_back(entry);
                 } catch (const std::exception &e) {


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
Recent providers weren't always ordered from the most recent to the oldest.
### Implementation description
Removed the usage of unordered_set to store providers

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
