### PR TITLE
fix: avoid spawning temporary console for utf-8 setup

### DIFF
--- a/main/gui/source/window/platform/windows.cpp
+++ b/main/gui/source/window/platform/windows.cpp
@@ -420,14 +420,16 @@ namespace hex {
             // If the application is running in debug mode, ImHex runs under the CONSOLE subsystem,
             // so we don't need to do anything besides enabling ANSI colors and UTF-8 encoding
             log::impl::enableColorPrinting();
-            system("chcp 65001 >nul");        //codepage 65001 = UTF-8.
+            ::SetConsoleOutputCP(CP_UTF8);
+            ::SetConsoleCP(CP_UTF8);
         } else if (hex::getEnvironmentVariable("__IMHEX_FORWARD_CONSOLE__") == "1") {
             // Check for the __IMHEX_FORWARD_CONSOLE__ environment variable that was set by the forwarder application
 
             // Enable ANSI colors in the console
             log::impl::enableColorPrinting();
             // Enable UTF-8 encoding
-            system("chcp 65001 >nul");
+            ::SetConsoleOutputCP(CP_UTF8);
+            ::SetConsoleCP(CP_UTF8);
         } else {
             log::impl::redirectToFile();
         }


### PR DESCRIPTION
### Problem description

To set up utf-8 console output `system("chcp 65001 >nul")` was being used. This was spawning a temporary console which became really annoying when running any sort of script that ran ImHex repeatedly.

### Implementation description

Replaced the `system("chcp 65001 >nul")` calls with the WinAPI functions `SetConsoleOutputCP(CP_UTF8)` and `SetConsoleCP(CP_UTF8)` to avoid spawning a new console window.