### PR TITLE
fix: Content Store can't update some patterns.

### DIFF
--- a/lib/libimhex/include/hex/helpers/http_requests.hpp
+++ b/lib/libimhex/include/hex/helpers/http_requests.hpp
@@ -117,6 +117,8 @@ namespace hex {
 
         static std::string urlDecode(const std::string &input);
 
+        static std::string curlify(const std::string &input);
+
         void setProgress(float progress) { m_progress = progress; }
         bool isCanceled() const { return m_canceled; }
 

--- a/lib/libimhex/source/helpers/http_requests.cpp
+++ b/lib/libimhex/source/helpers/http_requests.cpp
@@ -2,6 +2,7 @@
 
 #include <hex/helpers/crypto.hpp>
 #include <hex/helpers/fmt.hpp>
+#include "boost/regex.hpp"
 
 namespace hex {
 
@@ -52,6 +53,11 @@ namespace hex {
                 i += 2;
             }
         }
+        return result;
+    }
+
+    std::string HttpRequest::curlify(const std::string &input) {
+        std::string result = boost::regex_replace(input, boost::regex(" "), "%20");
         return result;
     }
 

--- a/plugins/builtin/source/content/views/view_store.cpp
+++ b/plugins/builtin/source/content/views/view_store.cpp
@@ -255,7 +255,7 @@ namespace hex::plugin::builtin {
                         if (entry.contains("name") && entry.contains("desc") && entry.contains("authors") && entry.contains("file") && entry.contains("url") && entry.contains("hash") && entry.contains("folder")) {
 
                             // Parse entry
-                            StoreEntry storeEntry = { entry["name"], entry["desc"], entry["authors"], entry["file"], entry["url"], entry["hash"], entry["folder"], false, false, false, false };
+                            StoreEntry storeEntry = { entry["name"], entry["desc"], entry["authors"], entry["file"], HttpRequest::curlify(entry["url"]), entry["hash"], entry["folder"], false, false, false, false };
 
                             updateEntryMetadata(storeEntry, category);
                             category.entries.push_back(storeEntry);


### PR DESCRIPTION
Both Devil May Cry HD Collection.tar and AC Unity.tar fail to download in the Content Store because of the spaces in the file names. Apparently curl will generate errors if the url link contains spaces. the fix is to url encode the spaces only, a process known as 'urlify'ing the link.

The implementation uses boost regex replace to perform the substitution when the link is added to the entry. Perhaps a better fix would be to patch the python code that generates the Store response, but I don't have merge permissions on that repository and all the testing I have done indicates that the problem has been resolved.
