### PR TITLE
Use ImGuiWindowFlags_NoCollapse for popups

### DIFF
--- a/plugins/builtin/include/content/views/view_hex_editor.hpp
+++ b/plugins/builtin/include/content/views/view_hex_editor.hpp
@@ -60,7 +60,7 @@ namespace hex::plugin::builtin {
             [[nodiscard]] bool isPinned() const { return m_isPinned; }
             void setPinned(const bool pinned) { m_isPinned = pinned; }
 
-            [[nodiscard]] virtual ImGuiWindowFlags getFlags() const { return ImGuiWindowFlags_AlwaysAutoResize; }
+            [[nodiscard]] virtual ImGuiWindowFlags getFlags() const { return ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse; }
 
         private:
             bool m_isPinned = false;


### PR DESCRIPTION
### Problem description
Fix for issue [[Bug] "Go to address..." not working #2549](https://github.com/WerWolv/ImHex/issues/2549#issuecomment-4147893751)

### Implementation description
Use `ImGuiWindowFlags_NoCollapse` flag for popups.
