### PR TITLE
fix: hex editor selection scrolling.

### DIFF
--- a/plugins/ui/source/ui/hex_editor.cpp
+++ b/plugins/ui/source/ui/hex_editor.cpp
@@ -1029,12 +1029,12 @@ namespace hex::ui {
                         if (m_shouldScrollToSelection && isSelectionValid()) {
                             // Make sure simply clicking on a byte at the edge of the screen won't cause scrolling
                             if ((ImGui::IsMouseDragging(ImGuiMouseButton_Left))) {
-                                if ((*m_selectionStart >= (*m_selectionEnd + bytesPerRow)) && y == (m_scrollPosition + 1)) {
+                                if (y == (m_scrollPosition + 1)) {
                                     if (i128(m_selectionEnd.value() - m_provider->getBaseAddress() - m_provider->getCurrentPageAddress()) <= (ImS64(m_scrollPosition + 1) * bytesPerRow)) {
                                         m_shouldScrollToSelection = false;
                                         m_scrollPosition -= 3;
                                     }
-                                } else if ((*m_selectionStart <= (*m_selectionEnd - bytesPerRow)) && y == ((m_scrollPosition + m_visibleRowCount) - 1)) {
+                                } else if (y == ((m_scrollPosition + m_visibleRowCount) - 1)) {
                                     if (i128(m_selectionEnd.value() - m_provider->getBaseAddress() - m_provider->getCurrentPageAddress()) >= (ImS64((m_scrollPosition + m_visibleRowCount) - 2) * bytesPerRow)) {
                                         m_shouldScrollToSelection = false;
                                         m_scrollPosition += 3;


### PR DESCRIPTION
Currently, if you start a selection in the middle of a largish file and without letting go of the left mouse key you place the mouse at the top line of the hex editor view then the selection will expand upwards and at some point the start of the selection will go out of view. If then you move the cursor (without letting go of the left mouse button) to the last line of the hex editor view you would expect that the end of the selection would start to increase in value, but it does nothing instead. A similar issue occurs at the other end.

The problem is that the code only allows the upward scrolling when moving the smaller address end to the first line, but it should also allow it when the bigger address end to the first line. This means that it doesn't matter which of the two ends is larger and this code removes the conditions on the relative sizes of the two ends allowing for selection growth to reverse direction.

