### PR TITLE
fix: buffer slice last byte out of range

### DIFF
--- a/plugins/builtin/source/content/data_processor_nodes/other_nodes.cpp
+++ b/plugins/builtin/source/content/data_processor_nodes/other_nodes.cpp
@@ -193,7 +193,7 @@ namespace hex::plugin::builtin {
 
             if (from < 0 || static_cast<u128>(from) >= input.size())
                 throwNodeError("'from' input out of range");
-            if (to < 0 || static_cast<u128>(to) >= input.size())
+            if (to < 0 || static_cast<u128>(to) > input.size())
                 throwNodeError("'to' input out of range");
             if (to <= from)
                 throwNodeError("'to' input needs to be greater than 'from' input");


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Fixes: #1880
The slice buffer node 'to' variable cannot be set to capture the last byte, throwing `'to' input out of range`.
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->

### Implementation description
The upper bound check was an greater or equals than, so switching it to a greater than fixes the issue.
<!-- Explain what you did to correct the problem -->