### PR TITLE
fix: Percent-encoded paths when opening files on macOS

### DIFF
--- a/lib/libimhex/source/helpers/utils_macos.m
+++ b/lib/libimhex/source/helpers/utils_macos.m
@@ -277,14 +277,24 @@
     @implementation HexDocument
 
     - (BOOL) readFromURL:(NSURL *)url ofType:(NSString *)typeName error:(NSError **)outError {
-        NSString* urlString = [url absoluteString];
-        const char* utf8String = [urlString UTF8String];
+        (void)typeName;
 
-        const char *prefix = "file://";
-        if (strncmp(utf8String, prefix, strlen(prefix)) == 0)
-            utf8String += strlen(prefix);
+        // Resolve file reference URLs (file:///.file/id=...) into a path based URL.
+        // -absoluteString must not be used here, as it returns a percent-encoded URL string
+        NSURL *filePathURL = [url filePathURL];
+        const char *path = filePathURL == nil ? NULL : [filePathURL fileSystemRepresentation];
 
-        openFile(utf8String);
+        if (path == NULL) {
+            if (outError != NULL) {
+                *outError = [NSError errorWithDomain:NSCocoaErrorDomain
+                                                code:NSFileReadUnsupportedSchemeError
+                                            userInfo:@{ NSURLErrorKey: url }];
+            }
+
+            return NO;
+        }
+
+        openFile(path);
 
         return YES;
     }


### PR DESCRIPTION
### Problem description

Trying to open `/tmp/my file.bin` by passing the path to the ImHex executable, results in `Failed to open data source: Failed to open file /tmp/my%20file.bin: No such file or directory`

`-[HexDocument readFromURL:ofType:error:]` in `lib/libimhex/source/helpers/utils_macos.m` pulled the path out of `-[NSURL absoluteString]`, so `open()` got `/tmp/my%20file.bin` (so this goes for all characters encoded by NSURL, not just spaces).

The argv route breaks for the same reason. AppKit turns launch arguments into `readFromURL:` calls for document-based apps, so the CLI path never reaches the `--open` subcommand handler.

This affects:
- `/Applications/ImHex.app/Contents/MacOS/ImHex "/tmp/my file.bin"`
- `open -a ImHex "/tmp/my file.bin"`
- Dragging and dropping `/tmp/my file.bin` onto the app icon

It’s not an issue when using the UI file open dialog or dragging and dropping into the UI.

### Implementation description

Use `-filePathURL` plus `-fileSystemRepresentation`. That also resolves `file:///.file/id=…` reference URLs, and the new early `return NO` sets `outError` per the `NSDocument` contract.

Verified against real files with a path containing a space, and through AppKit's actual delivery path for both invocations.Tested on macOS Tahoe 26.5.1.

Related issue (maybe): #568