### PR TITLE
fix: division by zero in sound visualizer.

### DIFF
--- a/plugins/visualizers/source/content/pl_visualizers/sound.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/sound.cpp
@@ -30,8 +30,10 @@ namespace hex::plugin::visualizers {
 
         if (sampleRate == 0)
             throw std::logic_error(fmt::format("Invalid sample rate: {}", sampleRate));
-        else if (channels == 0)
+        if (channels == 0)
             throw std::logic_error(fmt::format("Invalid channel count: {}", channels));
+        if (downSampling == 0)
+            throw std::logic_error(fmt::format("Invalid down sampling factor: {} / 2400 / {} = {}", wavePattern->getSize(), channels, downSampling));
         u64 sampledIndex;
         if (shouldReset) {
             waveData.clear();


### PR DESCRIPTION
Can happen if input is less than 2400*channels number of points. The fix is detecting it and throwing an error.

