### PR TITLE
fix: share trackers on synced patterns.

### DIFF
--- a/lib/libimhex/include/hex/ui/banner.hpp
+++ b/lib/libimhex/include/hex/ui/banner.hpp
@@ -20,6 +20,7 @@ namespace hex {
 
             virtual void draw() { drawContent(); }
             virtual void drawContent() = 0;
+            virtual void onClose() {};
 
             [[nodiscard]] static std::list<std::unique_ptr<BannerBase>> &getOpenBanners();
 
@@ -27,7 +28,7 @@ namespace hex {
                 return m_color;
             }
 
-            void close() { m_shouldClose = true; }
+            void close() { onClose(); m_shouldClose = true; }
             [[nodiscard]] bool shouldClose() const { return m_shouldClose; }
 
         protected:

--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -21,6 +21,12 @@ namespace hex::plugin::builtin {
     public:
         const std::string& get(prv::Provider *provider) const;
         std::string& get(prv::Provider *provider);
+        const wolv::io::ChangeTracker& getTracker(prv::Provider *provider) const;
+        wolv::io::ChangeTracker& getTracker(prv::Provider *provider);
+        const bool& getIgnoreNextChangeEvent(prv::Provider *provider) const;
+        bool& getIgnoreNextChangeEvent(prv::Provider *provider);
+        const bool& getChangeEventAcknowledgementPending(prv::Provider *provider) const;
+        bool& getChangeEventAcknowledgementPending(prv::Provider *provider);
         [[nodiscard]] bool hasProviderSpecificSource(prv::Provider *provider) const;
 
         bool isSynced() const;
@@ -30,6 +36,12 @@ namespace hex::plugin::builtin {
         bool m_synced = false;
         PerProvider<std::string> m_perProviderSource;
         std::string m_sharedSource;
+        PerProvider<wolv::io::ChangeTracker> m_PPchangeTracker;
+        PerProvider<bool> m_PPignoreNextChangeEvent;
+        PerProvider<bool> m_PPchangeEventAcknowledgementPending;
+        wolv::io::ChangeTracker m_sharedChangeTracker;
+        bool m_sharedIgnoreNextChangeEvent = false;
+        bool m_sharedChangeEventAcknowledgementPending = false;
     };
 
     using TextHighlighter = hex::plugin::builtin::TextHighlighter;
@@ -170,9 +182,6 @@ namespace hex::plugin::builtin {
         bool m_openGotoLinePopUp = false;
         bool m_patternEvaluating = false;
         std::map<std::fs::path, std::string> m_patternNames;
-        PerProvider<wolv::io::ChangeTracker> m_changeTracker;
-        PerProvider<bool> m_ignoreNextChangeEvent;
-        PerProvider<bool> m_changeEventAcknowledgementPending;
         PerProvider<bool> m_patternFileDirty;
         PerProvider<bool> m_patternFileInitialized;
 

--- a/plugins/builtin/source/content/providers/file_provider.cpp
+++ b/plugins/builtin/source/content/providers/file_provider.cpp
@@ -425,8 +425,9 @@ namespace hex::plugin::builtin {
             (void)this->open(!m_loadedIntoMemory);
 
             getUndoStack().reapply();
-            m_changeEventAcknowledgementPending = false;
             EventDataChanged::post(this);
+        },[this] {
+            m_changeEventAcknowledgementPending = false;
         });
     }
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -188,6 +188,43 @@ namespace hex::plugin::builtin {
         return m_perProviderSource.get(provider);
     }
 
+    const wolv::io::ChangeTracker& PatternSourceCode::getTracker(prv::Provider *provider) const {
+        if (m_synced)
+            return m_sharedChangeTracker;
+
+        return m_PPchangeTracker.get(provider);
+    }
+    wolv::io::ChangeTracker& PatternSourceCode::getTracker(prv::Provider *provider) {
+        if (m_synced)
+            return m_sharedChangeTracker;
+
+        return m_PPchangeTracker.get(provider);
+    }
+    const bool& PatternSourceCode::getIgnoreNextChangeEvent(prv::Provider *provider) const {
+        if (m_synced)
+            return m_sharedIgnoreNextChangeEvent;
+
+        return m_PPignoreNextChangeEvent.get(provider);
+    }
+    bool& PatternSourceCode::getIgnoreNextChangeEvent(prv::Provider *provider) {
+        if (m_synced)
+            return m_sharedIgnoreNextChangeEvent;
+
+        return m_PPignoreNextChangeEvent.get(provider);
+    }
+    const bool& PatternSourceCode::getChangeEventAcknowledgementPending(prv::Provider *provider) const {
+        if (m_synced)
+            return m_sharedChangeEventAcknowledgementPending;
+
+        return m_PPchangeEventAcknowledgementPending.get(provider);
+    }
+    bool& PatternSourceCode::getChangeEventAcknowledgementPending(prv::Provider *provider) {
+        if (m_synced)
+            return m_sharedChangeEventAcknowledgementPending;
+
+        return m_PPchangeEventAcknowledgementPending.get(provider);
+    }
+
     bool PatternSourceCode::hasProviderSpecificSource(prv::Provider* provider) const {
         return !m_perProviderSource.get(provider).empty();
     }
@@ -1663,8 +1700,8 @@ namespace hex::plugin::builtin {
             m_textEditor.get(provider).setText(code, true);
             m_sourceCode.get(provider) = code;
             if (trackFile) {
-                m_changeTracker.get(provider) = wolv::io::ChangeTracker(file);
-                m_changeTracker.get(provider).startTracking([this, provider]{ this->handleFileChange(provider); });
+                m_sourceCode.getTracker(provider) = wolv::io::ChangeTracker(file);
+                m_sourceCode.getTracker(provider).startTracking([this, provider]{ this->handleFileChange(provider); });
             }
             ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
                 std::ignore = runtime;
@@ -2675,18 +2712,21 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::handleFileChange(prv::Provider *provider) {
-        if (m_ignoreNextChangeEvent.get(provider)) {
-            m_ignoreNextChangeEvent.get(provider) = false;
+        if (m_sourceCode.getIgnoreNextChangeEvent(provider)) {
+            if (!m_sourceCode.isSynced())
+                m_sourceCode.getIgnoreNextChangeEvent(provider) = false;
             return;
         }
 
-        if (m_changeEventAcknowledgementPending.get(provider)) {
+        if (m_sourceCode.getChangeEventAcknowledgementPending(provider)) {
             return;
         }
 
-        m_changeEventAcknowledgementPending.get(provider) = true;
+        m_sourceCode.getChangeEventAcknowledgementPending(provider) = true;
         hex::ui::BannerButton::open(ICON_VS_INFO, "hex.builtin.provider.file.reload_changes", ImColor(66, 104, 135), "hex.builtin.provider.file.reload_changes.reload", [this, provider] {
-            m_changeEventAcknowledgementPending.get(provider) = false;
+            auto path = m_sourceCode.getTracker(provider).getPath();
+            loadPatternFile(path, provider, true);
+            m_sourceCode.getChangeEventAcknowledgementPending(provider) = false;
         });
     }
 
@@ -2751,14 +2791,14 @@ namespace hex::plugin::builtin {
                 wolv::io::File file(path, wolv::io::File::Mode::Create);
                 file.writeString(wolv::util::trim(m_textEditor.get(provider).getText()));
                 m_patternFileDirty.get(provider) = false;
-                auto loadedPath = m_changeTracker.get(provider).getPath();
+                auto loadedPath = m_sourceCode.getTracker(provider).getPath();
                 if ((loadedPath.empty() && loadedPath != path) || (!loadedPath.empty() && !trackFile) || loadedPath == path)
-                    m_changeTracker.get(provider).stopTracking();
+                    m_sourceCode.getTracker(provider).stopTracking();
 
                 if (trackFile) {
-                    m_changeTracker.get(provider) = wolv::io::ChangeTracker(file);
-                    m_changeTracker.get(provider).startTracking([this, provider]{ this->handleFileChange(provider); });
-                    m_ignoreNextChangeEvent.get(provider) = true;
+                    m_sourceCode.getTracker(provider) = wolv::io::ChangeTracker(file);
+                    m_sourceCode.getTracker(provider).startTracking([this, provider]{ this->handleFileChange(provider); });
+                    m_sourceCode.getIgnoreNextChangeEvent(provider) = true;
                 }
             }
         );
@@ -2768,7 +2808,7 @@ namespace hex::plugin::builtin {
         auto provider = ImHexApi::Provider::get();
         if (provider == nullptr)
             return;
-        auto path = m_changeTracker.get(provider).getPath();
+        auto path = m_sourceCode.getTracker(provider).getPath();
         wolv::io::File file(path, wolv::io::File::Mode::Create);
         if (file.isValid() && trackFile) {
             if (isPatternDirty(provider)) {

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2726,6 +2726,7 @@ namespace hex::plugin::builtin {
         hex::ui::BannerButton::open(ICON_VS_INFO, "hex.builtin.provider.file.reload_changes", ImColor(66, 104, 135), "hex.builtin.provider.file.reload_changes.reload", [this, provider] {
             auto path = m_sourceCode.getTracker(provider).getPath();
             loadPatternFile(path, provider, true);
+        },[this,provider] {
             m_sourceCode.getChangeEventAcknowledgementPending(provider) = false;
         });
     }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2814,6 +2814,7 @@ namespace hex::plugin::builtin {
             if (isPatternDirty(provider)) {
                 file.writeString(wolv::util::trim(m_textEditor.get(provider).getText()));
                 m_patternFileDirty.get(provider) = false;
+                m_sourceCode.getIgnoreNextChangeEvent(provider) = true;
             }
             return;
         }

--- a/plugins/ui/include/banners/banner_button.hpp
+++ b/plugins/ui/include/banners/banner_button.hpp
@@ -10,8 +10,8 @@ namespace hex::ui {
 
     class BannerButton : public Banner<BannerButton> {
     public:
-        BannerButton(const char *icon, UnlocalizedString message, ImColor color, UnlocalizedString buttonText, std::function<void()> buttonCallback)
-            : Banner(color), m_icon(icon), m_message(std::move(message)), m_buttonText(std::move(buttonText)), m_buttonCallback(std::move(buttonCallback)) { }
+        BannerButton(const char *icon, UnlocalizedString message, ImColor color, UnlocalizedString buttonText, std::function<void()> buttonCallback, std::function<void()> closeCallback = []{})
+            : Banner(color), m_icon(icon), m_message(std::move(message)), m_buttonText(std::move(buttonText)), m_buttonCallback(std::move(buttonCallback)), m_closeCallback(std::move(closeCallback)) { }
 
         void drawContent() override {
             const std::string buttonText = fmt::format(" {} ", Lang(m_buttonText).get());
@@ -52,11 +52,16 @@ namespace hex::ui {
             ImGui::PopStyleVar(3);
         }
 
+        void onClose() override {
+            m_closeCallback();
+        }
+
     private:
         const char *m_icon;
         UnlocalizedString m_message;
         UnlocalizedString m_buttonText;
         std::function<void()> m_buttonCallback;
+        std::function<void()> m_closeCallback;
     };
 
 }


### PR DESCRIPTION
Currently, the sync pattern and the tracker systems are independent of each other which creates problems like reloading banners on pattern saving when patterns are synced.

The PR adds the tracker and the associated variables to the PatternSourceCode class that implements the sync feature. This was patterns that are synced share the trackers as well thus eliminating most problems. When files are saved there is an ignore variable that was used only once but now it checks to see if file is synced before resetting it.