### PR TITLE
build: archlinux and MSVC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,8 +281,6 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DCMAKE_C_COMPILER="$($(Get-Command cl.exe).Path)"                        `
             -DCMAKE_CXX_COMPILER="$($(Get-Command cl.exe).Path)"                      `
-            -DCMAKE_C_FLAGS="/d2Qslpvec-"                                             `
-            -DCMAKE_CXX_FLAGS="/d2Qslpvec-"                                           `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache                                        `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                                      `
             -DCMAKE_INSTALL_PREFIX="$(Join-Path $PWD 'install')"                      `

--- a/lib/libimhex/include/hex/api/localization_manager.hpp
+++ b/lib/libimhex/include/hex/api/localization_manager.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <functional>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <wolv/types/static_string.hpp>
 
 EXPORT_MODULE namespace hex {

--- a/lib/libimhex/include/hex/helpers/logger.hpp
+++ b/lib/libimhex/include/hex/helpers/logger.hpp
@@ -2,7 +2,7 @@
 
 #include <hex.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/color.h>
 
 #include <wolv/io/file.hpp>


### PR DESCRIPTION
Archlinux needs to change some headers to include `fmt/format.hpp` instead of `fmt/core.hpp`. 
The archlinux build will not be fixed until the PR in disassembler repo gets merged by somebody with push permissions there.

MSVC builds had last change reverted because not only it did not fix the build errors, but it added some extra ones. Seeing how this was the only workaround we can apply we probably will need to update the compiler to 2026 and wait for the version that has the fix to be used in github actions.
