### PR TITLE
Debugging on Clang builds on Windows targeting ARM64 fixes (I use VSCode)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ project(ImHex
 )
 configureProject()
 
+if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Forces Clang on Windows to use DWARF format
+    add_compile_options(-gdwarf-5 -glldb)
+endif()
+
 # Add ImHex sources
 add_custom_target(imhex_all ALL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,7 @@ project(ImHex
 configureProject()
 
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # Forces Clang on Windows to use DWARF format
-    add_compile_options(-gdwarf-5 -glldb)
+    add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:-gdwarf-5;-glldb>")
 endif()
 
 # Add ImHex sources


### PR DESCRIPTION
### Problem description
When building a debug version on Windows (building on an ARM system targeting ARM, debugging with VSCode), debugging doesn't work properly. For example, breakpoints can't be set.

The issue can be found [here](https://github.com/WerWolv/ImHex/issues/2770).

### Implementation description
Force the build to use DWARF debug info.

### Context
I've been trying to figure this out for a bit now. Built LLVM locally. Turns out the problem was the debug info. I'd be surprised if the changes could not be better placed.

### Potential issues
Perhaps it could bloat release builds as is. I'm not sure. EDIT: I have added changes to address this. I suspect someone like @WerWolv or @paxcut would be more qualified to integrate the spirit of these changes properly.

### Environment
Debugging with VSCode (with the "LLDB DAP" extension) using LLVM (lldb-dap.exe). My "launch.json":
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "C++ Windows ARM64 Launch",
            "type": "lldb-dap",
            "request": "launch",
            "program": "${workspaceFolder}/build-debug/install/imhex-gui.exe",
            "args": [],
            "stopAtEntry": false,
            "cwd": "${workspaceFolder}",
            "environment": []
        }
    ]
}
```

My locally built "lldb-dap.exe" is in my path. Building locally, although initially a dead end, means I can use a later version of Python, so I'm sticking with it. Not sure why but installing LLVM required Python 3.11 and I use 3.14, which my locally built LLVM seems to use just fine.
