### PR TITLE
fix: clear modified addresses on save

### DIFF
--- a/plugins/builtin/source/content/views/view_patches.cpp
+++ b/plugins/builtin/source/content/views/view_patches.cpp
@@ -70,6 +70,7 @@ namespace hex::plugin::builtin {
 
         EventProviderSaved::subscribe([this](prv::Provider *provider) {
             m_savedOperations.get(provider) = provider->getUndoStack().getAppliedOperations().size();
+            m_modifiedAddresses.get(provider).clear();
             EventHighlightingChanged::post();
         });
 


### PR DESCRIPTION
These addresses are not modified anymore

This removes the red color of every address on Ctrl+S. @WerWolv Do you confirm this is what should occur, and I'm not modifying something intentional ?