### PR TITLE
fix: Crash when closing empty delimiters

### DIFF
--- a/plugins/ui/source/ui/text_editor/editor.cpp
+++ b/plugins/ui/source/ui/text_editor/editor.cpp
@@ -938,7 +938,7 @@ namespace hex::ui {
 
         if (!m_removed.empty()) {
             auto start = m_removedRange.m_start;
-            editor->m_lines.insertTextAt(start, m_removed.c_str());
+            editor->m_lines.insertTextAt(start, m_removed);
             editor->m_lines.colorize();
         }
 
@@ -954,7 +954,7 @@ namespace hex::ui {
 
         if (!m_added.empty()) {
             auto start = m_addedRange.m_start;
-            editor->m_lines.insertTextAt(start, m_added.c_str());
+            editor->m_lines.insertTextAt(start, m_added);
             editor->m_lines.colorize();
         }
 

--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -730,10 +730,12 @@ namespace hex::ui {
         auto charCoords = lines->lineIndexCoords(lineIndex + 1, charIndex);
         i32 direction2 = 1;
         if (direction1 == -1 || direction1 == 1) {
-            Coordinates position = lines->lineCoordinates(charCoords.m_line, charCoords.m_column - 1);
-            if (checkPosition(lines, position)) {
-                from = position;
-                return true;
+            if (charCoords.m_column > 0) {
+                Coordinates position = lines->lineCoordinates(charCoords.m_line, charCoords.m_column - 1);
+                if (checkPosition(lines, position)) {
+                    from = position;
+                    return true;
+                }
             }
             if (direction1 == -1)
                 direction2 = 0;
@@ -744,10 +746,12 @@ namespace hex::ui {
                 direction2 = -1;
         }
         if (direction2 != 1) {
-            auto position = lines->lineCoordinates(charCoords.m_line, charCoords.m_column + direction2);
-            if (checkPosition(lines, position)) {
-                from = position;
-                return true;
+            if (charCoords.m_column + direction2 >= 0) {
+                auto position = lines->lineCoordinates(charCoords.m_line, charCoords.m_column + direction2);
+                if (checkPosition(lines, position)) {
+                    from = position;
+                    return true;
+                }
             }
         }
         u64 result;

--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -668,8 +668,8 @@ namespace hex::ui {
         auto result = lines->lineCoordsIndex(start);
         auto character = line[result];
         auto color = colors[result];
-        if ((s_separators.find(character) != std::string::npos && (static_cast<PaletteIndex>(color) == PaletteIndex::Separator)) || (static_cast<PaletteIndex>(color) == PaletteIndex::WarningText) ||
-            (s_operators.find(character)  != std::string::npos && (static_cast<PaletteIndex>(color) == PaletteIndex::Operator))  || (static_cast<PaletteIndex>(color) == PaletteIndex::WarningText)) {
+        if ((s_separators.find(character) != std::string::npos && (static_cast<PaletteIndex>(color) == PaletteIndex::Separator || static_cast<PaletteIndex>(color) == PaletteIndex::WarningText)) ||
+            (s_operators.find(character)  != std::string::npos && (static_cast<PaletteIndex>(color) == PaletteIndex::Operator || static_cast<PaletteIndex>(color) == PaletteIndex::WarningText))) {
             if (from != lines->lineIndexCoords(lineIndex + 1, result)) {
                 from = lines->lineIndexCoords(lineIndex + 1, result);
                 m_changed = true;

--- a/plugins/ui/source/ui/text_editor/render.cpp
+++ b/plugins/ui/source/ui/text_editor/render.cpp
@@ -107,12 +107,14 @@ namespace hex::ui {
             if (line.empty())
                 return false;
 
-            for (auto keys : m_codeFoldKeys) {
-                if (keys.m_start.m_line == lineIndex && m_codeFoldDelimiters.contains(keys)) {
-                      auto delimiter = m_codeFoldDelimiters[keys].first;
-                      if (!delimiter || (delimiter != '(' && delimiter != '[' && delimiter != '{' && delimiter != '<'))
-                            return false;
-                      return !line.contains(delimiter);
+            for (auto key : m_codeFoldKeys) {
+                if (key.m_start.m_line == lineIndex && m_codeFoldDelimiters.contains(key)) {
+                    auto delimiter = m_codeFoldDelimiters[key].first;
+                    if (!delimiter || (delimiter != '(' && delimiter != '[' && delimiter != '{' && delimiter != '<'))
+                        return false;
+                    if (key.m_start.m_column >= m_unfoldedLines[lineIndex].m_lineMaxColumn)
+                        return true;
+                    return !line.contains(delimiter);
                 }
             }
             return !line.ends_with('{');
@@ -1009,8 +1011,7 @@ namespace hex::ui {
         if (delimiters.size() < 2)
             return key;
 
-        auto lineIndex = key.m_start.m_line;
-        Coordinates openDelimiterCoordinates = m_lines->find(delimiters.substr(0,1), Coordinates(lineIndex, 0));
+        Coordinates openDelimiterCoordinates = m_lines->find(delimiters.substr(0,1), key.m_start);
         Coordinates closeDelimiterCoordinates;
         Line openDelimiterLine = m_lines->m_unfoldedLines[openDelimiterCoordinates.m_line];
         i32 columnIndex = 0;

--- a/plugins/ui/source/ui/text_editor/render.cpp
+++ b/plugins/ui/source/ui/text_editor/render.cpp
@@ -1710,13 +1710,13 @@ namespace hex::ui {
         auto line = operator[](aFrom.m_line);
         i32 colIndex = lineCoordsIndex(aFrom);
         auto substr1 = line.m_chars.substr(0, colIndex);
-        auto substr2 =line.m_chars.substr(colIndex, line.m_chars.size() - colIndex);
+        auto substr2 = line.m_chars.substr(colIndex, line.m_chars.size() - colIndex);
         if (substr2.size() < substr1.size()) {
-            auto distanceToEnd = line.stringTextSize(substr2.c_str());
+            auto distanceToEnd = line.stringTextSize(substr2);
             line.m_lineMaxColumn = line.lineTextSize();
             return line.m_lineMaxColumn - distanceToEnd;
         }
-        return line.stringTextSize(substr1.c_str());
+        return line.stringTextSize(substr1);
     }
 
     void TextEditor::drawCodeFolds(float lineIndex, ImDrawList *drawList) {


### PR DESCRIPTION
Doing
```cpp
{
}
```
or 
```cpp
{
{
}
}
```
was making imhex crash when closing folds. The cases were not considered during development because they are illegal pattern language statements.fix was to adjust the code to accommodate for them.