### PR TITLE
Skip Rendering Patterns When Evaluation Has Been Scheduled

### DIFF
--- a/plugins/builtin/include/content/views/view_pattern_data.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_data.hpp
@@ -35,6 +35,7 @@ namespace hex::plugin::builtin {
         Region m_hoveredPatternRegion = Region::Invalid();
         ui::PatternValueEditor m_patternValueEditor;
         PerProvider<std::vector<VirtualFile>> m_virtualFiles;
+        u32 m_scheduledEvaluators;
 
     };
 


### PR DESCRIPTION
Problem:
A data race occurs between the main rendering thread and the background evaluation thread when scheduling a new evaluation. Although the runtime is protected by a lock, the patterns themselves are not. Prior to scheduling a new evaluation, the drawer is cleared via drawer->reset(). However, there is a narrow window after scheduling but before the evaluation thread acquires the runtime lock, during which rendering can repopulate the drawer.
This leads to concurrent access: the main thread retains references to patterns from the previous evaluation, while the evaluation thread clears and reloads the evaluator's local data section.

Example of Visible Issue:

Patterns from the prior evaluation hold references to the evaluator's local data section, with destructors that decrement the reference count. Upon starting the new evaluation,
the local data section is cleared and repopulated with new data (incrementing ref counts for the fresh content). After the evaluation completes, the drawer is cleared again, triggering destructors for the stale patterns. This decrements the ref count on the now-replaced local data to zero, erroneously erasing valid data. Result: Value is render as "Tried accessing out of bounds pattern local cell".

Solution:
Introduce a tracker variable m_scheduledEvaluators in ViewPatternData to indicate pending evaluations. During rendering, skip pattern updates if any evaluations are scheduled (m_scheduledEvaluators > 0). This prevents repopulation of the drawer in the critical window.
