### PR TITLE
fix: `HighlightSourceCode` `m_lines` use after free crash

### DIFF
--- a/plugins/builtin/include/content/text_highlighting/pattern_language.hpp
+++ b/plugins/builtin/include/content/text_highlighting/pattern_language.hpp
@@ -164,7 +164,7 @@ namespace hex::plugin::builtin {
         /**
          * @brief Entry point to syntax highlighting
          */
-        void highlightSourceCode();
+        void highlightSourceCode(const std::string& text);
         void processSource();
         void clearVariables();
 

--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -2246,7 +2246,7 @@ namespace hex::plugin::builtin {
 
 
 // Only update if needed. Must wait for the parser to finish first.
-    void TextHighlighter::highlightSourceCode() {
+    void TextHighlighter::highlightSourceCode(const std::string& text) {
         m_wasInterrupted = false;
         ON_SCOPE_EXIT {
             if (!m_tokenColors.empty())
@@ -2298,10 +2298,7 @@ namespace hex::plugin::builtin {
             m_globalTokenRange.insert(Interval(0, m_tokens.size()-1));
 
             ui::TextEditor *editor = m_viewPatternEditor->getTextEditor();
-            if (editor != nullptr)
-                m_text = editor->getText();
-            else
-                log::warn("Text editor not found, provider is null");
+            m_text = text;
 
             if (m_text.empty() || m_text == "\n")
                 return;

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1435,7 +1435,9 @@ namespace hex::plugin::builtin {
                 if (m_textHighlighter.getRunningColorizers() == 0) {
                     m_textHighlighter.m_needsToUpdateColors = false;
                     m_changesWereParsed = false;
-                    TaskManager::createBackgroundTask("HighlightSourceCode", [this](auto &) { m_textHighlighter.highlightSourceCode(); });
+                      
+                    auto text = m_textEditor.get(provider).getText();
+                    TaskManager::createBackgroundTask("HighlightSourceCode", [this, text](auto &) { m_textHighlighter.highlightSourceCode(text); });
                 } else {
                     m_textHighlighter.interrupt();
                 }


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description

https://github.com/WerWolv/ImHex/issues/2542

A task manager running the task `TaskManager::createBackgroundTask("HighlightSourceCode", [this](auto &) { m_textHighlighter.highlightSourceCode(); });` runs on one thread while the main thread's render runs on the main thread, and they both call into pattern editor, and both access m_lines concurrently without locking.

### Implementation description

I changed it to call `getText()` from the main thread and then pass that as a parameter to ` m_textHighlighter.
highlightSourceCode(text);`.

This is enough to keep it from crashing at startup when compiled with asan, but I don't think it is a complete fix. I figured I should get some feedback on the direction before changing too much.


### Additional things
<!-- Anything else you would like to say -->
While I have some experience debugging threading issues and heap corruption, I haven't worked on ImHex before, so I'm probably missing a lot.


