### PR TITLE
fix: improved pattern editor task handling

### DIFF
--- a/lib/libimhex/source/api/task_manager.cpp
+++ b/lib/libimhex/source/api/task_manager.cpp
@@ -332,6 +332,7 @@ namespace hex {
                         }
                     } catch (const Task::TaskInterruptor &) {
                         // Handle the task being interrupted by user request
+                        log::debug("Task '{}' was interrupted", task->m_unlocalizedName.get());
                         task->interruption();
                     } catch (const std::exception &e) {
                         log::error("Exception in task '{}': {}", task->m_unlocalizedName.get(), e.what());

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -155,7 +155,7 @@ namespace hex::plugin::builtin {
 
         PerProvider<std::list<EnvVar>> m_envVarEntries;
 
-        PerProvider<TaskHolder> m_analysisTask;
+        TaskHolder m_analysisTask;
         PerProvider<bool> m_shouldAnalyze;
         PerProvider<bool> m_breakpointHit;
         PerProvider<bool> m_debuggerActive;

--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -2515,7 +2515,6 @@ namespace hex::plugin::builtin {
             m_viewPatternEditor->setChangesWereColored(!m_viewPatternEditor->interrupted());
         };
         try {
-            m_viewPatternEditor->incrementRunningHighlighters(1);
             clearVariables();
             if (!m_UDTs.empty())
                 m_UDTs.clear();

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1402,29 +1402,33 @@ namespace hex::plugin::builtin {
             *m_executionDone = true;
         }
 
-        if (m_shouldAnalyze) {
-            m_shouldAnalyze = false;
+        if (m_shouldAnalyze.get(provider)) {
 
-            m_analysisTask = TaskManager::createBackgroundTask("hex.builtin.task.analyzing_data", [this, provider](Task &task) {
-                if (!m_suggestSupportedPatterns)
-                    return;
+            if (m_analysisTask.isRunning())
+                m_analysisTask.interrupt();
+            else {
+                m_shouldAnalyze.get(provider) = false;
+                m_analysisTask = TaskManager::createBackgroundTask("hex.builtin.task.analyzing_data", [this, provider](Task &task) {
+                    if (!m_suggestSupportedPatterns)
+                        return;
 
-                auto foundPatterns = magic::findViablePatterns(provider, &task);
+                    auto foundPatterns = magic::findViablePatterns(provider, &task);
 
-                if (!foundPatterns.empty()) {
-                    std::scoped_lock lock(m_possiblePatternFilesMutex);
+                    if (!foundPatterns.empty()) {
+                        std::scoped_lock lock(m_possiblePatternFilesMutex);
 
-                    auto &possiblePatterns = m_possiblePatternFiles.get(provider);
+                        auto &possiblePatterns = m_possiblePatternFiles.get(provider);
 
-                    possiblePatterns = std::move(foundPatterns);
+                        possiblePatterns = std::move(foundPatterns);
 
-                    if (m_autoApplyPatterns && possiblePatterns.size() == 1) {
-                        loadPatternFile(possiblePatterns.front().patternFilePath, provider, false);
-                    } else {
-                        PopupAcceptPattern::open(this);
+                        if (m_autoApplyPatterns && possiblePatterns.size() == 1) {
+                            loadPatternFile(possiblePatterns.front().patternFilePath, provider, false);
+                        } else {
+                            PopupAcceptPattern::open(this);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
 
         {
@@ -1459,6 +1463,7 @@ namespace hex::plugin::builtin {
                         if (m_runAutomatically)
                             m_triggerAutoEvaluate = true;
                     });
+                    m_runningParsers += 1;
                     m_hasUnevaluatedChanges.get(provider) = false;
             }
 
@@ -1470,8 +1475,16 @@ namespace hex::plugin::builtin {
                 interrupt();
             else if (m_runningHighlighters == 0 && m_changesWereParsed && !m_changesWereColored && !m_allStepsCompleted) {
                 m_textHighlighter.get(provider).setViewPatternEditor(this);
+                bool restoreInterruptState = false;
+                if (interrupted()) {
+                    restoreInterruptState = true;
+                    resetInterrupt();
+                }
                 m_textHighlighter.get(provider).updateRequiredInputs();
+                if (restoreInterruptState)
+                    interrupt();
                 TaskManager::createBackgroundTask("HighlightSourceCode", [this,provider](auto &) { m_textHighlighter.get(provider).highlightSourceCode(); });
+                m_runningHighlighters += 1;
             } else if (m_changesWereColored && !m_allStepsCompleted) {
                 m_textHighlighter.get(provider).setRequestedIdentifierColors();
                 m_allStepsCompleted = true;
@@ -1649,7 +1662,6 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::parsePattern(const std::string &code, prv::Provider *provider) {
-        m_runningParsers += 1;
 
         ContentRegistry::PatternLanguage::configureRuntime(*m_editorRuntime, nullptr);
         const auto &ast = m_editorRuntime->parseString(code, pl::api::Source::DefaultSource);


### PR DESCRIPTION
Pattern editor tasks for different providers can run contiguously and that can create problems. The analysis task has no restrictions on task creation. The parser and highlighting tasks restriction to one task relies on the task not being queued. 

This PR aims to ensure only one of the provider's tasks runs at a time. The analysis task checks to see if the task is running before creating a new one and if it is it interrupts it and will not create a new task until the previous one has finished. For the other two tasks, the variable used to restrict the number of tasks is incremented in the main thread when the task is created so that it is counted even if task is queued.

A message to the log was added when tasks are interrupted and code was added to prevent the highlighting task interruption from triggering an exception in the main thread.
