### PR TITLE
Fix/utf8 log alignment

### DIFF
--- a/lib/libimhex/source/helpers/logger.cpp
+++ b/lib/libimhex/source/helpers/logger.cpp
@@ -3,7 +3,6 @@
 #include <hex/api/task_manager.hpp>
 
 #include <hex/helpers/fs.hpp>
-#include <hex/helpers/fmt.hpp>
 #include <hex/helpers/default_paths.hpp>
 #include <hex/helpers/auto_reset.hpp>
 
@@ -13,7 +12,6 @@
 #include <mutex>
 #include <chrono>
 #include <fmt/chrono.h>
-#include <hex/helpers/debugging.hpp>
 
 #if defined(OS_WINDOWS)
     #include <Windows.h>
@@ -142,7 +140,7 @@ namespace hex::log {
 
             constexpr static auto MaxTagLength = 25;
             const auto totalLength = std::min(static_cast<size_t>(MaxTagLength),
-                                              projectName.length() + (threadName.empty() ? 0 : 3 + threadName.length()));
+                                              projectName.length() + (threadName.empty() ? 0 : 3 + wolv::util::utf8StringLength(threadName)));
 
             const auto remainingSpace = MaxTagLength - projectName.length() - 3;
 
@@ -150,7 +148,7 @@ namespace hex::log {
                 now,
                 s_colorOutputEnabled ? fmt::format(ts, "{}", level) : level,
                 projectName.substr(0, std::min(projectName.length(), static_cast<size_t>(MaxTagLength))),
-                wolv::util::truncateUtf8(threadName, remainingSpace),
+                wolv::util::utf8Substr(threadName, 0, remainingSpace),
                 "",
                 MaxTagLength - totalLength
             );


### PR DESCRIPTION
The problem is caused by calculating space used by strings using string.length() which only works if every char in the string is encoded in 1 byte. The wrongly calculated space is then used to truncate the string at the wrong place. Finally, the wrongly calculated space is used to align the log entries which results in misalignment. The fix consists on counting utf-8 characters to calculate the spaces and using a function designed to work on utf-8 strings that returns sub-stings.

A further problem with alignment was caused when using CJK chars that are wider than regular half-width characters which throws the space calculations off. This was fixed by detecting when CJK glyphs are being used and adjusting the sizes using a reasonable approximation that 1 CJK char ~ 1.75 half-width chars.

Compare the two images. Before the PR:

<img width="1665" height="858" alt="zoomit" src="https://github.com/user-attachments/assets/9d1a467d-a0fa-4cf6-882f-51712044234f" />

and after the PR: 

<img width="1925" height="863" alt="after" src="https://github.com/user-attachments/assets/bb905f79-8bb5-4bd3-85b5-fb36327bc19b" />

Note how the utf-8 strings are truncated more than they should and that for those same entries the alignment is lost but are not with the changes. The image shows how CJK glyphs are handled.