### PR TITLE
Truncate utf8 only at code point boundaries

### DIFF
--- a/lib/libimhex/source/api/task_manager.cpp
+++ b/lib/libimhex/source/api/task_manager.cpp
@@ -9,6 +9,7 @@
 #include <jthread.hpp>
 #include <hex/helpers/debugging.hpp>
 #include <hex/trace/exceptions.hpp>
+#include <wolv/utils/string.hpp>
 #include <utility>
 
 #if defined(OS_WINDOWS)
@@ -534,7 +535,8 @@ namespace hex {
 
     void TaskManager::setCurrentThreadName(const std::string &name) {
         std::ranges::fill(s_currentThreadName, '\0');
-        std::ranges::copy(name | std::views::take(255), s_currentThreadName.begin());
+        auto truncatedName = wolv::util::truncateUtf8(name, s_currentThreadName.size()-1);
+        std::ranges::copy(truncatedName, s_currentThreadName.begin());
 
         #if defined(OS_WINDOWS)
             using SetThreadDescriptionFunc =  HRESULT(WINAPI*)(HANDLE hThread, PCWSTR lpThreadDescription);

--- a/lib/libimhex/source/helpers/logger.cpp
+++ b/lib/libimhex/source/helpers/logger.cpp
@@ -8,6 +8,7 @@
 #include <hex/helpers/auto_reset.hpp>
 
 #include <wolv/io/file.hpp>
+#include <wolv/utils/string.hpp>
 
 #include <mutex>
 #include <chrono>
@@ -134,6 +135,11 @@ namespace hex::log {
                 threadName = "???";
             }
 
+            // Example prefix:
+            // [04:24:08] [DEBUG] [builtin | Init Tasks]
+            //                     |<------ tag ------|
+            //                    
+
             constexpr static auto MaxTagLength = 25;
             const auto totalLength = std::min(static_cast<size_t>(MaxTagLength),
                                               projectName.length() + (threadName.empty() ? 0 : 3 + threadName.length()));
@@ -144,11 +150,11 @@ namespace hex::log {
                 now,
                 s_colorOutputEnabled ? fmt::format(ts, "{}", level) : level,
                 projectName.substr(0, std::min(projectName.length(), static_cast<size_t>(MaxTagLength))),
-                threadName.substr(0, remainingSpace),
+                wolv::util::truncateUtf8(threadName, remainingSpace),
                 "",
                 MaxTagLength - totalLength
             );
-        }
+        }   
 
         namespace color {
 


### PR DESCRIPTION
### Problem description
<!-- Describe the bug that you fixed/feature request that you implemented, or link to an existing issue describing it -->
There are utf8 sequences passed to the logging code which contains invalid utf8 code points. This causes an exception, which is catched, but the log is not correct as a result. The cause is truncating strings without regard for mutibyte code points.

See [here](https://github.com/WerWolv/ImHex/issues/2697) for the issue.

### Implementation description
Added a function to truncate utf8 strings correctly to [libwolv](https://github.com/WerWolv/libwolv/pull/39) and used it in some troublesome places.
