### PR TITLE
Update ImGuiExt's custom styling to support

### DIFF
--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <string>
 #include <span>
+#include <variant>
 
 #include <imgui.h>
 
@@ -179,23 +180,16 @@ namespace ImGuiExt {
         } Styles;
     };
 
-     enum class StyleType {
-            Float,
-            ImVec2
-        };
+    using StyleVariantType = std::variant<float, ImVec2>;
 
     struct StyleTypeRef {
-        StyleType StyleType;
-        size_t Size;
+        size_t VariantIndex;
         size_t Offset;
     };
 
     struct ImGuiExStyleMod {
         StyleTypeRef Ref;
-        union {
-            float FloatValue;
-            ImVec2 ImVec2Value;
-        } Backup;
+        StyleVariantType BackupValue;
     };
 
     struct ImGuiExColorMod {
@@ -223,7 +217,8 @@ namespace ImGuiExt {
     void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
     void PopCustomColor(int count = 1);
 
-    void PushStyle(ImGuiCustomCol idx, float val);
+    void PushStyle(ImGuiCustomStyle idx, float val);
+    void PushStyle(ImGuiCustomStyle idx, const ImVec2 &val);
     void PopStyle(int count = 1);
 
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -213,6 +213,10 @@ namespace ImGuiExt {
         return GetContext().Data;
     }
 
+    inline ImHexCustomData::Styles_& GetCustomStyle() {
+        return GetCustomData().Styles;   
+    }
+
     void PushCustomColor(ImGuiCustomCol idx, ImU32 col);
     void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
     void PopCustomColor(int count = 1);
@@ -224,7 +228,7 @@ namespace ImGuiExt {
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
     ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);
 
-    float& GetCustomStyle(ImGuiCustomStyle idx);
+    float& GetCustomStyleFromId(ImGuiCustomStyle idx);
 
     void StyleCustomColorsDark();
     void StyleCustomColorsLight();

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -178,8 +178,15 @@ namespace ImGuiExt {
         } styles;
     };
 
+    struct ImGuiExColorMod {
+        ImGuiCol    Col;
+        ImVec4      BackupValue;
+    };
+
     struct ImGuiExtContext {
         ImHexCustomData Data;
+
+        ImVector<ImGuiExColorMod> ColorStack;
     };
 
     inline ImGuiExtContext& GetContext() {
@@ -196,7 +203,7 @@ namespace ImGuiExt {
 
     void PushCustomColor(ImGuiCustomCol idx, ImU32 col);
     void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
-    void PopCustomColor(int count);
+    void PopCustomColor(int count = 1);
 
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
     ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -63,6 +63,7 @@ enum ImGuiCustomCol : int {
 
 enum ImGuiCustomStyle {
     ImGuiCustomStyle_WindowBlur,
+    ImGuiCustomStyle_PopupWindowAlpha,
 
     ImGuiCustomStyle_COUNT
 };
@@ -171,11 +172,7 @@ namespace ImGuiExt {
 
     struct ImHexCustomData {
         ImVec4 Colors[ImGuiCustomCol_COUNT];
-
-        struct Styles {
-            float WindowBlur = 0.0F;
-            float PopupWindowAlpha = 0.0F; // Alpha used by Popup tool windows when the user is not hovering over them
-        } styles;
+        float Styles[ImGuiCustomStyle_COUNT] = {};
     };
 
     struct ImGuiExColorMod {
@@ -183,10 +180,17 @@ namespace ImGuiExt {
         ImVec4      BackupValue;
     };
 
+    struct ImGuiExStyleMod {
+        ImGuiCustomStyle    Style;
+        float               BackupValue;
+    };
+
     struct ImGuiExtContext {
         ImHexCustomData Data;
 
+        // Stacks
         ImVector<ImGuiExColorMod> ColorStack;
+        ImVector<ImGuiExStyleMod> StyleStack;
     };
 
     inline ImGuiExtContext& GetContext() {
@@ -197,19 +201,17 @@ namespace ImGuiExt {
         return GetContext().Data;
     }
 
-    inline ImHexCustomData::Styles& GetCustomStyle() {
-        return GetCustomData().styles;
-    }
-
     void PushCustomColor(ImGuiCustomCol idx, ImU32 col);
     void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
     void PopCustomColor(int count = 1);
 
+    void PushStyle(ImGuiCustomCol idx, float val);
+    void PopStyle(int count = 1);
+
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
     ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);
 
-    float GetCustomStyleFloat(ImGuiCustomStyle idx);
-    ImVec2 GetCustomStyleVec2(ImGuiCustomStyle idx);
+    float& GetCustomStyle(ImGuiCustomStyle idx);
 
     void StyleCustomColorsDark();
     void StyleCustomColorsLight();

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -172,17 +172,35 @@ namespace ImGuiExt {
 
     struct ImHexCustomData {
         ImVec4 Colors[ImGuiCustomCol_COUNT];
-        float Styles[ImGuiCustomStyle_COUNT] = {};
+        
+        struct Styles_ {
+            float WindowBlur = 0.0F;
+            float PopupWindowAlpha = 0.0F; // Alpha used by Popup tool windows when the user is not hovering over them
+        } Styles;
+    };
+
+     enum class StyleType {
+            Float,
+            ImVec2
+        };
+
+    struct StyleTypeRef {
+        StyleType StyleType;
+        size_t Size;
+        size_t Offset;
+    };
+
+    struct ImGuiExStyleMod {
+        StyleTypeRef Ref;
+        union {
+            float FloatValue;
+            ImVec2 ImVec2Value;
+        } Backup;
     };
 
     struct ImGuiExColorMod {
         ImGuiCol    Col;
         ImVec4      BackupValue;
-    };
-
-    struct ImGuiExStyleMod {
-        ImGuiCustomStyle    Style;
-        float               BackupValue;
     };
 
     struct ImGuiExtContext {

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -178,14 +178,28 @@ namespace ImGuiExt {
         } styles;
     };
 
-    ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
-    ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);
+    struct ImGuiExtContext {
+        ImHexCustomData Data;
+    };
+
+    inline ImGuiExtContext& GetContext() {
+        return *static_cast<ImGuiExtContext *>(ImGui::GetIO().UserData);
+    }
+
+    inline ImHexCustomData& GetCustomData() {
+        return GetContext().Data;
+    }
 
     inline ImHexCustomData::Styles& GetCustomStyle() {
-        auto &customData = *static_cast<ImHexCustomData *>(ImGui::GetIO().UserData);
-
-        return customData.styles;
+        return GetCustomData().styles;
     }
+
+    void PushCustomColor(ImGuiCustomCol idx, ImU32 col);
+    void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
+    void PopCustomColor(int count);
+
+    ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
+    ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);
 
     float GetCustomStyleFloat(ImGuiCustomStyle idx);
     ImVec2 GetCustomStyleVec2(ImGuiCustomStyle idx);

--- a/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
+++ b/lib/libimhex/include/hex/ui/imgui_imhex_extensions.h
@@ -173,8 +173,8 @@ namespace ImGuiExt {
 
     struct ImHexCustomData {
         ImVec4 Colors[ImGuiCustomCol_COUNT];
-        
-        struct Styles_ {
+
+        struct StyleData {
             float WindowBlur = 0.0F;
             float PopupWindowAlpha = 0.0F; // Alpha used by Popup tool windows when the user is not hovering over them
         } Styles;
@@ -213,7 +213,7 @@ namespace ImGuiExt {
         return GetContext().Data;
     }
 
-    inline ImHexCustomData::Styles_& GetCustomStyle() {
+    inline ImHexCustomData::StyleData& GetCustomStyle() {
         return GetCustomData().Styles;   
     }
 
@@ -228,7 +228,8 @@ namespace ImGuiExt {
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul = 1.0F);
     ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul = 1.0F);
 
-    float& GetCustomStyleFromId(ImGuiCustomStyle idx);
+    float GetCustomStyleFloat(ImGuiCustomStyle idx);
+    ImVec2 GetCustomStyleVec2(ImGuiCustomStyle idx);
 
     void StyleCustomColorsDark();
     void StyleCustomColorsLight();

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -684,22 +684,34 @@ namespace ImGuiExt {
         return result;
     }
 
+    void PushCustomColor(ImGuiCustomCol idx, ImU32 col) {
+        (void)idx; (void)col;
+    }
+
+    void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col) {
+        (void)idx; (void)col;
+    }
+
+    void PopCustomColor(int count) {
+        (void)count;
+    }
+
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul) {
-        auto &customData = *static_cast<ImHexCustomData *>(GImGui->IO.UserData);
+        auto &customData = GetCustomData();
         ImVec4 c         = customData.Colors[idx];
         c.w *= GImGui->Style.Alpha * alpha_mul;
         return ColorConvertFloat4ToU32(c);
     }
 
     ImVec4 GetCustomColorVec4(ImGuiCustomCol idx, float alpha_mul) {
-        auto &customData = *static_cast<ImHexCustomData *>(GImGui->IO.UserData);
+        auto &customData = GetCustomData();
         ImVec4 c         = customData.Colors[idx];
         c.w *= GImGui->Style.Alpha * alpha_mul;
         return c;
     }
 
     float GetCustomStyleFloat(ImGuiCustomStyle idx) {
-        auto &customData = *static_cast<ImHexCustomData *>(GImGui->IO.UserData);
+        auto &customData = GetCustomData();
 
         switch (idx) {
             case ImGuiCustomStyle_WindowBlur:
@@ -715,7 +727,7 @@ namespace ImGuiExt {
     }
 
     void StyleCustomColorsDark() {
-        auto &colors = static_cast<ImHexCustomData *>(GImGui->IO.UserData)->Colors;
+        auto &colors = GetCustomData().Colors;
 
         colors[ImGuiCustomCol_DescButton]        = ImColor(20, 20, 20);
         colors[ImGuiCustomCol_DescButtonHovered] = ImColor(40, 40, 40);
@@ -737,7 +749,7 @@ namespace ImGuiExt {
     }
 
     void StyleCustomColorsLight() {
-        auto &colors = static_cast<ImHexCustomData *>(GImGui->IO.UserData)->Colors;
+        auto &colors = GetCustomData().Colors;
 
         colors[ImGuiCustomCol_DescButton]        = ImColor(230, 230, 230);
         colors[ImGuiCustomCol_DescButtonHovered] = ImColor(210, 210, 210);
@@ -759,7 +771,7 @@ namespace ImGuiExt {
     }
 
     void StyleCustomColorsClassic() {
-        auto &colors = static_cast<ImHexCustomData *>(GImGui->IO.UserData)->Colors;
+        auto &colors = GetCustomData().Colors;
 
         colors[ImGuiCustomCol_DescButton]        = ImColor(40, 40, 80);
         colors[ImGuiCustomCol_DescButtonHovered] = ImColor(60, 60, 100);

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -703,7 +703,7 @@ namespace ImGuiExt {
     }
 
     void PopCustomColor(int count) {
-         ImGuiExtContext &g = GetContext();
+        ImGuiExtContext &g = GetContext();
         if (g.ColorStack.Size < count)
         {
             IM_ASSERT_USER_ERROR(0, "Calling ImGUiExt::PopCustomColor() too many times!");
@@ -714,6 +714,31 @@ namespace ImGuiExt {
             ImGuiExColorMod &backup = g.ColorStack.back();
             g.Data.Colors[backup.Col] = backup.BackupValue;
             g.ColorStack.pop_back();
+            count--;
+        }
+    }
+
+    void PushStyle(ImGuiCustomStyle idx, float val) {
+        ImGuiExtContext &g = GetContext();
+        ImGuiExStyleMod backup;
+        backup.Style = idx;
+        backup.BackupValue = g.Data.Styles[idx];
+        g.StyleStack.push_back(backup);
+        g.Data.Styles[idx] = val;
+    }
+
+    void PopStyle(int count) {
+        ImGuiExtContext &g = GetContext();
+        if (g.StyleStack.Size < count)
+        {
+            IM_ASSERT_USER_ERROR(0, "Calling ImGUiExt::PopStyle() too many times!");
+            count = g.StyleStack.Size;
+        }
+        while (count > 0)
+        {
+            ImGuiExStyleMod &backup = g.StyleStack.back();
+            g.Data.Styles[backup.Style] = backup.BackupValue;
+            g.StyleStack.pop_back();
             count--;
         }
     }
@@ -732,20 +757,9 @@ namespace ImGuiExt {
         return c;
     }
 
-    float GetCustomStyleFloat(ImGuiCustomStyle idx) {
+    float& GetCustomStyle(ImGuiCustomStyle idx) {
         auto &customData = GetCustomData();
-
-        switch (idx) {
-            case ImGuiCustomStyle_WindowBlur:
-                return customData.styles.WindowBlur;
-            default:
-                return 0.0F;
-        }
-    }
-
-    ImVec2 GetCustomStyleVec2(ImGuiCustomStyle idx) {
-        std::ignore = idx;
-        return {};
+        return customData.Styles[idx];
     }
 
     void StyleCustomColorsDark() {

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -25,6 +25,7 @@
 #include <hex/api/task_manager.hpp>
 #include <hex/api/theme_manager.hpp>
 #include <hex/helpers/logger.hpp>
+#include <wolv/utils/variant_type_index.hpp>
 
 namespace ImGuiExt {
 
@@ -32,23 +33,29 @@ namespace ImGuiExt {
 
     namespace {
 
-        template <class T>
-        inline constexpr bool always_false = false;
-
         template <typename Class, typename Member>
         constexpr StyleTypeRef toStyleRef(Member Class::*member)
         {
             const size_t off = reinterpret_cast<size_t>(&(reinterpret_cast<Class const volatile*>(0)->*member));
-            if constexpr (std::is_same_v<Member, float>) return {StyleType::Float, sizeof(Member), off};
-            else if constexpr (std::is_same_v<Member, ImVec2>) return {StyleType::ImVec2, sizeof(Member), off};
-            else
-                static_assert(always_false<Member>, "Unsupported type");
+            return {wolv::util::VariantTypeIndex<Member, StyleVariantType>, off};
         };
 
         const StyleTypeRef s_StyleLocations[] = {
             toStyleRef(&ImHexCustomData::Styles_::WindowBlur),
             toStyleRef(&ImHexCustomData::Styles_::PopupWindowAlpha)
         };
+
+        template <typename V>
+        inline V& getStyleValue(ImGuiExtContext &g, const StyleTypeRef &ref) {
+            V &value = *reinterpret_cast<V*>(reinterpret_cast<char*>(&g.Data.Styles)+ref.Offset);
+            return value;
+        }
+
+        template <typename V>
+        inline void writeStyleValue(ImGuiExtContext &g, const StyleTypeRef &ref, const V &val) {
+            V &value = getStyleValue<V>(g, ref);
+            value = val;
+        }
 
         bool isOpenGLExtensionSupported(const char *name) {
             static std::set<std::string> extensions;
@@ -741,13 +748,26 @@ namespace ImGuiExt {
         ImGuiExtContext &g = GetContext();
         ImGuiExStyleMod backup;
         backup.Ref = s_StyleLocations[idx];
-        if (backup.Ref.StyleType != StyleType::Float) {
+        if (backup.Ref.VariantIndex != wolv::util::VariantTypeIndex<float, StyleVariantType>) {
             assert(!"ImGuiExt::PushStyle: idx is not a float style");
             return;
         }
-        backup.Backup.FloatValue = val;
+        backup.BackupValue = getStyleValue<float>(g, backup.Ref);
         g.StyleStack.push_back(backup);
-        g.Data.Styles[idx] = val;
+        writeStyleValue(g, backup.Ref, val);
+    }
+
+    void PushStyle(ImGuiCustomStyle idx, const ImVec2 &val) {
+        ImGuiExtContext &g = GetContext();
+        ImGuiExStyleMod backup;
+        backup.Ref = s_StyleLocations[idx];
+        if (backup.Ref.VariantIndex != wolv::util::VariantTypeIndex<ImVec2, StyleVariantType>) {
+            assert(!"ImGuiExt::PushStyle: idx is not an ImVec2 style");
+            return;
+        }
+        backup.BackupValue = getStyleValue<ImVec2>(g, backup.Ref);
+        g.StyleStack.push_back(backup);
+        writeStyleValue(g, backup.Ref, val);
     }
 
     void PopStyle(int count) {
@@ -760,7 +780,7 @@ namespace ImGuiExt {
         while (count > 0)
         {
             ImGuiExStyleMod &backup = g.StyleStack.back();
-            memcpy(&g.Data.Styles, &backup.Backup, backup.Ref.Size);
+            writeStyleValue(g, backup.Ref, std::get<float>(backup.BackupValue));
             g.StyleStack.pop_back();
             count--;
         }
@@ -781,8 +801,8 @@ namespace ImGuiExt {
     }
 
     float& GetCustomStyle(ImGuiCustomStyle idx) {
-        auto &customData = GetCustomData();
-        return customData.Styles[idx];
+        ImGuiExtContext &g = GetContext();
+        return getStyleValue<float>(g, s_StyleLocations[idx]);
     }
 
     void StyleCustomColorsDark() {

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -685,15 +685,37 @@ namespace ImGuiExt {
     }
 
     void PushCustomColor(ImGuiCustomCol idx, ImU32 col) {
-        (void)idx; (void)col;
+        ImGuiExtContext &g = GetContext();
+        ImGuiExColorMod backup;
+        backup.Col = idx;
+        backup.BackupValue = g.Data.Colors[idx];
+        g.ColorStack.push_back(backup);
+        g.Data.Colors[idx] = ColorConvertU32ToFloat4(col);
     }
 
     void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col) {
-        (void)idx; (void)col;
+        ImGuiExtContext &g = GetContext();
+        ImGuiExColorMod backup;
+        backup.Col = idx;
+        backup.BackupValue = g.Data.Colors[idx];
+        g.ColorStack.push_back(backup);
+        g.Data.Colors[idx] = col;
     }
 
     void PopCustomColor(int count) {
-        (void)count;
+         ImGuiExtContext &g = GetContext();
+        if (g.ColorStack.Size < count)
+        {
+            IM_ASSERT_USER_ERROR(0, "Calling ImGUiExt::PopCustomColor() too many times!");
+            count = g.ColorStack.Size;
+        }
+        while (count > 0)
+        {
+            ImGuiExColorMod &backup = g.ColorStack.back();
+            g.Data.Colors[backup.Col] = backup.BackupValue;
+            g.ColorStack.pop_back();
+            count--;
+        }
     }
 
     ImU32 GetCustomColorU32(ImGuiCustomCol idx, float alpha_mul) {

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -40,9 +40,9 @@ namespace ImGuiExt {
             return {wolv::util::VariantTypeIndex<Member, StyleVariantType>, off};
         };
 
-        const StyleTypeRef s_StyleLocations[] = {
-            toStyleRef(&ImHexCustomData::Styles_::WindowBlur),
-            toStyleRef(&ImHexCustomData::Styles_::PopupWindowAlpha)
+        const StyleTypeRef s_StyleReferences[] = {
+            toStyleRef(&ImHexCustomData::StyleData::WindowBlur),
+            toStyleRef(&ImHexCustomData::StyleData::PopupWindowAlpha)
         };
 
         template <typename V>
@@ -747,7 +747,7 @@ namespace ImGuiExt {
     void PushStyle(ImGuiCustomStyle idx, float val) {
         ImGuiExtContext &g = GetContext();
         ImGuiExStyleMod backup;
-        backup.Ref = s_StyleLocations[idx];
+        backup.Ref = s_StyleReferences[idx];
         if (backup.Ref.VariantIndex != wolv::util::VariantTypeIndex<float, StyleVariantType>) {
             assert(!"ImGuiExt::PushStyle: idx is not a float style");
             return;
@@ -760,7 +760,7 @@ namespace ImGuiExt {
     void PushStyle(ImGuiCustomStyle idx, const ImVec2 &val) {
         ImGuiExtContext &g = GetContext();
         ImGuiExStyleMod backup;
-        backup.Ref = s_StyleLocations[idx];
+        backup.Ref = s_StyleReferences[idx];
         if (backup.Ref.VariantIndex != wolv::util::VariantTypeIndex<ImVec2, StyleVariantType>) {
             assert(!"ImGuiExt::PushStyle: idx is not an ImVec2 style");
             return;
@@ -800,9 +800,16 @@ namespace ImGuiExt {
         return c;
     }
 
-    float& GetCustomStyleFromId(ImGuiCustomStyle idx) {
+    float GetCustomStyleFloat(ImGuiCustomStyle idx) {
+        assert((s_StyleReferences[idx].VariantIndex == wolv::util::VariantTypeIndex<float, StyleVariantType>));
         ImGuiExtContext &g = GetContext();
-        return getStyleValue<float>(g, s_StyleLocations[idx]);
+        return getStyleValue<float>(g, s_StyleReferences[idx]);
+    }
+
+    ImVec2 GetCustomStyleVec2(ImGuiCustomStyle idx) {
+        assert((s_StyleReferences[idx].VariantIndex == wolv::util::VariantTypeIndex<float, StyleVariantType>));
+        ImGuiExtContext &g = GetContext();
+        return getStyleValue<ImVec2>(g, s_StyleReferences[idx]);
     }
 
     void StyleCustomColorsDark() {

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <algorithm>
 #include <numbers>
+#include <type_traits>
 
 #include <hex/api/imhex_api/system.hpp>
 
@@ -30,6 +31,24 @@ namespace ImGuiExt {
     using namespace ImGui;
 
     namespace {
+
+        template <class T>
+        inline constexpr bool always_false = false;
+
+        template <typename Class, typename Member>
+        constexpr StyleTypeRef toStyleRef(Member Class::*member)
+        {
+            const size_t off = reinterpret_cast<size_t>(&(reinterpret_cast<Class const volatile*>(0)->*member));
+            if constexpr (std::is_same_v<Member, float>) return {StyleType::Float, sizeof(Member), off};
+            else if constexpr (std::is_same_v<Member, ImVec2>) return {StyleType::ImVec2, sizeof(Member), off};
+            else
+                static_assert(always_false<Member>, "Unsupported type");
+        };
+
+        const StyleTypeRef s_StyleLocations[] = {
+            toStyleRef(&ImHexCustomData::Styles_::WindowBlur),
+            toStyleRef(&ImHexCustomData::Styles_::PopupWindowAlpha)
+        };
 
         bool isOpenGLExtensionSupported(const char *name) {
             static std::set<std::string> extensions;
@@ -721,8 +740,12 @@ namespace ImGuiExt {
     void PushStyle(ImGuiCustomStyle idx, float val) {
         ImGuiExtContext &g = GetContext();
         ImGuiExStyleMod backup;
-        backup.Style = idx;
-        backup.BackupValue = g.Data.Styles[idx];
+        backup.Ref = s_StyleLocations[idx];
+        if (backup.Ref.StyleType != StyleType::Float) {
+            assert(!"ImGuiExt::PushStyle: idx is not a float style");
+            return;
+        }
+        backup.Backup.FloatValue = val;
         g.StyleStack.push_back(backup);
         g.Data.Styles[idx] = val;
     }
@@ -737,7 +760,7 @@ namespace ImGuiExt {
         while (count > 0)
         {
             ImGuiExStyleMod &backup = g.StyleStack.back();
-            g.Data.Styles[backup.Style] = backup.BackupValue;
+            memcpy(&g.Data.Styles, &backup.Backup, backup.Ref.Size);
             g.StyleStack.pop_back();
             count--;
         }

--- a/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
+++ b/lib/libimhex/source/ui/imgui_imhex_extensions.cpp
@@ -800,7 +800,7 @@ namespace ImGuiExt {
         return c;
     }
 
-    float& GetCustomStyle(ImGuiCustomStyle idx) {
+    float& GetCustomStyleFromId(ImGuiCustomStyle idx) {
         ImGuiExtContext &g = GetContext();
         return getStyleValue<float>(g, s_StyleLocations[idx]);
     }

--- a/main/gui/include/window.hpp
+++ b/main/gui/include/window.hpp
@@ -64,7 +64,7 @@ namespace hex {
 
         std::set<int> m_pressedKeys;
 
-        ImGuiExt::ImHexCustomData m_imguiCustomData;
+        ImGuiExt::ImGuiExtContext m_imguiExtContext;
 
         bool m_emergencyPopupOpen = false;
         bool m_shouldUnlockFrameRate = false;

--- a/main/gui/source/window/platform/windows.cpp
+++ b/main/gui/source/window/platform/windows.cpp
@@ -618,7 +618,7 @@ namespace hex {
                     );
 
                 if (setWindowCompositionAttribute != nullptr) {
-                    ACCENTPOLICY policy = { ImGuiExt::GetCustomStyle().WindowBlur > 0.5F ? 4U : 0U, 0, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_BlurBackground), 0 };
+                    ACCENTPOLICY policy = { ImGuiExt::GetCustomStyle(ImGuiCustomStyle_WindowBlur) > 0.5F ? 4U : 0U, 0, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_BlurBackground), 0 };
                     WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) };
                     setWindowCompositionAttribute(hwnd, &data);
                 }

--- a/main/gui/source/window/platform/windows.cpp
+++ b/main/gui/source/window/platform/windows.cpp
@@ -618,7 +618,7 @@ namespace hex {
                     );
 
                 if (setWindowCompositionAttribute != nullptr) {
-                    ACCENTPOLICY policy = { ImGuiExt::GetCustomStyle(ImGuiCustomStyle_WindowBlur) > 0.5F ? 4U : 0U, 0, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_BlurBackground), 0 };
+                    ACCENTPOLICY policy = { ImGuiExt::GetCustomStyle().WindowBlur > 0.5F ? 4U : 0U, 0, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_BlurBackground), 0 };
                     WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) };
                     setWindowCompositionAttribute(hwnd, &data);
                 }

--- a/main/gui/source/window/window.cpp
+++ b/main/gui/source/window/window.cpp
@@ -1330,7 +1330,7 @@ namespace hex {
             ImNodes::GetIO().LinkDetachWithModifierClick.Modifier = &always;
         }
 
-        io.UserData = &m_imguiCustomData;
+        io.UserData = &m_imguiExtContext;
 
         style.ScaleAllSizes(ImHexApi::System::getGlobalScale());
         auto scale = ImHexApi::System::getNativeScale();

--- a/plugins/builtin/source/content/themes.cpp
+++ b/plugins/builtin/source/content/themes.cpp
@@ -208,11 +208,11 @@ namespace hex::plugin::builtin {
 
                 ThemeManager::addThemeHandler("imhex", ImHexColorMap,
                    [](u32 colorId) -> ImColor {
-                       return static_cast<ImGuiExt::ImHexCustomData *>(ImGui::GetCurrentContext()->IO.UserData)->Colors[colorId];
+                       return ImGuiExt::GetCustomData().Colors[colorId];
 
                    },
                    [](u32 colorId, ImColor color) {
-                       static_cast<ImGuiExt::ImHexCustomData *>(ImGui::GetCurrentContext()->IO.UserData)->Colors[colorId] = color;
+                       ImGuiExt::GetCustomData().Colors[colorId] = color;
                    }
                 );
             }

--- a/plugins/builtin/source/content/themes.cpp
+++ b/plugins/builtin/source/content/themes.cpp
@@ -396,10 +396,9 @@ namespace hex::plugin::builtin {
             }
 
             {
-                auto &style = ImGuiExt::GetCustomStyle();
                 const static ThemeManager::StyleMap ImHexStyleMap = {
-                        { "window-blur",    { .value=&style.WindowBlur,    .min=0.0F,   .max=1.0F,   .needsScaling=true } },
-                        { "popup-alpha",            { .value=&style.PopupWindowAlpha,          .min=0.0F,   .max=1.0F,    .needsScaling=false } },
+                        { "window-blur",    { .value=&ImGuiExt::GetCustomStyle(ImGuiCustomStyle_WindowBlur), .min=0.0F,  .max=1.0F, .needsScaling=true } },
+                        { "popup-alpha",    { .value=&ImGuiExt::GetCustomStyle(ImGuiCustomStyle_PopupWindowAlpha), .min=0.0F, .max=1.0F, .needsScaling=false } },
                 };
 
                 ThemeManager::addStyleHandler("imhex", ImHexStyleMap);

--- a/plugins/builtin/source/content/themes.cpp
+++ b/plugins/builtin/source/content/themes.cpp
@@ -397,8 +397,8 @@ namespace hex::plugin::builtin {
 
             {
                 const static ThemeManager::StyleMap ImHexStyleMap = {
-                        { "window-blur",    { .value=&ImGuiExt::GetCustomStyle(ImGuiCustomStyle_WindowBlur), .min=0.0F,  .max=1.0F, .needsScaling=true } },
-                        { "popup-alpha",    { .value=&ImGuiExt::GetCustomStyle(ImGuiCustomStyle_PopupWindowAlpha), .min=0.0F, .max=1.0F, .needsScaling=false } },
+                        { "window-blur",    { .value=&ImGuiExt::GetCustomStyle().WindowBlur, .min=0.0F,  .max=1.0F, .needsScaling=true } },
+                        { "popup-alpha",    { .value=&ImGuiExt::GetCustomStyle().PopupWindowAlpha, .min=0.0F, .max=1.0F, .needsScaling=false } },
                 };
 
                 ThemeManager::addStyleHandler("imhex", ImHexStyleMap);

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -207,7 +207,7 @@ namespace hex::plugin::builtin {
         bool open = true;
 
         ImGui::SetNextWindowPos(ImGui::GetCurrentWindowRead()->ContentRegionRect.Min - ImGui::GetStyle().WindowPadding, ImGuiCond_Once);
-        const auto configuredAlpha = ImGuiExt::GetCustomStyle(ImGuiCustomStyle_PopupWindowAlpha);
+        const auto configuredAlpha = ImGuiExt::GetCustomStyle().PopupWindowAlpha;
         bool alphaIsChanged = false;
         if (m_currPopup != nullptr && !m_currentPopupHover && m_currentPopupHasHovered && m_currentPopupDetached && configuredAlpha < 0.99F && configuredAlpha > 0.01F) {
             ImGui::PushStyleVar(ImGuiStyleVar_Alpha, configuredAlpha);

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -207,7 +207,7 @@ namespace hex::plugin::builtin {
         bool open = true;
 
         ImGui::SetNextWindowPos(ImGui::GetCurrentWindowRead()->ContentRegionRect.Min - ImGui::GetStyle().WindowPadding, ImGuiCond_Once);
-        const auto configuredAlpha = ImGuiExt::GetCustomStyle().PopupWindowAlpha;
+        const auto configuredAlpha = ImGuiExt::GetCustomStyle(ImGuiCustomStyle_PopupWindowAlpha);
         bool alphaIsChanged = false;
         if (m_currPopup != nullptr && !m_currentPopupHover && m_currentPopupHasHovered && m_currentPopupDetached && configuredAlpha < 0.99F && configuredAlpha > 0.01F) {
             ImGui::PushStyleVar(ImGuiStyleVar_Alpha, configuredAlpha);


### PR DESCRIPTION
## Desciption
Update ImGuiExt's custom styling to support the ImGui Push* and Pop* methods for custom colours and styling.

### Dependencies
[libwolv](https://github.com/WerWolv/libwolv/pull/40)
[pattern_language](https://github.com/WerWolv/PatternLanguage/pull/231)

### Example
You can now do this:

```c++
ImGuiExt::PushCustomColor(ImGuiCustomCol_DescButton, IM_COL32(255, 0, 0, 255)); // Added
if (ImGuiExt::BeginSubWindow("hex.builtin.welcome.header.customize"_lang, nullptr, ImVec2(ImGui::GetContentRegionAvail().x - windowPadding, 0), ImGuiChildFlags_AutoResizeX)) {
    if (ImGuiExt::DescriptionButton("hex.builtin.welcome.customize.settings.title"_lang, "hex.builtin.welcome.customize.settings.desc"_lang, ICON_VS_SETTINGS_GEAR, ImVec2(ImGui::GetContentRegionAvail().x, 0)))
        RequestOpenWindow::post("Settings");
}
ImGuiExt::EndSubWindow();
ImGuiExt::PopCustomColor(); // Added
```

And get this ugliness:

<img width="1077" height="
436" alt="image" src="https://github.com/user-attachments/assets/02261506-520f-4ee2-9037-50c068b9d108" />

## Implementaion Details

The following functions have been added to `ImGuiExt`. They behave as you would expect:
```c++
void PushCustomColor(ImGuiCustomCol idx, ImU32 col);
void PushCustomColor(ImGuiCustomCol idx, const ImVec4& col);
void PopCustomColor(int count = 1);

void PushStyle(ImGuiCustomStyle idx, float val);
void PushStyle(ImGuiCustomStyle idx, const ImVec2 &val);
void PopStyle(int count = 1);
```

For the custom colour functions the code was lifted and adapted from ImGui's.

The styling functions diverge from ImGui's. ImGui's implementaion is very low level and not easily extended. Instead I used `std::variant` as the storage in the style stack with some template voodoo. The voodoo was from previous PR I made that was merged, but I moved it into `LibWolv`. It can be easily extended to support types beyond `float` and `ImVec2`.

