### PR TITLE
Add shortcuts for extending selection till file start/end

### DIFF
--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -963,6 +963,8 @@
     "hex.builtin.view.hex_editor.shortcut.selection_page_up": "Extend selection up one page",
     "hex.builtin.view.hex_editor.shortcut.cursor_page_up": "Move cursor up one page",
     "hex.builtin.view.hex_editor.shortcut.selection_page_down": "Extend selection down one page",
+    "hex.builtin.view.hex_editor.shortcut.selection_file_up": "Extend selection to the start of the file",
+    "hex.builtin.view.hex_editor.shortcut.selection_file_down": "Extend selection to the end of the file",
     "hex.builtin.view.hex_editor.shortcut.cursor_page_down": "Move cursor down one page",
     "hex.builtin.view.highlight_rules.name": "Highlight Rules",
     "hex.builtin.view.highlight_rules.new_rule": "New Rule",

--- a/plugins/builtin/source/content/views/view_hex_editor.cpp
+++ b/plugins/builtin/source/content/views/view_hex_editor.cpp
@@ -611,6 +611,51 @@ namespace hex::plugin::builtin {
             m_hexEditor.jumpIfOffScreen();
         });
 
+        ShortcutManager::addShortcut(this, CTRLCMD + SHIFT + Keys::Home, "hex.builtin.view.hex_editor.shortcut.selection_file_up", [this] {
+            auto selection = getSelection();
+            auto cursor = m_hexEditor.getCursorPosition().value_or(selection.getEndAddress());
+
+            if (m_hexEditor.getMode() == ui::HexEditor::Mode::Insert)
+                return;
+
+            u64 startAddress = 0;
+
+            if (cursor != selection.getStartAddress()) {
+                setSelection(selection.getStartAddress(), startAddress);
+                m_hexEditor.setCursorPosition(startAddress);
+            } else {
+                setSelection(startAddress, selection.getEndAddress());
+                m_hexEditor.setCursorPosition(startAddress);
+            }
+
+            m_hexEditor.jumpIfOffScreen();
+        });
+
+        ShortcutManager::addShortcut(this, CTRLCMD + SHIFT + Keys::End, "hex.builtin.view.hex_editor.shortcut.selection_file_down", [this] {
+            auto selection = getSelection();
+            auto cursor = m_hexEditor.getCursorPosition().value_or(selection.getEndAddress());
+
+            if (m_hexEditor.getMode() == ui::HexEditor::Mode::Insert)
+                return;
+
+            auto provider = m_hexEditor.getProvider();
+            if (provider == nullptr)
+                return;
+
+            auto fileSize = provider->getSize();
+            auto endAddress = fileSize > 0 ? fileSize - 1 : 0;
+
+            if (cursor != selection.getStartAddress()) {
+                setSelection(selection.getStartAddress(), endAddress);
+                m_hexEditor.setCursorPosition(endAddress);
+            } else {
+                setSelection(endAddress, selection.getEndAddress());
+                m_hexEditor.setCursorPosition(endAddress);
+            }
+
+            m_hexEditor.jumpIfOffScreen();
+        });
+
     }
 
     void ViewHexEditor::registerEvents() {


### PR DESCRIPTION
### Problem description

ImHex already supports extending the current selection by page and line, but it does not provide shortcuts for extending the selection to the beginning or end of the file. HxD has these shortcuts and I used them very often.

### Implementation description

Added two new shortcuts:

- `Ctrl/Cmd + Shift + Home` – Extend the current selection to the start of the file.
- `Ctrl/Cmd + Shift + End` – Extend the current selection to the end of the file.

The implementation mirrors the existing selection extension behavior by preserving the opposite selection anchor and moving the cursor to the new endpoint. Added only English localization.