### PR TITLE
fix: using variable interpolation `${{ in dl-cache.yml...

### DIFF
--- a/.github/workflows/dl-cache.yml
+++ b/.github/workflows/dl-cache.yml
@@ -21,12 +21,13 @@ jobs:
         id: version
         env:
           GH_TOKEN: ${{ github.token }}
+          CACHE_KEY: ${{ github.event.inputs.cache_key }}
         run: |
           VERSION=$(gh api repos/$GITHUB_REPOSITORY/actions/caches \
           --jq "
             .actions_caches[]
             | select(.ref == \"refs/heads/$GITHUB_REF_NAME\")
-            | select(.key == \"${{ github.event.inputs.cache_key }}\")
+            | select(.key == \"$CACHE_KEY\")
             | .version
           ")
           echo "version=$VERSION" | tee $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fix high severity security issue in `.github/workflows/dl-cache.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/dl-cache.yml:24` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/dl-cache.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
