### PR TITLE
fix: issue #2758

### DIFF
--- a/plugins/builtin/include/content/views/view_pattern_editor.hpp
+++ b/plugins/builtin/include/content/views/view_pattern_editor.hpp
@@ -113,8 +113,7 @@ namespace hex::plugin::builtin {
         std::atomic<u32> m_runningParsers    = 0;
         std::atomic<u32> m_runningHighlighters = 0;
 
-        PerProvider<bool> m_hasUnevaluatedChanges;
-        std::atomic<bool> m_changesWereParsed = false;
+        PerProvider<bool> m_hasUnparsedChanges;
         std::atomic<bool> m_changesWereColored = false;
         std::atomic<bool> m_allStepsCompleted = false;
         std::atomic<bool> m_interrupt;

--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -250,9 +250,7 @@ namespace hex::plugin::builtin {
             token = m_curr[0];
         }
         catch (const std::out_of_range &e) {
-            auto t = e.what();
-            if (t == nullptr)
-                return false;
+            log::error("IdentifierHighlighter::isValid: Out of range error: {}", e.what());
             return false;
         }
         return isLocationValid(token.location);
@@ -564,7 +562,7 @@ namespace hex::plugin::builtin {
         }
     }
 
-    void IdentifierHighlighter::skipDelimiters(i32 maxSkipCount, Token delimiter[2], i8 increment) {
+    void IdentifierHighlighter::skipDelimiters(i32 maxSkipCount, Token delimiters[2], i8 increment) {
         auto curr = m_curr;
         i32 skipCount = 0;
         i32 depth = 0;
@@ -581,17 +579,29 @@ namespace hex::plugin::builtin {
         next(increment);
         skipCountLimit -= increment;
 
-        if (peek(delimiter[0])) {
+        if (peek(delimiters[0])) {
             next(increment);
             skipCountLimit -= increment;
             while (skipCount < skipCountLimit) {
 
-                if (peek(delimiter[1])) {
+                if (delimiters[0].value == tkn::Operator::BoolLessThan.value && peek(tkn::Separator::LeftParenthesis)) {
+                    Token parentheses[2] = {tkn::Separator::LeftParenthesis, tkn::Separator::RightParenthesis};
+                    next(-increment);
+                    skipCountLimit += increment;
+                    skipDelimiters(maxSkipCount, parentheses, 1);
+                } else if (delimiters[0].value == tkn::Operator::BoolGreaterThan.value && peek(tkn::Separator::RightParenthesis)) {
+                    Token parentheses[2] = {tkn::Separator::RightParenthesis, tkn::Separator::LeftParenthesis};
+                    next(-increment);
+                    skipCountLimit += increment;
+                    skipDelimiters(maxSkipCount,parentheses, -1);
+                }
+
+                if (peek(delimiters[1])) {
 
                     if (depth == 0)
                         return;
                     depth--;
-                } else if (peek(delimiter[0]))
+                } else if (peek(delimiters[0]))
                     depth++;
                 else if (peek(tkn::Separator::Semicolon)) {
                     if (increment < 0)
@@ -1950,7 +1960,7 @@ namespace hex::plugin::builtin {
         try {
             source = location.source;
         } catch  (const std::out_of_range &e) {
-            log::error("TextHighlighter::IsLocationValid: Out of range error: {}", e.what());
+            log::error("IdentifierHighlighter::isLocationValid: Out of range error: {}", e.what());
             return false;
         }
         if (source == nullptr)
@@ -2577,10 +2587,11 @@ namespace hex::plugin::builtin {
 
 // Only update if needed. Must wait for the parser to finish first.
     void IdentifierHighlighter::highlightSourceCode() {
+        bool wasInterrupted = false;
         m_viewPatternEditor->resetInterrupt();
         ON_SCOPE_EXIT {
             m_viewPatternEditor->incrementRunningHighlighters(-1);
-            m_viewPatternEditor->setChangesWereColored(!m_viewPatternEditor->interrupted());
+            m_viewPatternEditor->setChangesWereColored(!wasInterrupted);
         };
         try {
             clearVariables();
@@ -2626,6 +2637,7 @@ namespace hex::plugin::builtin {
             }
         } catch (const std::out_of_range &e) {
             log::debug("TextHighlighter::highlightSourceCode: Out of range error: {}", e.what());
+            wasInterrupted = true;
             return;
         }
     }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -630,7 +630,7 @@ namespace hex::plugin::builtin {
                     ImGui::SameLine(0, 10_scaled);
                     if (ImGuiExt::DimmedIconToggle(ICON_VS_EDIT_SPARKLE, &m_runAutomatically)) {
                         if (m_runAutomatically)
-                            m_hasUnevaluatedChanges.get(provider) = true;
+                            m_hasUnparsedChanges.get(provider) = true;
                     }
                     ImGui::SetItemTooltip("%s", "hex.builtin.view.pattern_editor.auto"_lang.get());
 
@@ -1276,33 +1276,33 @@ namespace hex::plugin::builtin {
                         if (pl::core::Token::isSigned(variable.type)) {
                             i64 value = i64(hex::get_or<i128>(variable.value, 0ll));
                             if (ImGui::InputScalar(label.c_str(), ImGuiDataType_S64, &value))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = i128(value);
                         } else if (pl::core::Token::isUnsigned(variable.type)) {
                             u64 value = u64(hex::get_or<u128>(variable.value, 0));
                             if (ImGui::InputScalar(label.c_str(), ImGuiDataType_U64, &value))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = u128(value);
                         } else if (pl::core::Token::isFloatingPoint(variable.type)) {
                             auto value = hex::get_or<double>(variable.value, 0.0);
                             if (ImGui::InputScalar(label.c_str(), ImGuiDataType_Double, &value))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = value;
                         } else if (variable.type == pl::core::Token::ValueType::Boolean) {
                             ImGui::SameLine(0, ImGui::GetContentRegionAvail().x - ImGui::GetTextLineHeightWithSpacing());
                             auto value = hex::get_or<bool>(variable.value, false);
                             if (ImGui::Checkbox(label.c_str(), &value))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = value;
                         } else if (variable.type == pl::core::Token::ValueType::Character) {
                             std::array<char, 2> buffer = { hex::get_or<char>(variable.value, '\x00') };
                             if (ImGui::InputText(label.c_str(), buffer.data(), buffer.size()))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = buffer[0];
                         } else if (variable.type == pl::core::Token::ValueType::String) {
                             auto buffer = hex::get_or<std::string>(variable.value, "");
                             if (ImGui::InputText(label.c_str(), buffer))
-                                m_hasUnevaluatedChanges.get(provider) = true;
+                                m_hasUnparsedChanges.get(provider) = true;
                             variable.value = buffer;
                         }
                     }
@@ -1478,15 +1478,14 @@ namespace hex::plugin::builtin {
 
             if (m_textEditor.get(provider).isTextChanged()) {
                 m_textEditor.get(provider).setTextChanged(false);
-                m_hasUnevaluatedChanges.get(provider) = true;
+                m_hasUnparsedChanges.get(provider) = true;
                 m_lastEditorChangeTime = std::chrono::steady_clock::now();
                 ImHexApi::Provider::markDirty();
                 markPatternFileDirty(provider);
             }
 
-            if (m_hasUnevaluatedChanges.get(provider) && m_runningEvaluators == 0 && m_runningParsers == 0 &&
+            if (m_hasUnparsedChanges.get(provider) && m_runningEvaluators == 0 && m_runningParsers == 0 &&
                 (std::chrono::steady_clock::now() - m_lastEditorChangeTime) > std::chrono::seconds(1ll)) {
-                    m_changesWereParsed = false;
                     m_changesWereColored = false;
                     m_allStepsCompleted = false;
                     auto code = m_textEditor.get(provider).getText();
@@ -1507,16 +1506,16 @@ namespace hex::plugin::builtin {
                         if (m_runAutomatically)
                             m_triggerAutoEvaluate = true;
                     });
-                    m_hasUnevaluatedChanges.get(provider) = false;
+                m_hasUnparsedChanges.get(provider) = false;
             }
 
             if (m_triggerAutoEvaluate.exchange(false)) {
                 this->evaluatePattern(m_textEditor.get(provider).getText(), provider);
             }
 
-            if (m_runningHighlighters > 0 && !m_changesWereParsed)
+            if (m_runningHighlighters > 0 && (m_hasUnparsedChanges.get(provider) || m_runningParsers > 0))
                 interrupt();
-            else if (m_runningHighlighters == 0 && m_changesWereParsed && !m_changesWereColored && !m_allStepsCompleted) {
+            else if (m_runningHighlighters == 0 && !m_hasUnparsedChanges.get(provider) && m_runningParsers == 0 && !m_changesWereColored && !m_allStepsCompleted) {
                 m_identifierHighlighter.get(provider).setViewPatternEditor(this);
                 bool restoreInterruptState = false;
                 if (interrupted()) {
@@ -1712,6 +1711,8 @@ namespace hex::plugin::builtin {
                 }
                 return false;
             });
+            m_changesWereColored = false;
+            m_allStepsCompleted = false;
             m_runningParsers += 1;
             TaskManager::createBackgroundTask("hex.builtin.task.parsing_pattern", [this, code, provider](auto&) { this->parsePattern(code, provider); });
         }
@@ -1753,7 +1754,6 @@ namespace hex::plugin::builtin {
             patternVariables = std::move(oldPatternVariables);
         }
 
-        m_changesWereParsed = true;
         m_changesWereColored = false;
         m_allStepsCompleted = false;
         if (m_runningParsers != 0)
@@ -1919,7 +1919,7 @@ namespace hex::plugin::builtin {
             m_textEditor.get(provider).setText(wolv::util::preprocessText(code));
             m_textEditor.get(provider).removeHiddenLinesFromPattern();
             m_sourceCode.get(provider) = code;
-            m_hasUnevaluatedChanges.get(provider) = true;
+            m_hasUnparsedChanges.get(provider) = true;
         });
 
         ContentRegistry::Settings::onChange("hex.builtin.setting.general", "hex.builtin.setting.general.sync_pattern_source", [this](const ContentRegistry::Settings::SettingsValue &value) {
@@ -2009,7 +2009,7 @@ namespace hex::plugin::builtin {
                 m_textEditor.get(newProvider).setShowWhitespaces(m_showWhiteSpaces);
                 m_textEditor.get(newProvider).setDisableCodeFolds(m_codeFoldsDisabled);
                 m_textEditor.get(newProvider).setAutoIndent(m_autoIndent);
-                m_hasUnevaluatedChanges.get(newProvider) = true;
+                m_hasUnparsedChanges.get(newProvider) = true;
                 m_consoleEditor.get(newProvider).setText(wolv::util::combineStrings(m_console.get(newProvider), "\n"));
                 m_consoleEditor.get(newProvider).setScroll(m_consoleScroll.get(newProvider));
             }
@@ -2453,7 +2453,7 @@ namespace hex::plugin::builtin {
                 m_textEditor.get(provider).removeHiddenLinesFromPattern();
                 m_sourceCode.get(provider) = m_textEditor.get(provider).getText();
 
-                m_hasUnevaluatedChanges.get(provider) = true;
+                m_hasUnparsedChanges.get(provider) = true;
                 return true;
             },
             .store = [this](prv::Provider *provider, const std::fs::path &basePath, const Tar &tar) {

--- a/plugins/ui/include/ui/text_editor.hpp
+++ b/plugins/ui/include/ui/text_editor.hpp
@@ -19,6 +19,7 @@
 #include <hex/helpers/utils.hpp>
 #include <hex/helpers/types.hpp>
 #include <pl/core/token.hpp>
+#include <pl/core/tokens.hpp>
 #include <pl/helpers/safe_iterator.hpp>
 #include <pl/core/location.hpp>
 
@@ -218,7 +219,7 @@ namespace hex::ui {
         using Palette           = std::array<ImU32, (u64) PaletteIndex::Max>;
         using Glyph             = u8;
         using CodeFoldBlocks    = std::map<Coordinates,Coordinates>;
-        using GlobalBlocks      = std::set<Interval>;
+        using IndentBlocks      = std::set<Range>;
 
         struct Identifier { Coordinates m_location; std::string m_declaration;};
         using Identifiers   = std::unordered_map<std::string, Identifier>;
@@ -498,6 +499,7 @@ namespace hex::ui {
             bool coordinatesNearDelimiter(Lines *lines, Coordinates &from);
             i32 detectDirection(Lines *lines, const Coordinates &from);
             void findMatchingDelimiter(Lines *lines, bool folded = true);
+            Line *getLine(Lines *lines, i32 lineIndex, bool folded = true);
             Coordinates findMatchingDelimiter(Lines *lines, Coordinates &from, bool folded = true);
             [[nodiscard]] bool isActive() const { return m_active; }
             [[nodiscard]] bool hasChanged() const { return m_changed; }
@@ -736,8 +738,8 @@ namespace hex::ui {
             Interval findBlockInRange(Interval interval);
             RangeFromCoordinates getDelimiterLineNumbers(i32 start, i32 end, const std::string &delimiters);
             void nonDelimitedFolds();
-            std::pair<i32,char> findMatchingDelimiter(i32 from);
-            CodeFoldBlocks foldPointsFromSource();
+            std::pair<i32,char> findFoldDelimiters(i32 from, bool isOpenFound);
+            void tokensFromSource();
             Coordinates findCommentEndCoord(i32 tokenId);
             void skipAttribute();
             bool isTokenIdValid(i32 tokenId);
@@ -757,6 +759,7 @@ namespace hex::ui {
             void resetToTokenId(i32 &lineIndex, i32 &currentTokenId, Location &location);
             i32 findNextDelimiter(bool openOnly);
             void resetCodeFoldStates();
+            void setIndentBlocks();
 
             constexpr static u32 Normal = 0;
             constexpr static u32 Not    = 1;
@@ -855,7 +858,7 @@ namespace hex::ui {
             SafeTokenIterator m_startToken, m_originalPosition, m_partOriginalPosition;
             Indices m_firstTokenIdOfLine;
             CodeFoldBlocks m_foldPoints;
-            GlobalBlocks m_globalBlocks;
+            IndentBlocks m_indentBlocks;
             i32 m_cachedGlobalRowMax{};
             bool m_globalRowMaxChanged = true;
         };
@@ -918,6 +921,8 @@ namespace hex::ui {
         void drawButtons(float lineNumber);
         void drawText(Coordinates &lineStart, u32 tokenLength, char color);
         i64 drawColoredText(i32 lineIndex, const ImVec2 &textEditorSize);
+        void drawBlockIndicators(ImDrawList *drawList);
+        void drawMatchedDelimiter();
         void postRender(float lineNumber, std::string textWindowName);
         ImVec2 calculateCharAdvance() const;
         void openCodeFoldAt(Coordinates line);
@@ -1069,6 +1074,8 @@ namespace hex::ui {
         inline static Palette m_palette = {};
         inline static Line Ellipsis = Line({'.','.','.'},{(i32)TextEditor::PaletteIndex::Operator,(i32)TextEditor::PaletteIndex::Operator,(i32)TextEditor::PaletteIndex::Operator},{0,0,0});
         inline static const Line m_emptyLine = Line();
+        inline static const std::string s_openDelimiters = "([{<";
+        inline static const std::string s_closeDelimiters = ")]}>";
         inline static const std::string s_delimiters = "()[]{}<>";
         inline static const std::string s_separators = "()[]{}";
         inline static const std::string s_operators = "<>";
@@ -1077,6 +1084,12 @@ namespace hex::ui {
         inline static const Range NoCodeFoldSelected = Range(Invalid, Invalid);
         inline static const i32 s_cursorBlinkInterval = 1200;
         inline static const i32 s_cursorBlinkOnTime = 800;
+        inline static std::map<char, std::pair<Token, Token>> s_delimiterTokens = {
+                {'{', {pl::core::tkn::Separator::LeftBrace, pl::core::tkn::Separator::RightBrace}},
+                {'[', {pl::core::tkn::Separator::LeftBracket, pl::core::tkn::Separator::RightBracket}},
+                {'(', {pl::core::tkn::Separator::LeftParenthesis, pl::core::tkn::Separator::RightParenthesis}},
+                {'<', {pl::core::tkn::Operator::BoolLessThan, pl::core::tkn::Operator::BoolGreaterThan}}
+        };
     };
 
     bool tokenizeCStyleString(strConstIter in_begin, strConstIter in_end, strConstIter &out_begin, strConstIter &out_end);

--- a/plugins/ui/source/ui/text_editor/codeFolder.cpp
+++ b/plugins/ui/source/ui/text_editor/codeFolder.cpp
@@ -166,45 +166,33 @@ namespace hex::ui {
 
     RangeFromCoordinates Lines::getDelimiterLineNumbers(i32 start, i32 end, const std::string &delimiters) {
         RangeFromCoordinates result = {Invalid, Invalid};
-        Coordinates first = Invalid;
+        Coordinates first;
         auto tokenStart = SafeTokenIterator(m_tokens.begin(), m_tokens.end());
-        m_curr = tokenStart + start;
-        Token::Separator openSeparator = Token::Separator::EndOfProgram;
-        Token::Separator closeSeparator = Token::Separator::EndOfProgram;
-        Token::Operator openOperator  = Token::Operator{};
-        Token::Operator closeOperator = Token::Operator{};
-        if (delimiters == "{}") {
-            openSeparator = Token::Separator::LeftBrace;
-            closeSeparator = Token::Separator::RightBrace;
-        } else if (delimiters == "[]") {
-            openSeparator = Token::Separator::LeftBracket;
-            closeSeparator = Token::Separator::RightBracket;
-        } else if (delimiters == "()") {
-            openSeparator = Token::Separator::LeftParenthesis;
-            closeSeparator = Token::Separator::RightParenthesis;
-        } else if (delimiters == "<>") {
-            openOperator = Token::Operator::BoolLessThan;
-            closeOperator = Token::Operator::BoolGreaterThan;
-        }
 
-        Token::Separator *separator;
-        if (separator = const_cast<Token::Separator *>(getValue<Token::Separator>(0)); separator == nullptr || *separator != openSeparator) {
-            if (const auto *opener = const_cast<Token::Operator *>(getValue<Token::Operator>(0)); opener == nullptr || *opener != openOperator)
-                return result;
-        }
+        if (delimiters.empty() || !s_openDelimiters.contains(delimiters[0]) || (delimiters.size() > 1 && !s_closeDelimiters.contains(delimiters[1])))
+            return result;
+        m_curr = tokenStart + start;
+        const Token openDelimiter = s_delimiterTokens[delimiters[0]].first;
+        const Token closeDelimiter = s_delimiterTokens[delimiters[0]].second;
+
+        if (!peek(openDelimiter))
+            return result;
+
         if (!m_curr->location.source->mainSource)
             return result;
         if (start > 0) {
             Location location1 = m_curr->location;
             Location location2;
-            auto save = m_curr;
-            while (peek(tkn::Literal::Comment, -1) || peek(tkn::Literal::DocComment, -1)) {
-                if (getTokenId() == 0)
-                    break;
-                next(-1);
-            }
-            next(-1);
-            if (separator != nullptr && *separator == Token::Separator::LeftParenthesis) {
+            if (openDelimiter.value == tkn::Separator::LeftParenthesis.value) {
+                auto save = m_curr;
+                while (peek(tkn::Literal::Comment, -1) || peek(tkn::Literal::DocComment, -1)) {
+                    if (getTokenId() == 0)
+                        break;
+                    next(-1);
+                }
+                if (getTokenId() > 0)
+                    next(-1);
+
                 if (const auto *separator2 = const_cast<Token::Separator *>(getValue<Token::Separator>(0)); separator2 != nullptr && (*separator2 == Token::Separator::Semicolon || *separator2 == Token::Separator::LeftBrace || *separator2 == Token::Separator::RightBrace)) {
                     m_curr = save;
                     location2 = m_curr->location;
@@ -212,10 +200,9 @@ namespace hex::ui {
                     location2 = m_curr->location;
                     m_curr = save;
                 }
-            } else {
+            } else
                 location2 = m_curr->location;
-                m_curr = save;
-            }
+
             if (location1.line != location2.line) {
                 Coordinates coord(location2);
                 first = coord + Coordinates(0, location2.length);
@@ -224,15 +211,8 @@ namespace hex::ui {
         } else
             first = Coordinates(m_curr->location);
         m_curr = tokenStart + end;
-        if (separator = const_cast<Token::Separator *>(getValue<Token::Separator>(0)); separator == nullptr || *separator != closeSeparator) {
-            if (const auto *closer = const_cast<Token::Operator *>(getValue<Token::Operator>(0)); closer == nullptr || *closer != closeOperator) {
-                if (const auto *separator2 = const_cast<Token::Separator *>(getValue<Token::Separator>(1)); separator2 != nullptr && *separator2 == closeSeparator) {
-                    next();
-                } else if (const auto *closer2 = const_cast<Token::Operator *>(getValue<Token::Operator>(1)); closer2 != nullptr && *closer2 == closeOperator) {
-                    next();
-                } else
-                    return result;
-            }
+        if (!peek(closeDelimiter) && !peek(tkn::Separator::EndOfProgram)) {
+             return result;
         }
         if (!m_curr->location.source->mainSource)
             return result;
@@ -302,88 +282,25 @@ namespace hex::ui {
         return getTokenId();
     }
 
-    CodeFoldBlocks Lines::foldPointsFromSource() {
+    void Lines::tokensFromSource() {
+
         auto code = getText();
         if (code.empty())
-            return m_foldPoints;
+            return;
         std::unique_ptr<pl::PatternLanguage> runtime = std::make_unique<pl::PatternLanguage>();
         ContentRegistry::PatternLanguage::configureRuntime(*runtime, nullptr);
         std::ignore = runtime->preprocessString(code, pl::api::Source::DefaultSource);
         m_tokens = runtime->getInternals().preprocessor->getResult();
         const u32 tokenCount = m_tokens.size();
         if (tokenCount == 0)
-            return m_foldPoints;
+            return;
+        m_startToken = SafeTokenIterator(m_tokens.begin(), m_tokens.end());
         loadFirstTokenIdOfLine();
         if (m_firstTokenIdOfLine.empty())
-            return m_foldPoints;
-        m_foldPoints.clear();
-        nonDelimitedFolds();
-        std::string openDelimiters = "{[(<";
-        size_t topLine = 0;
-        m_startToken = SafeTokenIterator(m_tokens.begin(), m_tokens.end());
-        m_curr = m_startToken;
-        auto location = m_curr->location;
-        i32 lineIndex = topLine;
-        i32 currentTokenId = 0;
-        while (currentTokenId < (i32) tokenCount) {
-
-            if (currentTokenId = findNextDelimiter(true); !peek(tkn::Separator::EndOfProgram)) {
-                if (currentTokenId < 0) {
-                    return m_foldPoints;
-                }
-                auto line = operator[](m_curr->location.line - 1);
-                size_t stringIndex = line.columnIndex(m_curr->location.column);
-                std::string openDelimiter = std::string(1, line[static_cast<u64>(stringIndex - 1)]);
-                location = m_curr->location;
-
-                if (auto idx = openDelimiters.find(openDelimiter); idx != std::string::npos) {
-                    if (idx == 3) {
-                        if (currentTokenId == 0) {
-                            return m_foldPoints;
-                        }
-                        next(-1);
-                        auto column = m_curr[0].location.column - 1;
-                        if (line.m_colors[column] != (char) PaletteIndex::UserDefinedType) {
-                            next(2);
-                            if (peek(tkn::Separator::EndOfProgram, -1)) {
-                                return m_foldPoints;
-                            }
-
-                            if (currentTokenId = getTokenId(); currentTokenId < 0) {
-                                return m_foldPoints;
-                            }
-                            resetToTokenId(lineIndex, currentTokenId, location);
-                            continue;
-                        }
-                    }
-                    auto start = currentTokenId;
-                    auto end = findMatchingDelimiter(currentTokenId);
-                    if (end.first < 0) {
-                        return m_foldPoints;
-                    }
-                    std::string value = openDelimiter + end.second;
-                    auto lineBased = getDelimiterLineNumbers(start, end.first, value);
-
-                    if (lineBased.first.getLine() != lineBased.second.getLine())
-                        m_foldPoints[lineBased.first] = lineBased.second;
-
-                    if (currentTokenId = getTokenId(m_startToken + end.first); currentTokenId < 0 || currentTokenId >= (i32) m_tokens.size()) {
-                        return m_foldPoints;
-                    }
-                    incrementTokenId(lineIndex, currentTokenId, location);
-                } else {
-                    return m_foldPoints;
-                }
-            } else {
-                return m_foldPoints;
-            }
-        }
-        return m_foldPoints;
+            return;
     }
 
-
-    std::pair<i32, char> Lines::findMatchingDelimiter(i32 from) {
-        std::string blockDelimiters = "{}[]()<>";
+    std::pair<i32, char> Lines::findFoldDelimiters(i32 from, bool isOpenFound) {
         std::pair<i32, char> result = std::make_pair(-1, '\0');
         auto tokenStart = SafeTokenIterator(m_tokens.begin(), m_tokens.end());
         const i32 tokenCount = m_tokens.size();
@@ -391,63 +308,78 @@ namespace hex::ui {
             return result;
         m_curr = tokenStart + from;
         Location location = m_curr->location;
-        auto line = operator[](location.line - 1);
-        std::string openDelimiter;
-        if (auto columnIndex = line.m_chars.find_first_of(blockDelimiters, location.column - 1); columnIndex != std::string::npos)
-            openDelimiter = line[static_cast<u64>(columnIndex)];
-        else
-            return result;
-
-        i32 currentTokenId = from + 1;
-        std::string closeDelimiter;
-        if (size_t idx = blockDelimiters.find(openDelimiter); idx != std::string::npos && currentTokenId < (i32) m_tokens.size())
-            closeDelimiter = blockDelimiters[idx + 1];
-        else
-            return result;
-        m_curr = tokenStart + currentTokenId;
-        location = m_curr->location;
         i32 lineIndex = location.line - 1;
-        while (currentTokenId < tokenCount) {
+        std::string delimiters, openDelimiter, closeDelimiter;
+        i32 currentTokenId = from;
+        auto line = operator[](lineIndex);
+        if (isOpenFound) {
+            delimiters = s_openDelimiters + s_closeDelimiters;
+            if (auto columnIndex = line.m_chars.find_first_of(s_delimiters, location.column - 1); columnIndex != std::string::npos) {
+                openDelimiter = line[static_cast<u64>(columnIndex)];
+                if (size_t idx = s_delimiters.find(openDelimiter); idx != std::string::npos && currentTokenId < (i32) m_tokens.size())
+                    closeDelimiter = s_delimiters[idx + 1];
+                else
+                    return result;
+            } else
+                return result;
+            currentTokenId++;
+            next();
+            lineIndex = m_curr->location.line - 1;
+        } else
+            delimiters = s_openDelimiters;
 
-            if (currentTokenId = findNextDelimiter(false); !peek(tkn::Separator::EndOfProgram)) {
+        while (currentTokenId < tokenCount) {
+            if (currentTokenId = findNextDelimiter(!isOpenFound); !peek(tkn::Separator::EndOfProgram)) {
                 if (currentTokenId < 0) {
                     return result;
                 }
                 line = operator[](m_curr->location.line - 1);
-                std::string currentChar = std::string(1, line[(u64)(m_curr->location.column - 1)]);
+                size_t stringIndex = line.columnIndex(m_curr->location.column);
+                std::string currentChar = std::string(1, line[static_cast<u64>(stringIndex - 1)]);
                 location = m_curr->location;
 
-                if (auto idx = blockDelimiters.find(currentChar); idx != std::string::npos) {
-                    if (currentChar == closeDelimiter) {
+                if (auto idx = delimiters.find(currentChar); idx != std::string::npos) {
+                    if (isOpenFound && currentChar == closeDelimiter) {
                         return std::make_pair(currentTokenId, closeDelimiter[0]);
                     } else {
-                        if (idx == 6 || idx == 7) {
+                        if (idx == 3 || (isOpenFound && idx == 7)) {
+                            if (currentTokenId == 0) {
+                                return result;
+                            }
                             next(-1);
-                            if (const auto *identifier = const_cast<Token::Identifier *>(getValue<Token::Identifier>(0));
-                                    ((idx == 6) && (identifier == nullptr || identifier->getType() != Token::Identifier::IdentifierType::UDT)) || (idx == 7)) {
+                            auto column = m_curr[0].location.column - 1;
+                            if (line.m_colors[column] != (char) PaletteIndex::UserDefinedType) {
                                 next(2);
                                 if (peek(tkn::Separator::EndOfProgram, -1)) {
                                     return result;
                                 }
 
-                                if (currentTokenId = getTokenId(); currentTokenId < 0)
+                                if (currentTokenId = getTokenId(); currentTokenId < 0) {
                                     return result;
-
+                                }
                                 resetToTokenId(lineIndex, currentTokenId, location);
                                 continue;
                             }
                         }
-                        if (idx % 2 == 0) {
+                        if (idx < 4) {
                             auto start = currentTokenId;
-                            auto end = findMatchingDelimiter(currentTokenId);
-                            if (end.first < 0)
-                                return result;
-                            std::string value = currentChar + end.second;
-                            auto lineBased = getDelimiterLineNumbers(start, end.first, value);
+                            auto end = findFoldDelimiters(currentTokenId, true);
+                            std::string value;
+                            std::pair<Coordinates, Coordinates> lineBased;
+                            i64 currTokenId;
+                            if (end.first < 0) {
+                                value = currentChar;
+                                lineBased = getDelimiterLineNumbers(start, tokenCount - 1, value);
+                                currTokenId = start;
+                            } else {
+                                value = currentChar + end.second;
+                                lineBased = getDelimiterLineNumbers(start, end.first, value);
+                                currTokenId = end.first;
+                            }
                             if (lineBased.first.getLine() != lineBased.second.getLine())
                                 m_foldPoints[lineBased.first] = lineBased.second;
 
-                            if (currentTokenId = getTokenId(tokenStart + end.first); currentTokenId < 0 || currentTokenId >= (i32) m_tokens.size())
+                            if (currentTokenId = getTokenId(tokenStart + currTokenId); currentTokenId < 0 || currentTokenId >= (i32) m_tokens.size())
                                 return result;
 
                             incrementTokenId(lineIndex, currentTokenId, location);
@@ -862,5 +794,54 @@ namespace hex::ui {
         if (id+index < 0 || id+index >= (i32)m_tokens.size())
             return false;
         return m_curr[index].type == token.type && m_curr[index] == token.value;
+    }
+
+    void Lines::setIndentBlocks() {
+        m_indentBlocks.clear();
+        m_indentBlocks.insert(Range(lineCoordinates(0, 0), lineCoordinates(size() - 1, m_unfoldedLines.back().size())));
+        for (auto interval : m_foldPoints) {
+            Range foldInterval(interval);
+            m_indentBlocks.insert(foldInterval);
+        }
+    }
+
+    void Lines::setAllCodeFolds() {
+        initializeCodeFolds();
+        tokensFromSource();
+        m_foldPoints.clear();
+        findFoldDelimiters(0, false);
+        setIndentBlocks();
+        nonDelimitedFolds();
+        m_codeFoldKeys.clear();
+        m_codeFolds.clear();
+        m_codeFoldKeyMap.clear();
+        m_codeFoldValueMap.clear();
+        m_codeFoldKeyLineMap.clear();
+        m_codeFoldValueLineMap.clear();
+        m_codeFoldDelimiters.clear();
+        m_indentBlocks.clear();
+        m_indentBlocks.insert(Range(lineCoordinates(0, 0), lineCoordinates(size() - 1, m_unfoldedLines.back().size())));
+        for (auto interval: m_foldPoints) {
+            Range foldInterval(interval);
+            m_indentBlocks.insert(foldInterval);
+            if (foldInterval.m_start.m_line > size() || foldInterval.m_end.m_line > size())
+                return;
+            std::pair<char, char> foldDelimiters = {};
+            foldDelimiters.second = m_unfoldedLines[foldInterval.m_end.m_line].m_chars[foldInterval.m_end.m_column];
+            if (foldDelimiters.second == '\0')
+                continue;
+            if (foldDelimiters.second == '/')
+                foldDelimiters.first = foldDelimiters.second;
+            else
+                foldDelimiters.first = foldDelimiters.second - 2 + (foldDelimiters.second == ')');
+            m_codeFoldKeys.insert(foldInterval);
+            m_codeFoldDelimiters[foldInterval] = foldDelimiters;
+            if (!m_codeFoldKeyMap.contains(foldInterval.m_start))
+                m_codeFoldKeyMap[foldInterval.m_start] = foldInterval.m_end;
+            if (!m_codeFoldValueMap.contains(foldInterval.m_end))
+                m_codeFoldValueMap[foldInterval.m_end] = foldInterval.m_start;
+            m_codeFoldKeyLineMap.insert(std::make_pair(foldInterval.m_start.m_line, foldInterval.m_start));
+            m_codeFoldValueLineMap.insert(std::make_pair(foldInterval.m_end.m_line, foldInterval.m_end));
+        }
     }
 }

--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -614,7 +614,7 @@ namespace hex::ui {
 
     u32 Line::skipSpaces(i32 charIndex) {
         u32 s;
-        for (s = 0; charIndex < (i32) m_chars.size() && m_chars[charIndex] == ' ' && m_flags[charIndex] == 0x00; ++s, ++charIndex);
+        for (s = 0; charIndex < (i32) m_chars.size() && m_chars[charIndex] == ' ' && (m_flags[charIndex] & ~(static_cast<u8>(FlagValues::Preprocessor) >> 1))== 0x00; ++s, ++charIndex);
         return s;
     }
 
@@ -666,8 +666,8 @@ namespace hex::ui {
 
     i32 MatchedDelimiter::detectDirection(Lines *lines, const Coordinates &from) {
         auto start = lines->lineCoordinates(from);
-        std::string delimiters = "()[]{}<>";
-        i32 result = -2; // dont check either
+
+        i32 result = -2; // don't check either previous or current char
 
         if (start == Invalid)
             return result;
@@ -675,26 +675,27 @@ namespace hex::ui {
         auto line = lines->m_unfoldedLines[lineIndex].m_chars;
         auto charIndex = lines->lineCoordsIndex(start);
         auto ch2 = line[charIndex];
-        auto idx2 = delimiters.find(ch2);
-        if (charIndex == 0) {// no previous character
-            if (idx2 == std::string::npos) // no delimiters
+        auto idx2 = s_delimiters.find(ch2);
+        if (charIndex == 0) {// no previous character on same line
+            if (idx2 == std::string::npos) // no delimiters found
                 return -2;// dont check either
             else
-                return 1; // check only current
-        }// charIndex > 0
+                return 1; // check only current char
+        }
+        // cursor is not at first char in line.
         auto ch1 = line[charIndex - 1];
-        auto idx1 = delimiters.find(ch1);
+        auto idx1 = s_delimiters.find(ch1);
         if (idx1 == std::string::npos && idx2 == std::string::npos) // no delimiters
             return -2;
-        if (idx1 != std::string::npos && idx2 != std::string::npos) {
+        if (idx1 != std::string::npos && idx2 != std::string::npos) { //two delimiters detected
             if (idx1 % 2) // closing delimiter + any delimiter
-                return -1; // check both and previous first
+                return -1; // check both directions, but check previous char first
             else if (!(idx1 % 2) && !(idx2 % 2)) // opening delimiter + opening delimiter
-                return 0; // check both and current first
+                return 0; // check both directions,  but current char first
         } else if (idx1 != std::string::npos) // only first delimiter
-            return 1; // check only previous
+            return 1; // check only previous char
         else  // only second delimiter
-            return 2; // check only current
+            return 2; // check only current char
 
         return result;
     }
@@ -771,6 +772,13 @@ namespace hex::ui {
         return false;
     }
 
+    Line *MatchedDelimiter::getLine(Lines *lines, i32 lineIndex, bool folded) {
+        if (folded)
+            return &lines->operator[](lineIndex);
+
+        return &lines->m_unfoldedLines[lineIndex];
+    }
+
     Coordinates MatchedDelimiter::findMatchingDelimiter(Lines *lines, Coordinates &from, bool folded) {
         Coordinates start;
         Coordinates result = Invalid;
@@ -787,23 +795,9 @@ namespace hex::ui {
         auto row = lines->lineIndexToRow(lineIndex);
         auto maxLineIndex = lines->size() - 1;
         auto charIndex = lines->lineCoordsIndex(start);
-        std::string line;
-        std::string colors;
-        if (!folded) {
-            line = lines->m_unfoldedLines[lineIndex].m_chars;
-            colors = lines->m_unfoldedLines[lineIndex].m_colors;
-        } else {
-            line = lines->operator[](lineIndex).m_chars;
-            colors = lines->operator[](lineIndex).m_colors;
-        }
-        if (!line.empty() && colors.empty()) {
-            m_active = false;
-            return Invalid;
-        }
-        std::string delimiters = "()[]{}<>";
-        char delimiterChar = line[charIndex];
-        char color1;
-        auto idx = delimiters.find_first_of(delimiterChar);
+        Line *line = getLine(lines, lineIndex, folded);
+
+        auto idx = s_delimiters.find_first_of(line->m_chars[charIndex]);
         if (idx == std::string::npos) {
             if (m_active) {
                 m_active = false;
@@ -811,76 +805,105 @@ namespace hex::ui {
             }
             return Invalid;
         }
-        auto delimiterChar2 = delimiters[idx ^ 1];
-        delimiters = delimiterChar;
-        delimiters += delimiterChar2;
-        i32 direction = 1 - 2 * (idx % 2);
-        if (idx > 5)
+
+        std::string auxiliaryDelimiters, delimiters = std::string(1,s_delimiters[idx ^ 1]);
+        delimiters += s_delimiters[idx];
+        i32 direction = 1 - ((idx & 1) << 1);
+        i32 auxDepth = 0;
+        char color1, auxColor;
+        bool firstTimeAux = false;
+        bool useIdx = false;
+        if (idx > 5) {
+            auxiliaryDelimiters += s_delimiters[(idx - 6) ^ 1];
+            auxiliaryDelimiters += s_delimiters[idx - 6];
+            firstTimeAux = true;
             color1 = static_cast<char>(PaletteIndex::Operator);
-        else
+            auxColor = static_cast<char>(PaletteIndex::Separator);
+        } else
             color1 = static_cast<char>(PaletteIndex::Separator);
         char color = static_cast<char>(PaletteIndex::WarningText);
+        u64 auxIdx;
         i32 depth = 1;
-        if (charIndex == (i64) (line.size() - 1) * (1 + direction) / 2) {
-            if (row + direction < 0 || lines->rowToLineIndex(row + direction) > (i64) maxLineIndex) {
-                m_active = false;
-                return Invalid;
-            }
-            if (!folded) {
-                if (lineIndex += direction; lineIndex < 0 || lineIndex > (i64) maxLineIndex) {
-                    m_active = false;
-                    return Invalid;
-                }
-            } else {
+        if (charIndex == (i64) (line->size() - 1) * ((1 + direction) >> 1)) {
+
+            if (folded) {
                 row += direction;
-                if(lineIndex = lines->rowToLineIndex(row); lineIndex <0 || lineIndex > (i64) maxLineIndex) {
-                    m_active = false;
-                    return Invalid;
-                }
-            }
-            if (!folded) {
-                line = lines->m_unfoldedLines[lineIndex].m_chars;
-                colors = lines->m_unfoldedLines[lineIndex].m_colors;
-            } else {
-                line = lines->operator[](lineIndex).m_chars;
-                colors = lines->operator[](lineIndex).m_colors;
-            }
-            if (!line.empty() && colors.empty()) {
+                lineIndex = lines->rowToLineIndex(row);
+            } else
+                lineIndex += direction;
+
+            if (row < 0 ||lineIndex < 0 || lineIndex > (i64) maxLineIndex) {
                 m_active = false;
                 return Invalid;
             }
-            charIndex = (line.size() - 1) * (1 - direction) / 2 - direction;
+
+            line = getLine(lines, lineIndex, folded);
+
+            charIndex = (line->size() - 1) * ((1 - direction) >> 1) - direction;
         }
         for (i32 i = charIndex + direction;; i += direction) {
-            if (direction == 1)
-                idx = line.find_first_of(delimiters, i);
-            else
-                idx = line.find_last_of(delimiters, i);
-            if (idx != std::string::npos) {
-                if (line[idx] == delimiterChar && (colors[idx] == color || colors[idx] == color1)) {
-                    ++depth;
-                    i = idx;
-                } else if ((line[idx] == delimiterChar2 && (colors[idx] == color)) || colors[idx] == color1) {
-                    --depth;
-                    if (depth == 0) {
+            if (auxDepth > 0 || firstTimeAux) {
+                if (direction == 1) {
+                    auxIdx = line->m_chars.find_first_of(auxiliaryDelimiters, i);
+                    if (firstTimeAux) {
+                        idx = line->m_chars.find_first_of(delimiters, i);
+                        if (idx < auxIdx)
+                            useIdx = true;
+                        firstTimeAux = false;
+                    }
+                } else {
+                    auxIdx = line->m_chars.find_last_of(auxiliaryDelimiters, i);
+                    if (firstTimeAux) {
+                        idx = line->m_chars.find_last_of(delimiters, i);
+                        if (idx > auxIdx)
+                            useIdx = true;
+                        firstTimeAux = false;
+                    }
+                }
+            } else
+                auxIdx = std::string::npos;
+
+            if (!useIdx && auxIdx != std::string::npos) {
+                if (line->m_chars[auxIdx] == auxiliaryDelimiters[1] && (line->m_colors[auxIdx] == color || line->m_colors[auxIdx] == auxColor)) {
+                    ++auxDepth;
+                    i = auxIdx;
+                } else if (line->m_chars[auxIdx] == auxiliaryDelimiters[0] && (line->m_colors[auxIdx] == color || line->m_colors[auxIdx] == auxColor)) {
+                    --auxDepth;
+                    if (auxDepth >= 0)
+                        i = auxIdx;
+                }
+            } else {
+                if (!useIdx) {
+                    if (direction == 1)
+                        idx = line->m_chars.find_first_of(delimiters, i);
+                    else
+                        idx = line->m_chars.find_last_of(delimiters, i);
+                } else
+                    useIdx = false;
+
+                if (idx != std::string::npos) {
+                    if (line->m_chars[idx] == delimiters[1] && (line->m_colors[idx] == color || line->m_colors[idx] == color1)) {
+                        ++depth;
+                        i = idx;
+                    } else if (line->m_chars[idx] == delimiters[0] && (line->m_colors[idx] == color || line->m_colors[idx] == color1)) {
+                        --depth;
+                        if (depth == 0) {
                             if (!folded)
                                 result = lines->lineIndexCoords(lineIndex + 1, idx);
                             else
-                                result = lines->foldedToUnfoldedCoords( lines->lineIndexCoords(lineIndex + 1, idx));
-                        m_active = true;
-                        break;
+                                result = lines->foldedToUnfoldedCoords(lines->lineIndexCoords(lineIndex + 1, idx));
+                            m_active = true;
+                            break;
+                        }
+                        i = idx;
+                    } else {
+                        i = idx;
                     }
-                    i = idx;
                 } else {
-                    i = idx;
+                    i = (line->size() - 1) * ((1 + direction) >> 1);
                 }
-            } else {
-                if (direction == 1)
-                    i = line.size() - 1;
-                else
-                    i = 0;
             }
-            if ((direction * i) >= (i32) ((line.size() - 1) * (1 + direction) / 2)) {
+            if ((direction * i) >= (i32) ((line->size() - 1) * ((1 + direction) >> 1))) {
                 if (lines->rowToLineIndex(row) == (i64) maxLineIndex * ((1 + direction) >> 1)) {
                     if (m_active) {
                         m_active = false;
@@ -901,18 +924,10 @@ namespace hex::ui {
                         }
                         return Invalid;
                     }
-                    if (!folded) {
-                        line = lines->m_unfoldedLines[lineIndex].m_chars;
-                        colors = lines->m_unfoldedLines[lineIndex].m_colors;
-                    } else {
-                         line = lines->operator[](lineIndex).m_chars;
-                         colors = lines->operator[](lineIndex).m_colors;
-                    }
-                    if (!line.empty() && colors.empty()) {
-                        m_active = false;
-                        return Invalid;
-                    }
-                    i = (line.size() - 1) * (1 - direction) / 2 - direction;
+
+                    line = getLine(lines, lineIndex, folded);
+
+                    i = (line->size() - 1) * ((1 - direction) >> 1) - direction;
                 }
             }
         }
@@ -925,16 +940,22 @@ namespace hex::ui {
         Coordinates result = findMatchingDelimiter(lines, from, folded);
         if (result != Invalid) {
             if (result != m_matched || hasChanged()) {
-                m_matched = result;
-                auto linesSize = (i32) lines->m_unfoldedLines.size();
-                auto matchedline = m_matched.m_line;
-                auto nearline = m_nearCursor.m_line;
-                if (matchedline < 0 || matchedline >= linesSize || nearline < 0 || nearline >= linesSize) {
+                from = result;
+                Coordinates nearCursor = findMatchingDelimiter(lines, from, folded);
+                if (nearCursor != m_nearCursor) {
                     m_active = false;
                     return;
                 }
-                i32 matchedLineSize = lines->m_unfoldedLines[matchedline].size();
-                i32 nearLineSize = lines->m_unfoldedLines[nearline].size();
+                m_matched = result;
+                auto linesSize = (i32) lines->m_unfoldedLines.size();
+                auto matchedLine = m_matched.m_line;
+                auto nearLine = m_nearCursor.m_line;
+                if (matchedLine < 0 || matchedLine >= linesSize || nearLine < 0 || nearLine >= linesSize) {
+                    m_active = false;
+                    return;
+                }
+                i32 matchedLineSize = lines->m_unfoldedLines[matchedLine].size();
+                i32 nearLineSize = lines->m_unfoldedLines[nearLine].size();
                 auto matchedColumn = m_matched.m_column;
                 auto nearColumn = m_nearCursor.m_column;
                 if (matchedColumn < 0 || matchedColumn >= matchedLineSize || nearColumn < 0 || nearColumn >= nearLineSize) {

--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -810,7 +810,8 @@ namespace hex::ui {
         delimiters += s_delimiters[idx];
         i32 direction = 1 - ((idx & 1) << 1);
         i32 auxDepth = 0;
-        char color1, auxColor;
+
+        char color1, auxColor = static_cast<char>(PaletteIndex::Separator);
         bool firstTimeAux = false;
         bool useIdx = false;
         if (idx > 5) {
@@ -818,7 +819,6 @@ namespace hex::ui {
             auxiliaryDelimiters += s_delimiters[idx - 6];
             firstTimeAux = true;
             color1 = static_cast<char>(PaletteIndex::Operator);
-            auxColor = static_cast<char>(PaletteIndex::Separator);
         } else
             color1 = static_cast<char>(PaletteIndex::Separator);
         char color = static_cast<char>(PaletteIndex::WarningText);

--- a/plugins/ui/source/ui/text_editor/render.cpp
+++ b/plugins/ui/source/ui/text_editor/render.cpp
@@ -1197,6 +1197,9 @@ namespace hex::ui {
                     if (!m_lines.m_codeFoldsDisabled)
                         drawCodeFolds(lineIndex, drawList);
 
+                    drawBlockIndicators(drawList);
+                    drawMatchedDelimiter();
+
                     if (!m_lines.m_ignoreImGuiChild) {
                         ImGui::EndChild();
                         ImGui::BeginChild(m_lines.m_title.c_str());
@@ -1788,20 +1791,28 @@ namespace hex::ui {
 
         renderCodeFolds(row, drawList, lineColor, state);
 
-        if (m_lines.m_matchedDelimiter.setNearCursor(&m_lines, m_lines.m_state.m_cursorPosition)) {
-            m_lines.m_matchedDelimiter.findMatchingDelimiter(&m_lines);
-            if (m_lines.isTrueMatchingDelimiter()) {
-                auto nearCursorScreenPos = m_lines.getLineStartScreenPos(0, lineIndexToRow(m_lines.m_matchedDelimiter.m_nearCursor.m_line));
-                auto matchedScreenPos = m_lines.getLineStartScreenPos(0, lineIndexToRow(m_lines.m_matchedDelimiter.m_matched.m_line));
+    }
 
-                if (nearCursorScreenPos != ImVec2(-1, -1) && matchedScreenPos != ImVec2(-1, -1) && nearCursorScreenPos.y != matchedScreenPos.y) {
+    void TextEditor::drawBlockIndicators(ImDrawList *drawList) {
+        for (auto &range: m_lines.m_indentBlocks) {
+            if (range.contains(m_lines.m_state.m_cursorPosition)) {
+                auto blockStartScreenPos = m_lines.getLineStartScreenPos(0, lineIndexToRow(range.m_start.m_line));
+                auto blockEndScreenPos = m_lines.getLineStartScreenPos(0, lineIndexToRow(range.m_end.m_line));
+
+                if (blockStartScreenPos != ImVec2(-1, -1) && blockEndScreenPos != ImVec2(-1, -1)) {
                     float lineX = m_lines.m_lineNumbersStartPos.x + m_lines.m_lineNumberFieldWidth - m_lines.m_charAdvance.x + 1_scaled;
-                    ImVec2 p1 = ImVec2(lineX, std::min(matchedScreenPos.y, nearCursorScreenPos.y));
-                    ImVec2 p2 = ImVec2(lineX, std::max(matchedScreenPos.y, nearCursorScreenPos.y) + m_lines.m_charAdvance.y - 1_scaled);
+                    ImVec2 p1 = ImVec2(lineX, std::min(blockStartScreenPos.y, blockEndScreenPos.y));
+                    ImVec2 p2 = ImVec2(lineX, std::max(blockStartScreenPos.y, blockEndScreenPos.y) + m_lines.m_charAdvance.y - 1_scaled);
                     drawList->AddLine(p1, p2, ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered]), 1.0f);
                 }
+                break;
             }
         }
+    }
+
+    void TextEditor::drawMatchedDelimiter() {
+        if (m_lines.m_matchedDelimiter.setNearCursor(&m_lines, m_lines.m_state.m_cursorPosition))
+            m_lines.m_matchedDelimiter.findMatchingDelimiter(&m_lines);
     }
 
     void TextEditor::renderCodeFolds(i32 row, ImDrawList *drawList, i32 color, FoldSymbol state) {

--- a/plugins/ui/source/ui/text_editor/support.cpp
+++ b/plugins/ui/source/ui/text_editor/support.cpp
@@ -1267,48 +1267,6 @@ namespace hex::ui {
         return m_lines.size();
     }
 
-    void Lines::setAllCodeFolds() {
-        initializeCodeFolds();
-        CodeFoldBlocks intervals = foldPointsFromSource();
-        m_codeFoldKeys.clear();
-        m_codeFolds.clear();
-        m_codeFoldKeyMap.clear();
-        m_codeFoldValueMap.clear();
-        m_codeFoldKeyLineMap.clear();
-        m_codeFoldValueLineMap.clear();
-        m_codeFoldDelimiters.clear();
-        for (auto interval : intervals) {
-            Range foldInterval(interval);
-            if (foldInterval.m_start.m_line > size() || foldInterval.m_end.m_line > size())
-                return;
-            std::pair<char,char> foldDelimiters = {};
-            foldDelimiters.second = m_unfoldedLines[foldInterval.m_end.m_line].m_chars[foldInterval.m_end.m_column];
-            if (foldDelimiters.second == '/')
-                foldDelimiters.first = foldDelimiters.second;
-            else
-                foldDelimiters.first = foldDelimiters.second - 2 + (foldDelimiters.second == ')');
-            m_codeFoldKeys.insert(foldInterval);
-            m_codeFoldDelimiters[foldInterval] = foldDelimiters;
-            if (!m_codeFoldKeyMap.contains(foldInterval.m_start))
-                m_codeFoldKeyMap[foldInterval.m_start] = foldInterval.m_end;
-            if (!m_codeFoldValueMap.contains(foldInterval.m_end))
-                m_codeFoldValueMap[foldInterval.m_end] = foldInterval.m_start;
-            m_codeFoldKeyLineMap.insert(std::make_pair(foldInterval.m_start.m_line,foldInterval.m_start));
-            m_codeFoldValueLineMap.insert(std::make_pair(foldInterval.m_end.m_line,foldInterval.m_end));
-        }
-
-        std::vector<Range> deactivated = getDeactivatedBlocks();
-        for (auto interval : deactivated) {
-            m_codeFoldKeys.insert(interval);
-            if (!m_codeFoldKeyMap.contains(interval.m_start))
-                m_codeFoldKeyMap[interval.m_start] = interval.m_end;
-            if (!m_codeFoldValueMap.contains(interval.m_end))
-                m_codeFoldValueMap[interval.m_end] = interval.m_start;
-            m_codeFoldKeyLineMap.insert(std::make_pair(interval.m_start.m_line,interval.m_start));
-            m_codeFoldValueLineMap.insert(std::make_pair(interval.m_end.m_line,interval.m_end));
-        }
-    }
-
     void Lines::removeHiddenLinesFromPattern() {
         i32 lineIndex = 0;
         const auto totalLines = (i32)m_unfoldedLines.size();


### PR DESCRIPTION
fixes issue #2758. Problem was caused by the improper parsing of the template arguments during the association of the variable type with the variable name. The fix uses the fact that template arguments containing comparison or shift operators must be enclosed with parentheses to avoid syntactic ambiguity, so when parentheses are detected they are used to skip parsing of what they surround. There was a lot of code duplication in the code that looked for matching delimiter which was removed and the detection and handling of the separate delimiter pairs was simplified greatly.

During the time it took to create this PR other problems in the pattern editor were discovered and their fixes are also included.
* The matching delimiter for templates was also set incorrectly when operators that could cause syntactic ambiguity were used.
* The block identification line was drawn when cursor was near the block delimiters instead of anywhere within the block. The code blocks are slightly different from code folds (e.g. imports and comments) and correspond to indentation level so m_globalBlocks was renamed to m_indentBlocks and its generation separated from the generation of code folds. An upcoming PR will handle real auto indentation extended to support pasting and deletion.
* If code folding was disabled both matching delimiter highlights and block id line were also disabled.
* ImHex crashed if lines were inserted while semantic highlighting was taking place which can only occur on very large patterns. The detection of task interruption needed to be fixed.
* m_changesWereParsed had the same information as m_hasUnevaluatedChanges, so it was removed and the latter was renamed to the more accurate m_hasUnparsedChanges.
* Some functions were moved to more sensible files and some remain to be moved to minimize this Pr changes.
