### PR TITLE
fix: add newly created projects to "Recent"

### DIFF
--- a/lib/libimhex/include/hex/api/events/events_lifecycle.hpp
+++ b/lib/libimhex/include/hex/api/events/events_lifecycle.hpp
@@ -80,6 +80,11 @@ namespace hex {
     EVENT_DEF(EventProjectOpened);
 
     /**
+     * @brief Called when a project is saved/saved as
+     */
+    EVENT_DEF(EventProjectSaved);
+
+    /**
      * @brief Called when a native message was received from another ImHex instance
      * @param rawData Raw bytes received from other instance
      */

--- a/plugins/builtin/source/content/project.cpp
+++ b/plugins/builtin/source/content/project.cpp
@@ -174,6 +174,8 @@ namespace hex::plugin::builtin {
 
         AchievementManager::unlockAchievement("hex.builtin.achievement.starting_out", "hex.builtin.achievement.starting_out.save_project.name");
 
+        EventProjectSaved::post();
+
         return result;
     }
 


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
Projects weren't being saved as recent when a new project was saved. They were only added as recent when re-opening the project

### Implementation description
<!-- Explain what you did to correct the problem -->
I also save projects as recent when saving them (I don't make a difference between saving existing and new projects)

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
