### PR TITLE
Fix: issues 2784 and 2785

### DIFF
--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -1380,8 +1380,8 @@ namespace hex::plugin::builtin {
                     result = definition;
                     return true;
                 }
-
-                vectorString.erase(vectorString.begin());
+                if (!vectorString.empty())
+                    vectorString.erase(vectorString.begin());
                 variableName = wolv::util::combineStrings(vectorString, ".");
                 Identifier *identifier = identifiers[0];
                 identifiers.erase(identifiers.begin());

--- a/plugins/visualizers/source/content/pl_visualizers/image.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/image.cpp
@@ -94,22 +94,23 @@ namespace hex::plugin::visualizers {
     }
 
     std::vector<u32> getIndices(pl::ptrn::Pattern *pattern, u64 width, u64 height) {
-        auto indexCount = width * height / pattern->getSize();
-        std::vector<u32> indices;
-        const auto *iterable = dynamic_cast<pl::ptrn::IIterable *>(pattern);
 
+        const auto *iterable = dynamic_cast<pl::ptrn::IIterable *>(pattern);
+        std::vector<u32> indices;
         if (iterable == nullptr || iterable->getEntryCount() == 0)
             return indices;
+
+        auto indexCount = (width * height) / iterable->getEntryCount();
         auto content = iterable->getEntry(0);
         auto byteCount = content->getSize();
 
         if (byteCount >= indexCount && indexCount != 0) {
-            auto bytePerIndex = byteCount / indexCount;
+            auto bytesPerIndex = byteCount / indexCount;
 
-            if (bytePerIndex == 1) {
+            if (bytesPerIndex == 1) {
                 auto temp = patternToArray<u8>(pattern);
                 indices = std::vector<u32>(temp.begin(), temp.end());
-            } else if (bytePerIndex == 2) {
+            } else if (bytesPerIndex == 2) {
                 auto temp = patternToArray<u16>(pattern);
                 indices = std::vector<u32>(temp.begin(), temp.end());
             } else // 32 bits indices make no sense.
@@ -119,9 +120,9 @@ namespace hex::plugin::visualizers {
             auto temp = patternToArray<u8>(pattern);
 
             if (indicesPerByte == 2) {
-                for (u32 i = 0; i < temp.size(); i++) {
-                    indices.push_back(temp[i] & 0xF);
-                    indices.push_back((temp[i] >> 4) & 0xF);
+                for (unsigned char i : temp) {
+                    indices.push_back(i & 0xF);
+                    indices.push_back((i >> 4) & 0xF);
                 }
             } else  // 2 bits indices are too little
                 return indices;


### PR DESCRIPTION
Issue #2784  was causing ImHex to crash when the semantic highlighter was unable to identify if a variable existed in a parent. The error was 100% reproducible and occurred when an empty vector had an element removed which was resolved by checking its size.

Issue #2785 asks for support for local array variables in order to construct full bitmaps images from paletted bitmaps because the builtin visualizer was not working. It turned out that the particular index size of 16 bits was never tested and didn't work. 16 bit indices are the only ones that report a difference in size and number of elements, while 4 and 6 bits report the same numbers. The visualizer was using the incorrect one but the problem never showed in previous tests.

