### PR TITLE
feat: unassigned shortcuts

### DIFF
--- a/lib/libimhex/include/hex/api/shortcut_manager.hpp
+++ b/lib/libimhex/include/hex/api/shortcut_manager.hpp
@@ -36,6 +36,8 @@ EXPORT_MODULE namespace hex {
         u32 m_key = 0;
     };
 
+    constexpr static auto UnassignedMin         = Key(static_cast<Keys>(0x0001'0000));
+    constexpr static auto UnassignedMax         = Key(static_cast<Keys>(0x0080'0000));
 
     constexpr static auto CTRL                  = Key(static_cast<Keys>(0x0100'0000));
     constexpr static auto ALT                   = Key(static_cast<Keys>(0x0200'0000));
@@ -64,12 +66,13 @@ EXPORT_MODULE namespace hex {
         bool operator<(const Shortcut &other) const;
         bool operator==(const Shortcut &other) const;
 
-        bool isLocal() const;
-        std::string toString() const;
-        KeyEquivalent toKeyEquivalent() const;
-        const std::set<Key>& getKeys() const;
-        bool has(Key key) const;
-        bool matches(const Shortcut &other) const;
+        [[nodiscard]] bool isLocal() const;
+        [[nodiscard]] std::string toString() const;
+        [[nodiscard]] KeyEquivalent toKeyEquivalent() const;
+        [[nodiscard]] const std::set<Key>& getKeys() const;
+        [[nodiscard]] bool has(Key key) const;
+        [[nodiscard]] bool matches(const Shortcut &other) const;
+        [[nodiscard]] bool isUnassigned() const;
 
     private:
         friend Shortcut operator+(const Key &lhs, const Key &rhs);
@@ -165,8 +168,10 @@ EXPORT_MODULE namespace hex {
 
         [[nodiscard]] static std::vector<ShortcutEntry> getGlobalShortcuts();
         [[nodiscard]] static std::vector<ShortcutEntry> getViewShortcuts(const View *view);
+        [[nodiscard]] static std::vector<Shortcut> &getUnusedUnassignedShortcuts();
 
         [[nodiscard]] static bool updateShortcut(const Shortcut &oldShortcut, Shortcut newShortcut, View *view = nullptr);
+        [[nodiscard]] static Shortcut generateUnassignedShortcut();
     };
 
 }

--- a/lib/libimhex/source/api/shortcut_manager.cpp
+++ b/lib/libimhex/source/api/shortcut_manager.cpp
@@ -19,6 +19,7 @@ namespace hex {
         std::optional<Shortcut> s_prevShortcut;
         bool s_macOSMode = false;
         AutoReset<std::optional<UnlocalizedString>> s_lastShortcutMainMenu;
+        std::vector<Shortcut> s_unusedUnassignedShortcuts;
 
     }
 
@@ -90,6 +91,7 @@ namespace hex {
         const auto SHIFT_NAME    = s_macOSMode ? "⇧" : "SHIFT";
         const auto SUPER_NAME    = s_macOSMode ? "⌘" : "SUPER";
         const auto Concatination = s_macOSMode ? " " : " + ";
+        const auto NA_NAME       = s_macOSMode ? "" : "Not Assigned";
 
         auto keys = m_keys;
         if (keys.erase(CTRL) > 0 || (!s_macOSMode && keys.erase(CTRLCMD) > 0)) {
@@ -107,6 +109,10 @@ namespace hex {
         if (keys.erase(SUPER) > 0 || (s_macOSMode && keys.erase(CTRLCMD) > 0)) {
             result += SUPER_NAME;
             result += Concatination;
+        }
+        if (auto idx = std::ranges::find_if(keys, [](const Key &key) { return key >= UnassignedMin && key <= UnassignedMax; }); idx != keys.end()) {
+            keys.erase(*idx);
+            result += NA_NAME;
         }
         keys.erase(CurrentView);
 
@@ -231,6 +237,8 @@ namespace hex {
             result += Concatination;
         }
 
+        if (result.starts_with("Not Assigned"))
+            result = "Not Assigned";
         if (result.ends_with(Concatination))
             result = result.substr(0, result.size() - strlen(Concatination));
 
@@ -277,6 +285,9 @@ namespace hex {
         #endif
     }
 
+    bool Shortcut::isUnassigned() const {
+        return std::ranges::any_of(m_keys, [](const Key &key) { return key >= UnassignedMin && key <= UnassignedMax; });
+    }
 
 
     void ShortcutManager::addGlobalShortcut(const Shortcut &shortcut, const std::vector<UnlocalizedString> &unlocalizedName, const std::function<void()> &callback, const EnabledCallback &enabledCallback) {
@@ -451,10 +462,24 @@ namespace hex {
         return result;
     }
 
+    std::vector<Shortcut> &ShortcutManager::getUnusedUnassignedShortcuts() {
+        return s_unusedUnassignedShortcuts;
+    }
+
     static bool updateShortcutImpl(const Shortcut &oldShortcut, const Shortcut &newShortcut, std::map<Shortcut, ShortcutManager::ShortcutEntry> &shortcuts) {
         if (shortcuts.contains(oldShortcut)) {
-            if (shortcuts.contains(newShortcut))
+            if (shortcuts.contains(newShortcut) || shortcuts.contains(newShortcut + AllowWhileTyping)) {
+                if (!oldShortcut.isUnassigned()) {
+                    auto shortcut = ShortcutManager::generateUnassignedShortcut();
+                    shortcuts[shortcut] = shortcuts[oldShortcut];
+                    shortcuts[shortcut].shortcut = shortcut;
+                    shortcuts.erase(oldShortcut);
+                }
                 return false;
+            }
+
+            if (oldShortcut.isUnassigned())
+                s_unusedUnassignedShortcuts.push_back(oldShortcut);
 
             shortcuts[newShortcut] = shortcuts[oldShortcut];
             shortcuts[newShortcut].shortcut = newShortcut;
@@ -467,9 +492,6 @@ namespace hex {
     bool ShortcutManager::updateShortcut(const Shortcut &oldShortcut, Shortcut newShortcut, View *view) {
         if (oldShortcut.matches(newShortcut))
             return true;
-
-        if (oldShortcut.has(AllowWhileTyping))
-            newShortcut += AllowWhileTyping;
 
         bool result;
         if (view != nullptr) {
@@ -494,5 +516,18 @@ namespace hex {
         s_macOSMode = true;
     }
 
+    // Generate unique key values for each unassigned shortcut
+    Shortcut ShortcutManager::generateUnassignedShortcut() {
+        static Key nextUnassignedKey = UnassignedMin;
+        std::set<Key> keys = { nextUnassignedKey };
+        Shortcut result(keys);
+        if (!s_unusedUnassignedShortcuts.empty())
+            result = Shortcut({ s_unusedUnassignedShortcuts.back() });
+        else if (nextUnassignedKey.getKeyCode() < UnassignedMax.getKeyCode())
+            nextUnassignedKey = Key(static_cast<Keys>(nextUnassignedKey.getKeyCode() + 1));
+        else
+            log::error("No more unassigned shortcuts available!");
+        return result;
+    }
 
 }

--- a/lib/libimhex/source/api/shortcut_manager.cpp
+++ b/lib/libimhex/source/api/shortcut_manager.cpp
@@ -91,7 +91,7 @@ namespace hex {
         const auto SHIFT_NAME    = s_macOSMode ? "⇧" : "SHIFT";
         const auto SUPER_NAME    = s_macOSMode ? "⌘" : "SUPER";
         const auto Concatination = s_macOSMode ? " " : " + ";
-        const auto NA_NAME       = s_macOSMode ? "" : "Not Assigned";
+        const auto NA_NAME       = "Not Assigned";
 
         auto keys = m_keys;
         if (keys.erase(CTRL) > 0 || (!s_macOSMode && keys.erase(CTRLCMD) > 0)) {
@@ -237,8 +237,8 @@ namespace hex {
             result += Concatination;
         }
 
-        if (result.starts_with("Not Assigned"))
-            result = "Not Assigned";
+        if (result.contains(NA_NAME))
+            result = NA_NAME;
         if (result.ends_with(Concatination))
             result = result.substr(0, result.size() - strlen(Concatination));
 

--- a/plugins/builtin/source/content/main_menu_items.cpp
+++ b/plugins/builtin/source/content/main_menu_items.cpp
@@ -446,19 +446,19 @@ namespace hex::plugin::builtin {
 
             /* IPS */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.ips"}, ICON_VS_GIT_PULL_REQUEST_NEW_CHANGES, 5150,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     importIPSPatch,
                                                     noRunningTaskAndWritableProvider);
 
             /* IPS32 */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.ips32"}, ICON_VS_GIT_PULL_REQUEST_NEW_CHANGES, 5200,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     importIPS32Patch,
                                                     noRunningTaskAndWritableProvider);
 
             /* Modified File */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.modified_file" }, ICON_VS_FILES, 5300,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     importModifiedFile,
                                                     noRunningTaskAndWritableProvider);
         }
@@ -470,13 +470,13 @@ namespace hex::plugin::builtin {
 
             /* Selection to File */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.selection_to_file" }, ICON_VS_FILE_BINARY, 6010,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     exportSelectionToFile,
                                                     ImHexApi::HexEditor::isSelectionValid);
 
             /* Base 64 */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.base64" }, ICON_VS_NOTE, 6020,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     exportBase64,
                                                     isProviderDumpable);
 
@@ -487,7 +487,7 @@ namespace hex::plugin::builtin {
 
             /* Report */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.report" }, ICON_VS_MARKDOWN, 6040,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     exportReport,
                                                     ImHexApi::Provider::isValid);
 
@@ -495,13 +495,13 @@ namespace hex::plugin::builtin {
 
             /* IPS */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.ips" }, ICON_VS_GIT_PULL_REQUEST_NEW_CHANGES, 6100,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     exportIPSPatch,
                                                     isProviderDumpable);
 
             /* IPS32 */
             ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.ips32" }, ICON_VS_GIT_PULL_REQUEST_NEW_CHANGES, 6150,
-                                                    Shortcut::None,
+                                                    ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                     exportIPS32Patch,
                                                     isProviderDumpable);
         }
@@ -594,7 +594,7 @@ namespace hex::plugin::builtin {
 
         ContentRegistry::UserInterface::addMenuItemSubMenu({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.layout" }, ICON_VS_LAYOUT, 1050, []{}, ImHexApi::Provider::isValid);
 
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.layout", "hex.builtin.menu.workspace.layout.save" }, 1100, Shortcut::None, [] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.layout", "hex.builtin.menu.workspace.layout.save" }, 1100, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [] {
             ui::PopupTextInput::open("hex.builtin.popup.save_layout.title", "hex.builtin.popup.save_layout.desc", [](const std::string &name) {
                 LayoutManager::save(name);
             });
@@ -602,7 +602,7 @@ namespace hex::plugin::builtin {
 
         ContentRegistry::UserInterface::addMenuItemSubMenu({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.layout" }, ICON_VS_LAYOUT, 1150, [] {
             bool locked = LayoutManager::isLayoutLocked();
-            if (menu::menuItemEx("hex.builtin.menu.workspace.layout.lock"_lang, ICON_VS_LOCK, Shortcut::None, locked, ImHexApi::Provider::isValid())) {
+            if (menu::menuItemEx("hex.builtin.menu.workspace.layout.lock"_lang, ICON_VS_LOCK, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, locked, ImHexApi::Provider::isValid())) {
                 LayoutManager::lockLayout(!locked);
                 ContentRegistry::Settings::write<bool>("hex.builtin.setting.interface", "hex.builtin.setting.interface.layout_locked", !locked);
             }
@@ -612,7 +612,7 @@ namespace hex::plugin::builtin {
 
         ContentRegistry::UserInterface::addMenuItemSubMenu({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.layout" }, 2000, [] {
             for (const auto &path : romfs::list("layouts")) {
-                if (menu::menuItem(wolv::util::capitalizeString(path.stem().string()).c_str(), Shortcut::None, false, ImHexApi::Provider::isValid())) {
+                if (menu::menuItem(wolv::util::capitalizeString(path.stem().string()).c_str(), ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, false, ImHexApi::Provider::isValid())) {
                     LayoutManager::loadFromString(std::string(romfs::get(path).string()));
                 }
             }
@@ -638,7 +638,7 @@ namespace hex::plugin::builtin {
 
         ContentRegistry::UserInterface::addMenuItemSeparator({ "hex.builtin.menu.workspace" }, 3000);
 
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.create" }, ICON_VS_ADD, 3100, Shortcut::None, [] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.workspace", "hex.builtin.menu.workspace.create" }, ICON_VS_ADD, 3100, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [] {
             ui::PopupTextInput::open("hex.builtin.popup.create_workspace.title", "hex.builtin.popup.create_workspace.desc", [](const std::string &name) {
                 WorkspaceManager::createWorkspace(name);
             });

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -288,10 +288,8 @@ for (const auto &path : m_paths) {
                 ImGui::BeginDisabled(m_drawShortcut.matches(m_defaultShortcut));
                 if (ImGuiExt::DimmedButton(ICON_VS_DISCARD, ImGui::GetStyle().FramePadding * 2 + ImVec2(ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight()))) {
                     this->reset();
-                    if (!m_hasDuplicate) {
-                        m_shortcut = m_defaultShortcut;
-                        settingChanged = true;
-                    }
+
+                    settingChanged = true;
 
                 }
                 ImGui::EndDisabled();
@@ -364,8 +362,15 @@ for (const auto &path : m_paths) {
             void reset() {
                 m_hasDuplicate = !ShortcutManager::updateShortcut(m_shortcut, m_defaultShortcut, m_view);
 
-                m_drawShortcut = m_defaultShortcut;
-                m_shortcut = m_defaultShortcut;
+                if (m_hasDuplicate) {
+                    auto shortcut = ShortcutManager::getShortcutByName(m_fullName, m_view);
+                    m_drawShortcut = shortcut;
+                    m_shortcut = shortcut;
+                    log::warn("Resetting shortcut failed: {} is already being used", m_defaultShortcut.toString());
+                } else {
+                    m_drawShortcut = m_defaultShortcut;
+                    m_shortcut = m_defaultShortcut;
+                }
             }
 
         private:
@@ -382,12 +387,22 @@ for (const auto &path : m_paths) {
 
                     auto newShortcut = Shortcut(std::move(keys));
                     m_hasDuplicate = !ShortcutManager::updateShortcut(m_shortcut, newShortcut, m_view);
-                    m_drawShortcut = std::move(newShortcut);
+
+                    // Remove default unassigned shortcuts from unused list.
+                    if (m_shortcut == m_defaultShortcut && m_shortcut.isUnassigned()) {
+                        auto unusedUnassignedShortcuts = ShortcutManager::getUnusedUnassignedShortcuts();
+                        if (auto shortcut_it = std::ranges::find(unusedUnassignedShortcuts, m_shortcut); shortcut_it != unusedUnassignedShortcuts.end())
+                           unusedUnassignedShortcuts.erase(shortcut_it);
+                    }
 
                     if (!m_hasDuplicate) {
+                        m_drawShortcut = std::move(newShortcut);
                         m_shortcut = m_drawShortcut;
                         log::info("Changed shortcut to {}", shortcut->toString());
                     } else {
+                        m_drawShortcut = ShortcutManager::getShortcutByName(m_fullName,m_view);
+                        m_shortcut = m_drawShortcut;
+                        m_hasDuplicate = false;
                         log::warn("Changing shortcut failed as it overlapped with another one", shortcut->toString());
                     }
 

--- a/plugins/builtin/source/content/views/view_bookmarks.cpp
+++ b/plugins/builtin/source/content/views/view_bookmarks.cpp
@@ -622,7 +622,7 @@ namespace hex::plugin::builtin {
         ContentRegistry::UserInterface::addMenuItemSeparator({ "hex.builtin.menu.file", "hex.builtin.menu.file.import" }, 5400);
 
         /* Import bookmarks */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.bookmark" }, ICON_VS_BOOKMARK, 5500, Shortcut::None, [this]{
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.bookmark" }, ICON_VS_BOOKMARK, 5500, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this]{
             fs::openFileBrowser(fs::DialogMode::Open, { { "Bookmarks File", "hexbm"} }, [&, this](const std::fs::path &path) {
                 try {
                     this->importBookmarks(ImHexApi::Provider::get(), nlohmann::json::parse(wolv::io::File(path, wolv::io::File::Mode::Read).readString()));
@@ -636,7 +636,7 @@ namespace hex::plugin::builtin {
 
 
         /* Export bookmarks */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.bookmark" }, ICON_VS_BOOKMARK, 6250, Shortcut::None, [this]{
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.bookmark" }, ICON_VS_BOOKMARK, 6250, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this]{
             fs::openFileBrowser(fs::DialogMode::Save, { { "Bookmarks File", "hexbm"} }, [&, this](const std::fs::path &path) {
                 nlohmann::json json;
                 this->exportBookmarks(ImHexApi::Provider::get(), json);

--- a/plugins/builtin/source/content/views/view_data_processor.cpp
+++ b/plugins/builtin/source/content/views/view_data_processor.cpp
@@ -401,7 +401,7 @@ namespace hex::plugin::builtin {
         });
 
         /* Import Nodes */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.data_processor" }, ICON_VS_CHIP, 5600, Shortcut::None, [this]{
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.data_processor" }, ICON_VS_CHIP, 5600, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this]{
             fs::openFileBrowser(fs::DialogMode::Open, { {"hex.builtin.view.data_processor.name"_lang, "hexnode" } },
                                 [&](const std::fs::path &path) {
                                     wolv::io::File file(path, wolv::io::File::Mode::Read);
@@ -413,7 +413,7 @@ namespace hex::plugin::builtin {
         }, ImHexApi::Provider::isValid);
 
         /* Export Nodes */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.data_processor" }, ICON_VS_CHIP, 8050, Shortcut::None, [this]{
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.data_processor" }, ICON_VS_CHIP, 8050, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this]{
             fs::openFileBrowser(fs::DialogMode::Save, { {"hex.builtin.view.data_processor.name"_lang, "hexnode" } },
                                 [&, this](const std::fs::path &path) {
                                     wolv::io::File file(path, wolv::io::File::Mode::Create);

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -757,7 +757,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Load Encoding File */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.custom_encoding" }, "あ", 5700, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.custom_encoding" }, "あ", 5700, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this]{
                                                     const auto basePaths = paths::Encodings.read();
                                                     std::vector<std::fs::path> paths;
@@ -920,7 +920,7 @@ namespace hex::plugin::builtin {
 
         /* Copy address */
         ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.copy_as", "hex.builtin.view.hex_editor.copy.address" }, ICON_VS_LOCATION, 1250,
-                                                Shortcut::None,
+                                                ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [] {
                                                     auto selection = ImHexApi::HexEditor::getSelection();
                                                     if (selection.has_value() && selection != Region::Invalid())
@@ -1006,7 +1006,7 @@ namespace hex::plugin::builtin {
 
         /* Paste... > Paste all as string */
         ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.paste_as", "hex.builtin.view.hex_editor.menu.edit.paste_all_string" }, ICON_VS_SYMBOL_KEY, 1510,
-                                                Shortcut::None,
+                                                ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [] {
                                                     pasteBytes(ImHexApi::HexEditor::getSelection().value_or( ImHexApi::HexEditor::ProviderRegion(Region { .address=0, .size=0 }, ImHexApi::Provider::get())), false, true);
                                                 },
@@ -1036,7 +1036,7 @@ namespace hex::plugin::builtin {
         ContentRegistry::UserInterface::addMenuItemSeparator({ "hex.builtin.menu.edit" }, 1600, this);
 
         /* Set Base Address */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.set_base" }, ICON_VS_LOCATION, 1650, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.set_base" }, ICON_VS_LOCATION, 1650, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto provider = ImHexApi::Provider::get();
                                                     this->openPopup<PopupBaseAddress>(provider->getBaseAddress());
@@ -1045,7 +1045,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Resize */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.resize" }, ICON_VS_ARROW_BOTH, 1700, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.resize" }, ICON_VS_ARROW_BOTH, 1700, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto provider = ImHexApi::Provider::get();
                                                     this->openPopup<PopupResize>(provider->getActualSize());
@@ -1054,7 +1054,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Insert */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.insert" }, ICON_VS_INSERT, 1750, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.insert" }, ICON_VS_INSERT, 1750, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto selection      = ImHexApi::HexEditor::getSelection();
 
@@ -1064,7 +1064,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Remove */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.remove" }, ICON_VS_CLEAR_ALL, 1800, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.remove" }, ICON_VS_CLEAR_ALL, 1800, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto selection = ImHexApi::HexEditor::getSelection();
 
@@ -1074,7 +1074,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Fill */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.fill" }, ICON_VS_PAINTCAN, 1810, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.fill" }, ICON_VS_PAINTCAN, 1810, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto selection = ImHexApi::HexEditor::getSelection();
 
@@ -1149,7 +1149,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Set Page Size */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.set_page_size" }, ICON_VS_BROWSER, 1860, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.set_page_size" }, ICON_VS_BROWSER, 1860, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     auto provider = ImHexApi::Provider::get();
                                                     this->openPopup<PopupPageSize>(provider->getPageSize());
@@ -1160,7 +1160,7 @@ namespace hex::plugin::builtin {
         ContentRegistry::UserInterface::addMenuItemSeparator({ "hex.builtin.menu.edit" }, 1900, this);
 
         /* Open in new provider */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.open_in_new_provider" }, ICON_VS_GO_TO_FILE, 1950, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.open_in_new_provider" }, ICON_VS_GO_TO_FILE, 1950, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [] {
                                                     auto selection = ImHexApi::HexEditor::getSelection();
 
@@ -1174,7 +1174,7 @@ namespace hex::plugin::builtin {
                                                 this);
 
         /* Decode as Text */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.decode_as_text" }, ICON_VS_CHAT_SPARKLE, 1960, Shortcut::None,
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.edit", "hex.builtin.view.hex_editor.menu.edit.decode_as_text" }, ICON_VS_CHAT_SPARKLE, 1960, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping,
                                                 [this] {
                                                     const auto selection = ImHexApi::HexEditor::getSelection();
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2150,21 +2150,21 @@ namespace hex::plugin::builtin {
         this);
 
         /* Replace Next */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_next" }, 1550, Shortcut::None, [this] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_next" }, 1550, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this] {
             m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->replace(&m_textEditor.get(ImHexApi::Provider::get()), true);
         }, [this] { return ImHexApi::Provider::isValid() && !m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->getReplaceWord().empty() && m_focusedSubWindowName.contains(TextEditorView); },
         []{ return false; },
         this);
 
         /* Replace Previous */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_previous" }, 1560, Shortcut::None, [this] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_previous" }, 1560, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this] {
             m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->replace(&m_textEditor.get(ImHexApi::Provider::get()), false);
         }, [this] { return ImHexApi::Provider::isValid() && !m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->getReplaceWord().empty() && m_focusedSubWindowName.contains(TextEditorView); },
         []{ return false; },
         this);
 
         /* Replace All */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_all" }, ICON_VS_REPLACE_ALL, 1570, Shortcut::None, [this] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.view.pattern_editor.menu.replace_all" }, ICON_VS_REPLACE_ALL, 1570, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this] {
             m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->replaceAll(&m_textEditor.get(ImHexApi::Provider::get()));
         }, [this] { return ImHexApi::Provider::isValid() && !m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->getReplaceWord().empty() && m_focusedSubWindowName.contains(TextEditorView); },
         this);
@@ -2177,12 +2177,12 @@ namespace hex::plugin::builtin {
         this);
 
         /* Import Pattern */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.pattern" }, ICON_VS_FILE_CODE, 5600, Shortcut::None, [this] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.import", "hex.builtin.menu.file.import.pattern" }, ICON_VS_FILE_CODE, 5600, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this] {
             openPatternFile(false);
         }, ImHexApi::Provider::isValid);
 
         /* Export Pattern */
-        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.pattern" }, ICON_VS_FILE_CODE, 7050, Shortcut::None, [this] {
+        ContentRegistry::UserInterface::addMenuItem({ "hex.builtin.menu.file", "hex.builtin.menu.file.export", "hex.builtin.menu.file.export.pattern" }, ICON_VS_FILE_CODE, 7050, ShortcutManager::generateUnassignedShortcut() + AllowWhileTyping, [this] {
             savePatternAsNewFile(false);
         }, [this] {
             return ImHexApi::Provider::isValid() && !wolv::util::trim(m_textEditor.get(ImHexApi::Provider::get()).getText()).empty();

--- a/plugins/builtin/source/content/views/view_settings.cpp
+++ b/plugins/builtin/source/content/views/view_settings.cpp
@@ -102,7 +102,7 @@ namespace hex::plugin::builtin {
                         if (subCategory.entries.empty())
                             continue;
 
-                        if (ImGuiExt::BeginSubWindow(Lang(subCategory.unlocalizedName))) {
+                        if (ImGuiExt::BeginSubWindow(Lang(subCategory.unlocalizedName), nullptr, ImVec2(0, 0), ImGuiChildFlags_NavFlattened)) {
                             for (auto &setting : subCategory.entries) {
                                 ImGui::BeginDisabled(!setting.widget->isEnabled());
                                 auto title = Lang(setting.unlocalizedName);

--- a/plugins/ui/source/ui/menu_items.cpp
+++ b/plugins/ui/source/ui/menu_items.cpp
@@ -154,8 +154,10 @@ namespace hex::menu {
                 if (s_useNativeMenuBar)
                     return macosMenuItemSelect(label, icon, shortcut.toKeyEquivalent(), selected, enabled);
             #endif
-
-            if (ImGui::MenuItemEx(label, icon, shortcut.toString().c_str(), selected != nullptr ? *selected : false, enabled)) {
+            auto shortcutStr = shortcut.toString();
+            if (shortcutStr == "Not Assigned")
+                shortcutStr = "";
+            if (ImGui::MenuItemEx(label, icon, shortcutStr.c_str(), selected != nullptr ? *selected : false, enabled)) {
                 if (selected != nullptr)
                     *selected = !*selected;
                 return true;

--- a/plugins/ui/source/ui/menu_items.cpp
+++ b/plugins/ui/source/ui/menu_items.cpp
@@ -121,8 +121,10 @@ namespace hex::menu {
                 if (s_useNativeMenuBar)
                     return macosMenuItem(label, nullptr, shortcut.toKeyEquivalent(), selected, enabled);
             #endif
-
-            return ImGui::MenuItem(label, shortcut.toString().c_str(), selected, enabled);
+            auto shortcutStr = shortcut.toString();
+            if (shortcutStr == "Not Assigned")
+                shortcutStr = "";
+            return ImGui::MenuItem(label, shortcutStr.c_str(), selected, enabled);
         }
 
         bool menuItem(const char *label, const Shortcut &shortcut, bool *selected, bool enabled) {
@@ -130,8 +132,10 @@ namespace hex::menu {
                 if (s_useNativeMenuBar)
                     return macosMenuItemSelect(label, nullptr, shortcut.toKeyEquivalent(), selected, enabled);
             #endif
-
-            return ImGui::MenuItem(label, shortcut.toString().c_str(), selected, enabled);
+            auto shortcutStr = shortcut.toString();
+            if (shortcutStr == "Not Assigned")
+                shortcutStr = "";
+            return ImGui::MenuItem(label, shortcutStr.c_str(), selected, enabled);
         }
 
         bool menuItemEx(const char *label, const char *icon, const Shortcut &shortcut, bool selected, bool enabled) {
@@ -139,8 +143,10 @@ namespace hex::menu {
                 if (s_useNativeMenuBar)
                     return macosMenuItem(label, icon, shortcut.toKeyEquivalent(), selected, enabled);
             #endif
-
-            return ImGui::MenuItemEx(label, icon, shortcut.toString().c_str(), selected, enabled);
+            auto shortcutStr = shortcut.toString();
+            if (shortcutStr == "Not Assigned")
+                shortcutStr = "";
+            return ImGui::MenuItemEx(label, icon, shortcutStr.c_str(), selected, enabled);
         }
 
         bool menuItemEx(const char *label, const char *icon, const Shortcut &shortcut, bool *selected, bool enabled) {


### PR DESCRIPTION
This PR attempt to address three problems that exist in the current shortcut implementation.

1. If users find themselves having to use some menu item repeatedly they are unable to create a shortcut for it because menu items without shortcuts are not listed in the shortcut setting. 
2. Shortcut conflicts leave key sequences in an inconsistent state where the values displayed don't correspond to the actual shortcut key sequence. 
3.  In order to "recycle" shortcuts used as defaults in ImHex one currently needs to assign some dummy shortcut to the action in question.

To address them keys that are not assigned to any key in the keyboard are defined. When these keys are part of a key sequence they make the sequence an unassigned shortcut. When a shortcut collision occurs, it is resolved by turning the shortcut being edited into an unassigned shortcut making its default sequence available to use elsewhere without a dummy.
