### PR TITLE
Allow access to web docker app from outside container

### DIFF
--- a/dist/web/serve.py
+++ b/dist/web/serve.py
@@ -10,6 +10,6 @@ class MyHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
 
 if __name__ == '__main__':
     os.chdir(".")
-    httpd = http.server.HTTPServer(("localhost", 9090), MyHttpRequestHandler)
+    httpd = http.server.HTTPServer(("0.0.0.0", 9090), MyHttpRequestHandler)
     print(f"Serving {os.getcwd()} on http://{httpd.server_address[0]}:{httpd.server_address[1]}")
     httpd.serve_forever()


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
When trying to install imhex as a docker container using `ghcr.io/werwolv/imhex/imhex-web`, the 9090 port doesn't connect to anything on the host server. Connections to 9090 work inside the container.

This is because the `localhost` address is `127.0.0.1` which does not allow for access from outside.

### Implementation description
Change server binding from `localhost` to `0.0.0.0` to allow connections from all interfaces, no just `lo`.

### Screenshots

<img width="345" height="257" alt="image" src="https://github.com/user-attachments/assets/2825ac11-657c-4c34-b918-60c4a2750b0f" />

Where 9090 is before and 9091 is after the change.

Before
<img width="846" height="339" alt="image" src="https://github.com/user-attachments/assets/4635467d-5190-49a8-bd97-f678f364250d" />

After
<img width="835" height="969" alt="image" src="https://github.com/user-attachments/assets/af3f0228-ae0b-4704-89c9-50b32c2198eb" />


### Additional things
<!-- Anything else you would like to say -->
