### PR TITLE
fix: DiskProvider::open() default result on Windows

### DIFF
--- a/plugins/builtin/source/content/providers/disk_provider.cpp
+++ b/plugins/builtin/source/content/providers/disk_provider.cpp
@@ -158,6 +158,7 @@ namespace hex::plugin::builtin {
 #endif
 
     prv::Provider::OpenResult DiskProvider::open() {
+        OpenResult result;
         m_readable = true;
         m_writable = true;
 
@@ -207,7 +208,6 @@ namespace hex::plugin::builtin {
             const auto &path = m_path.native();
 
             m_diskHandle = ::open(path.c_str(), O_RDWR);
-            OpenResult result;
             if (m_diskHandle == -1) {
                 result = OpenResult::warning(fmt::format("hex.builtin.provider.disk.error.read_rw"_lang, path, formatSystemError(errno)));
                 m_diskHandle = ::open(path.c_str(), O_RDONLY);


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

### Implementation description
<!-- Explain what you did to correct the problem -->

### Screenshots
<!-- If your change is visual, take a screenshot showing it. Ideally, make before/after sceenshots -->

### Additional things
<!-- Anything else you would like to say -->
