### PR TITLE
Fix: fixes #2594

### DIFF
--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -1831,7 +1831,7 @@ namespace hex::plugin::builtin {
         auto topLine = 0;
         while (m_firstTokenIdOfLine.at(topLine) == -1)
             topLine++;
-        auto bottomLine = m_lines.size();
+        auto bottomLine = previousLine(m_firstTokenIdOfLine.size());
         for (u32 line = topLine; line < bottomLine; line = nextLine(line)) {
             if (m_lines[line].empty())
                 continue;


### PR DESCRIPTION
The assumption that the number of lines of colors will be equal to the number of lines in the input signal is incorrect. As issue #2594 shows, erroneous input can cause the lexer to end processing the input file prematurely thus being unable to create tokens past the line where the error occurred which in turn implies that no colors can be found beyond those lines. 

To fix the crash (the underlying problem is user caused and can't be fixed) is to use the size of the vectors containing the first token index of each line since that size must be equal to the number of lines stored in token sequence.

