### PR TITLE
Search for included patterns in user provided folders

### DIFF
--- a/lib/libimhex/source/api/content_registry.cpp
+++ b/lib/libimhex/source/api/content_registry.cpp
@@ -724,7 +724,7 @@ namespace hex {
                 );
             }
 
-            runtime.setIncludePaths(paths::PatternsInclude.read() | paths::Patterns.read());
+            runtime.setIncludePaths(paths::PatternsInclude.read() | paths::Patterns.read() | ImHexApi::System::getAdditionalFolderPaths());
 
             for (const auto &[ns, name, paramCount, callback, dangerous] : impl::getFunctions()) {
                 if (dangerous)

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2802,7 +2802,7 @@ namespace hex::plugin::builtin {
         auto provider = ImHexApi::Provider::get();
         if (provider == nullptr)
             return;
-        const auto basePaths = paths::Patterns.read();
+        const auto basePaths = paths::Patterns.read() | ImHexApi::System::getAdditionalFolderPaths();
         std::vector<std::fs::path> paths;
 
         for (const auto &imhexPath : basePaths) {


### PR DESCRIPTION
### Problem description
Folders tab in settings specifies "Specify additional **search paths for patterns**, scripts, Yara rules and more"

However this is false. I don't think the argument is used for scripts or YARA rules, either. The vector is only read in getDataPaths, which is only accessed by getConfigPaths, and extractBundledFiles.

Also, relative paths do not work for file-backed patterns.

### Implementation description
Added `ImHexApi::System::getAdditionalFolderPaths()` to the calls that looks for pattern paths.
