### PR TITLE
Changes related to the addresses displayed in the hex editor including:

### DIFF
--- a/plugins/builtin/include/content/popups/hex_editor/popup_hex_editor_base_address.hpp
+++ b/plugins/builtin/include/content/popups/hex_editor/popup_hex_editor_base_address.hpp
@@ -10,7 +10,7 @@ namespace hex::plugin::builtin {
         explicit PopupBaseAddress(u64 baseAddress);
         void draw(ViewHexEditor *editor) override;
         [[nodiscard]] UnlocalizedString getTitle() const override;
-
+        [[nodiscard]] bool isValid() const;
     private:
         static void setBaseAddress(u64 baseAddress);
         u64 m_baseAddress;

--- a/plugins/builtin/source/content/pl_pragmas.cpp
+++ b/plugins/builtin/source/content/pl_pragmas.cpp
@@ -11,11 +11,13 @@ namespace hex::plugin::builtin {
     void registerPatternLanguagePragmas() {
 
         ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
-            auto baseAddress = wolv::util::from_chars<i64>(value);
-            if (!baseAddress.has_value())
+            auto baseAddress = wolv::util::from_chars<u64>(value);
+            u64 dataSize = runtime.getInternals().evaluator->getDataSize();
+            if (!baseAddress.has_value() || (dataSize > 0 && dataSize - 1 > std::numeric_limits<u64>::max() - baseAddress.value()))
                 return false;
 
-            ImHexApi::Provider::get()->setBaseAddress(*baseAddress);
+            if (ImHexApi::Provider::isValid())
+                ImHexApi::Provider::get()->setBaseAddress(*baseAddress);
             runtime.setDataBaseAddress(*baseAddress);
 
             return true;

--- a/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_base_address.cpp
+++ b/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_base_address.cpp
@@ -10,21 +10,31 @@ namespace hex::plugin::builtin {
     PopupBaseAddress::PopupBaseAddress(u64 baseAddress) : m_baseAddress(baseAddress) {}
 
     void PopupBaseAddress::draw(ViewHexEditor *editor) {
+        const auto width = ImGui::GetWindowWidth();
         ImGuiExt::InputHexadecimal("##base_address", &m_baseAddress);
         if (ImGui::IsItemFocused() && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))) {
-            setBaseAddress(m_baseAddress);
-            editor->closePopup();
-        }
-
-        ImGuiExt::ConfirmButtons("hex.ui.common.set"_lang, "hex.ui.common.cancel"_lang,
-            [&, this]{
+            if (this->isValid()) {
                 setBaseAddress(m_baseAddress);
                 editor->closePopup();
-            },
-            [&]{
+            }
+        }
+        ImGui::BeginDisabled(!this->isValid());
+        {
+            ImGui::SetCursorPosX(width / 9);
+
+            if (ImGui::Button("hex.ui.common.set"_lang,  ImVec2(width / 3, 0))) {
+                setBaseAddress(m_baseAddress);
                 editor->closePopup();
             }
-        );
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(width / 9 * 5);
+        if (ImGui::Button("hex.ui.common.cancel"_lang,  ImVec2(width / 3, 0))) {
+            // Cancel the action, without updating settings nor pasting.
+            editor->closePopup();
+        }
     }
 
     UnlocalizedString PopupBaseAddress::getTitle() const {
@@ -34,6 +44,14 @@ namespace hex::plugin::builtin {
     void PopupBaseAddress::setBaseAddress(u64 baseAddress) {
         if (ImHexApi::Provider::isValid())
             ImHexApi::Provider::get()->setBaseAddress(baseAddress);
+    }
+
+    bool PopupBaseAddress::isValid() const {
+        if (ImHexApi::Provider::isValid()) {
+            u64 dataSize = ImHexApi::Provider::get()->getActualSize();
+            return (dataSize == 0 || dataSize - 1 <= std::numeric_limits<u64>::max() - m_baseAddress);
+        }
+        return false;
     }
 
 }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1457,6 +1457,15 @@ namespace hex::plugin::builtin {
                     m_allStepsCompleted = false;
                     auto code = m_textEditor.get(provider).getText();
                     EventPatternEditorChanged::post(code);
+                    ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
+                        std::ignore = runtime;
+                        auto baseAddress = wolv::util::from_chars<u64>(value);
+                        if (ImHexApi::Provider::isValid()) {
+                            u64 dataSize = ImHexApi::Provider::get()->getActualSize();
+                            return baseAddress.has_value() && (dataSize == 0 || dataSize - 1 <= std::numeric_limits<u64>::max() - baseAddress.value());
+                        }
+                        return false;
+                    });
                     TaskManager::createBackgroundTask("hex.builtin.task.parsing_pattern", [this, code = std::move(code), provider](auto &){
                         this->parsePattern(code, provider);
 
@@ -1657,6 +1666,15 @@ namespace hex::plugin::builtin {
                 m_changeTracker.get(provider) = wolv::io::ChangeTracker(file);
                 m_changeTracker.get(provider).startTracking([this, provider]{ this->handleFileChange(provider); });
             }
+            ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
+                std::ignore = runtime;
+                auto baseAddress = wolv::util::from_chars<u64>(value);
+                if (ImHexApi::Provider::isValid()) {
+                    u64 dataSize = ImHexApi::Provider::get()->getActualSize();
+                    return baseAddress.has_value() && (dataSize == 0 || dataSize - 1 <= std::numeric_limits<u64>::max() - baseAddress.value());
+                }
+                return false;
+            });
             TaskManager::createBackgroundTask("hex.builtin.task.parsing_pattern", [this, code, provider](auto&) { this->parsePattern(code, provider); });
         }
     }
@@ -1725,6 +1743,19 @@ namespace hex::plugin::builtin {
         m_accessHistoryIndex = 0;
 
         EventHighlightingChanged::post();
+
+        ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
+            auto baseAddress = wolv::util::from_chars<u64>(value);
+            u64 dataSize = runtime.getInternals().evaluator->getDataSize();
+            if (!baseAddress.has_value() || (dataSize > 0 && dataSize - 1 > std::numeric_limits<u64>::max() - baseAddress.value()))
+                return false;
+
+            if (ImHexApi::Provider::isValid())
+                ImHexApi::Provider::get()->setBaseAddress(*baseAddress);
+            runtime.setDataBaseAddress(*baseAddress);
+
+            return true;
+        });
 
         TaskManager::createTask("hex.builtin.view.pattern_editor.evaluating", TaskManager::NoProgress, [this, code, provider](auto &task) {
             // Disable exception tracing to speed up evaluation

--- a/plugins/ui/include/ui/hex_editor.hpp
+++ b/plugins/ui/include/ui/hex_editor.hpp
@@ -128,17 +128,19 @@ namespace hex::ui {
         void setSelection(u64 start, u64 end) {
             if (!ImHexApi::Provider::isValid() || m_provider == nullptr)
                 return;
+            u64 size = m_provider->getActualSize();
+            u64 baseAddress = m_provider->getBaseAddress();
 
-            if (start > m_provider->getBaseAddress() + m_provider->getActualSize())
+            if (size == 0 || size - 1 > std::numeric_limits<u64>::max() - baseAddress)
                 return;
 
-            if (start < m_provider->getBaseAddress())
+            const size_t maxAddress = size + baseAddress - 1;
+
+            if (start > maxAddress || end > maxAddress)
                 return;
 
-            if (m_provider->getActualSize() == 0)
+            if (start < baseAddress || end < baseAddress)
                 return;
-
-            const size_t maxAddress = m_provider->getActualSize() + m_provider->getBaseAddress() - 1;
 
             constexpr static auto alignDown = [](u64 value, u64 alignment) {
                 return value & ~(alignment - 1);

--- a/plugins/ui/source/ui/hex_editor.cpp
+++ b/plugins/ui/source/ui/hex_editor.cpp
@@ -645,12 +645,20 @@ namespace hex::ui {
                 ImGui::TableSetupScrollFreeze(0, 2);
 
                 // Row address column
+                u64 maxAddress = m_provider->getActualSize();
+                if (maxAddress > 0)
+                    maxAddress--;
+                if ((m_scrollPosition + m_visibleRowCount) * bytesPerRow < maxAddress)
+                    maxAddress = (m_scrollPosition + m_visibleRowCount) * bytesPerRow;
+
+                if (maxAddress + m_provider->getCurrentPageAddress() < std::numeric_limits<u64>::max() - m_provider->getBaseAddress())
+                    maxAddress += m_provider->getBaseAddress() + m_provider->getCurrentPageAddress();
+                else
+                    maxAddress = std::numeric_limits<u64>::max();
+
                 ImGui::TableSetupColumn("hex.ui.common.address"_lang, ImGuiTableColumnFlags_WidthFixed,
                     m_provider == nullptr ? 0 :
-                    CharacterSize.x * std::max(
-                        fmt::formatted_size("{:08X}: ", ((m_scrollPosition + m_visibleRowCount) * bytesPerRow) + m_provider->getBaseAddress() + m_provider->getCurrentPageAddress()),
-                        m_separatorStride == 0 ? 0 : fmt::formatted_size("{} {}", "hex.ui.common.segment"_lang, (m_scrollPosition + m_visibleRowCount) * bytesPerRow + m_provider->getBaseAddress() + m_provider->getCurrentPageAddress() / m_separatorStride)
-                    )
+                    CharacterSize.x * std::max(fmt::formatted_size("{:08X}: ", maxAddress),m_separatorStride == 0 ? 0 : fmt::formatted_size("{} {}", "hex.ui.common.segment"_lang, maxAddress / m_separatorStride))
                 );
                 ImGui::TableSetupColumn("");
 


### PR DESCRIPTION
- Don't change base address when parsing pragma base_address, only change on evaluation.

- Detect invalid base addresses that cause addresses to overflow 64 bits in both pragma and popup.

- Calculate and display correctly the addresses at the end of files with ending address at u64_max. Fixed cursor and selections as well.

- Ensure only unsigned integers are used to allow the use of the full range of values for addresses using 64 bits.
