### PR TITLE
fix: dos date and time in big endian

### DIFF
--- a/plugins/builtin/source/content/data_inspector.cpp
+++ b/plugins/builtin/source/content/data_inspector.cpp
@@ -821,15 +821,15 @@ namespace hex::plugin::builtin {
 #endif
 
         struct DOSDate {
-            unsigned day   : 5;
-            unsigned month : 4;
-            unsigned year  : 7;
+            u16 day   : 5;
+            u16 month : 4;
+            u16 year  : 7;
         };
 
         struct DOSTime {
-            unsigned seconds : 5;
-            unsigned minutes : 6;
-            unsigned hours   : 5;
+            u16 seconds : 5;
+            u16 minutes : 6;
+            u16 hours   : 5;
         };
 
         ContentRegistry::DataInspector::add("hex.builtin.inspector.dos_date", sizeof(DOSDate), [](auto buffer, auto endian, auto style) {


### PR DESCRIPTION
The other half of the issue was that the structures that the data inspector was using to store the 16 bit values were using a 32 bit underlying type instead of a 16 bit. That worked ok for little endian, but with 4 bytes the resulting value was actually the next u16 after the one selected.

