### PR TITLE
fix: popup when highlighting was cancelled

### DIFF
--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -2556,10 +2556,7 @@ namespace hex::plugin::builtin {
             }
         } catch (const std::out_of_range &e) {
             log::debug("TextHighlighter::highlightSourceCode: Out of range error: {}", e.what());
-            m_viewPatternEditor->interrupt();
             return;
         }
-
-                return;
     }
 }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1479,11 +1479,7 @@ namespace hex::plugin::builtin {
                 interrupt();
             else if (m_runningHighlighters == 0 && m_changesWereParsed && !m_changesWereColored && !m_allStepsCompleted) {
                 m_textHighlighter.get(provider).setViewPatternEditor(this);
-                try {
-                    m_textHighlighter.get(provider).updateRequiredInputs();
-                } catch (...) {
-
-                }
+                m_textHighlighter.get(provider).updateRequiredInputs();
                 TaskManager::createBackgroundTask("HighlightSourceCode", [this,provider](auto &) { m_textHighlighter.get(provider).highlightSourceCode(); });
             } else if (m_changesWereColored && !m_allStepsCompleted) {
                 m_textHighlighter.get(provider).setRequestedIdentifierColors();


### PR DESCRIPTION
Popup was caused by old code that set the interrupt flag when the exception was caught in the thread and was already fixed in the code folding branch.
