### PR TITLE
Make LoadLibrary in version stripper more efficient and reliable.

### DIFF
--- a/main/version_stripper/source/main.cpp
+++ b/main/version_stripper/source/main.cpp
@@ -33,7 +33,7 @@ BOOL CALLBACK EnumResLangProc(
 LangIds getLangIDs(LPCTSTR pExe) {
     LangIds langs;
 
-    HMODULE hMod = LoadLibrary(pExe);
+    HMODULE hMod = LoadLibraryEx(pExe, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE);
     if (hMod == nullptr)
         throw std::runtime_error("LoadLibrary failed!");
 


### PR DESCRIPTION
### Description
Make LoadLibrary in version stripper more efficient and reliable.

### Implementation description
Replace LoadLibrary with LoadLibraryEx and the LOAD_LIBRARY_AS_IMAGE_RESOURCE flag. This will be more efficent and reliable. For example the old way would fail if a static import could not be resolved. No DllMain calls will be made.