### PR TITLE
Improve handling of imhex_patterns_SOURCE_DIR

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -665,6 +665,11 @@ function(downloadImHexPatternsFiles dest)
         if (NOT EXISTS ${imhex_patterns_SOURCE_DIR})
             set(imhex_patterns_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../ImHex-Patterns")
         endif()
+
+        # it does not exist, fallback to empty path to skip installing.
+        if (NOT EXISTS ${imhex_patterns_SOURCE_DIR})
+            set(imhex_patterns_SOURCE_DIR "")
+        endif()
     endif ()
 
     install(CODE "set(imhex_patterns_SOURCE_DIR \"${imhex_patterns_SOURCE_DIR}\")")


### PR DESCRIPTION
### Problem description
If building without ImHex Patterns at all, the install phase will error out with missing files.

This is  a very niche situation, I know. It's what happens in my Gentoo overlay since I separate patterns into a separate package.

### Implementation description
Resets imhex_patterns_SOURCE_DIR to an empty string so that installation can be omitted in a later step.