### PR TITLE
Fix nullptr deref when opening ImHex without a provider on frame 1

### DIFF
--- a/plugins/ui/source/ui/hex_editor.cpp
+++ b/plugins/ui/source/ui/hex_editor.cpp
@@ -645,16 +645,20 @@ namespace hex::ui {
                 ImGui::TableSetupScrollFreeze(0, 2);
 
                 // Row address column
-                u64 maxAddress = m_provider->getActualSize();
-                if (maxAddress > 0)
-                    maxAddress--;
-                if ((m_scrollPosition + m_visibleRowCount) * bytesPerRow < maxAddress)
-                    maxAddress = (m_scrollPosition + m_visibleRowCount) * bytesPerRow;
+                u64 maxAddress = std::numeric_limits<u64>::max();
+                
+                if (m_provider != nullptr) {
+                    maxAddress = m_provider->getActualSize();
+                    if (maxAddress > 0)
+                        maxAddress--;
+                    if ((m_scrollPosition + m_visibleRowCount) * bytesPerRow < maxAddress)
+                        maxAddress = (m_scrollPosition + m_visibleRowCount) * bytesPerRow;
 
-                if (maxAddress + m_provider->getCurrentPageAddress() < std::numeric_limits<u64>::max() - m_provider->getBaseAddress())
-                    maxAddress += m_provider->getBaseAddress() + m_provider->getCurrentPageAddress();
-                else
-                    maxAddress = std::numeric_limits<u64>::max();
+                    if (maxAddress + m_provider->getCurrentPageAddress() < std::numeric_limits<u64>::max() - m_provider->getBaseAddress())
+                        maxAddress += m_provider->getBaseAddress() + m_provider->getCurrentPageAddress();
+                    else
+                        maxAddress = std::numeric_limits<u64>::max();
+                }
 
                 ImGui::TableSetupColumn("hex.ui.common.address"_lang, ImGuiTableColumnFlags_WidthFixed,
                     m_provider == nullptr ? 0 :


### PR DESCRIPTION
<!--
Please provide as much information as possible about what your PR aims to do.
PRs with no description will most likely be closed until more information is provided.
If you're planing on changing fundamental behaviour or add big new features, please open a GitHub Issue first before starting to work on it.
If it's not something big and you still want to contact us about it, feel free to do so !
-->

### Problem description
Commit https://github.com/WerWolv/ImHex/commit/f813656e8ccfb2a5166ba824130b9bd7d210d3e5 introduced a nullptr dereference that happens on the first frame of a provider being opened.

```
[12:03:47] [INFO]  [main | Main]                Switching to workspace 'Default'
Process 89715 stopped
* thread #1, name = 'ImHex 🔍', stop reason = signal SIGSEGV: address not mapped to object (fault address=0x0)
    frame #0: 0x00007fffcdd43958 ui.hexpluglib`::drawEditor() at hex_editor.cpp:648:46
   645 	                ImGui::TableSetupScrollFreeze(0, 2);
   646 	
   647 	                // Row address column
-> 648 	                u64 maxAddress = m_provider->getActualSize();
    	                                             ^
   649 	                if (maxAddress > 0)
   650 	                    maxAddress--;
   651 	                if ((m_scrollPosition + m_visibleRowCount) * bytesPerRow < maxAddress)
(lldb) bt
* thread #1, name = 'ImHex 🔍', stop reason = signal SIGSEGV: address not mapped to object (fault address=0x0)
  * frame #0: 0x00007fffcdd43958 ui.hexpluglib`::drawEditor() at hex_editor.cpp:648:46
    frame #1: 0x00007fffcdd4954b ui.hexpluglib`::draw() at hex_editor.cpp:1409:15
    frame #2: 0x00007fffdc01eb21 diffing.hexplug`::drawDiffColumn() at view_diff.cpp:64:30
    frame #3: 0x00007fffdc01d56d diffing.hexplug`::drawContent() at view_diff.cpp:271:28
    frame #4: 0x00007ffff7af7413 libimhex.so.1.39.0.WIP`::draw() at view.cpp:201:23
    frame #5: 0x0000555555593e7d imhex`::frame() at window.cpp:759:23
    frame #6: 0x000055555559237d imhex`hex::Window::fullFrame() at window.cpp:200:19
    frame #7: 0x00005555555948b5 imhex`::loop() at window.cpp:297:19
    frame #8: 0x00005555555c211c imhex`::runImHex() at desktop.cpp:54:28
    frame #9: 0x00005555555836a6 imhex`main at main.cpp:73:12
    frame #10: 0x00007ffff682f43b libc.so.6`___lldb_unnamed_symbol_2b3c0 + 123
    frame #11: 0x00007ffff682f4eb libc.so.6`__libc_start_main + 139
    frame #12: 0x00005555555831d5 imhex`_start + 37
```

### Implementation description
If nullptr check guard.
