### PR TITLE
fix: logs with utf-8 multibyte chars.

### DIFF
--- a/lib/libimhex/source/helpers/logger.cpp
+++ b/lib/libimhex/source/helpers/logger.cpp
@@ -128,30 +128,26 @@ namespace hex::log {
             const auto time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             const auto now = *std::localtime(&time);
 
-            auto threadName = TaskManager::getCurrentThreadName();
+            auto threadName = TaskManager::getCurrentThreadName(); // may contain multibyte UTF-8 characters
             if (threadName.empty()) [[unlikely]] {
                 threadName = "???";
             }
 
-            // Example prefix:
+            // Prefix format:
+            // |<-time->| |level|  |<------ tag ----->|
             // [04:24:08] [DEBUG] [builtin | Init Tasks]
-            //                     |<------ tag ------|
-            //                    
+            // |<---------- ASCII --------->||<-UTF8->|
 
             constexpr static auto MaxTagLength = 25;
-            const auto totalLength = std::min(static_cast<size_t>(MaxTagLength),
-                                              projectName.length() + (threadName.empty() ? 0 : 3 + wolv::util::utf8StringLength(threadName)));
 
-            const auto remainingSpace = MaxTagLength - projectName.length() - 3;
-
-            fmt::print(dest, "[{0:%H:%M:%S}] {1} [{2} | {3}] {4: <{5}} ",
-                now,
-                s_colorOutputEnabled ? fmt::format(ts, "{}", level) : level,
-                projectName.substr(0, std::min(projectName.length(), static_cast<size_t>(MaxTagLength))),
-                wolv::util::utf8Substr(threadName, 0, remainingSpace),
-                "",
-                MaxTagLength - totalLength
-            );
+            auto tag = fmt::format("{} | {}", projectName, threadName);
+            auto fixedLengthTag = fmt::format("{:<{}.{}}", tag, MaxTagLength, MaxTagLength);
+            // This step is needed to avoid chopping off closing bracket
+            if (fixedLengthTag.length() > tag.length())
+                tag = fmt::format("[{}]{}  ", tag, fixedLengthTag.substr(tag.length()));
+            else
+                tag = fmt::format("[{}]  ", fixedLengthTag);
+            fmt::print(dest, "[{0:%H:%M:%S}] {1} {2}", now, s_colorOutputEnabled ? fmt::format(ts, "{}", level) : level, tag);
         }   
 
         namespace color {

--- a/main/gui/source/window/platform/windows.cpp
+++ b/main/gui/source/window/platform/windows.cpp
@@ -418,13 +418,16 @@ namespace hex {
     void Window::initNative() {
         if (ImHexApi::System::isDebugBuild()) {
             // If the application is running in debug mode, ImHex runs under the CONSOLE subsystem,
-            // so we don't need to do anything besides enabling ANSI colors
+            // so we don't need to do anything besides enabling ANSI colors and UTF-8 encoding
             log::impl::enableColorPrinting();
+            system("chcp 65001 >nul");        //codepage 65001 = UTF-8.
         } else if (hex::getEnvironmentVariable("__IMHEX_FORWARD_CONSOLE__") == "1") {
             // Check for the __IMHEX_FORWARD_CONSOLE__ environment variable that was set by the forwarder application
 
             // Enable ANSI colors in the console
             log::impl::enableColorPrinting();
+            // Enable UTF-8 encoding
+            system("chcp 65001 >nul");
         } else {
             log::impl::redirectToFile();
         }

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -603,6 +603,7 @@
     "hex.builtin.task.loading_encoding_file": "Loading encoding file...",
     "hex.builtin.task.filtering_data": "Filtering data...",
     "hex.builtin.task.evaluating_nodes": "Evaluating nodes...",
+    "hex.builtin.task.highlighting_pattern": "Highlighting pattern...",
     "hex.builtin.title_bar_button.debug_build": "Debug build\n\nSHIFT + Click to open Debug Menu",
     "hex.builtin.title_bar_button.feedback": "Leave Feedback",
     "hex.builtin.title_bar_button.interactive_help": "Interactive Help",

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1531,7 +1531,7 @@ namespace hex::plugin::builtin {
                 m_identifierHighlighter.get(provider).updateRequiredInputs();
                 if (restoreInterruptState)
                     interrupt();
-                TaskManager::createBackgroundTask("HighlightSourceCode", [this,provider](auto &) { m_identifierHighlighter.get(provider).highlightSourceCode(); });
+                TaskManager::createBackgroundTask("hex.builtin.task.highlighting_pattern", [this,provider](auto &) { m_identifierHighlighter.get(provider).highlightSourceCode(); });
                 m_runningHighlighters += 1;
             } else if (m_changesWereColored && !m_allStepsCompleted) {
                 m_identifierHighlighter.get(provider).setRequestedIdentifierColors(m_colorizeIdentifiers);


### PR DESCRIPTION
{fmt} library can deal with all the issues caused by utf-8 chars in logs. Original code used {fmt} but only to pad the spaces calculated assuming 1 byte per char.

Also included code to change the windows console to use utf-8 and named the syntax highlighting task like other tasks created near it.
