### PR TITLE
Fix build with USE_SYSTEM_LLVM failing to find Demangle.h

### DIFF
--- a/lib/trace/CMakeLists.txt
+++ b/lib/trace/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(LIBIMHEX_LIBRARY_TYPE_PRIVATE PRIVATE)
 endif()
 
-target_include_directories(tracing ${LIBIMHEX_LIBRARY_TYPE_PUBLIC} include)
+target_include_directories(tracing ${LIBIMHEX_LIBRARY_TYPE_PUBLIC} include ${LLVM_INCLUDE_DIRS})
 
 if (NOT IMHEX_DISABLE_STACKTRACE)
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Compiling ImHex with -DUSE_SYSTEM_LLVM=ON will cause a compile error as [lib/trace/source/stacktrace.cpp](https://github.com/WerWolv/ImHex/blob/21a94d67c29d6a20928a21d1e41fcb296b2a9491/lib/trace/source/stacktrace.cpp#L5) cannot find Demangle.h

### Implementation description
This adds the LLVM include directive to the CMakeLists.txt file for lib/trace