### PR TITLE
fix: Infinite loop in hex::dec::lz4_decompress

### DIFF
--- a/plugins/decompress/source/content/pl_functions.cpp
+++ b/plugins/decompress/source/content/pl_functions.cpp
@@ -299,20 +299,23 @@ namespace hex::plugin::decompress {
                     std::vector<u8> outBuffer(1024 * 1024);
 
                     const u8* sourcePointer = compressedData.data();
-                    size_t srcSize = compressedData.size();
+                    size_t srcRemaining = compressedData.size();
+                    size_t ret = -1;
 
-                    while (srcSize > 0) {
+                    while (ret != 0) {
                         u8* dstPtr = outBuffer.data();
                         size_t dstCapacity = outBuffer.size();
-
-                        size_t ret = LZ4F_decompress(dctx, dstPtr, &dstCapacity, sourcePointer, &srcSize, nullptr);
+                        size_t srcSize = srcRemaining;
+                        
+                        ret = LZ4F_decompress(dctx, dstPtr, &dstCapacity, sourcePointer, &srcSize, nullptr);
                         if (LZ4F_isError(ret)) {
                             LZ4F_freeDecompressionContext(dctx);
                             return u128(sourcePointer - compressedData.data());
                         }
 
                         section.insert(section.end(), outBuffer.begin(), outBuffer.begin() + dstCapacity);
-                        sourcePointer += (compressedData.size() - srcSize);
+                        sourcePointer += srcSize;
+                        srcRemaining -= srcSize;
                     }
 
                     LZ4F_freeDecompressionContext(dctx);


### PR DESCRIPTION
### Problem description
The pattern function `hex::dec::lz4_decompress` freezes and infinitely allocates memory even on valid trivial LZ4 data.
Repro:
1. Before you start, save all your work or be prepared to kill imhex process quickly because it will eat a lot of memory very quickly indefinitely
2. Open the attached [lz4.bin](https://github.com/user-attachments/files/30457283/lz4.zip) file (extract it from the zip first, github doesn't allow me to upload raw bin files)
3. Apply this pattern: 
```
import std.mem;
import hex.dec;

u8 compressedData[std::mem::size()] @ 0x00;
std::mem::Section decompressedSection = std::mem::create_section("Decompressed Data");
bool success = hex::dec::lz4_decompress(compressedData, decompressedSection, true);
```
4. Observe the evaluator never ending and infinitely rising memory consumption

Tested on Windows nightly (v1.39.0.WIP, 5ce75b3) and [v1.38.1](https://github.com/WerWolv/ImHex/releases/tag/v1.38.1) MSI release

### Implementation description
The issue seems to be in misunderstanding of the in-out srcSizePtr parameter. When the function completes, the variable will contain [number of bytes consumed](https://github.com/lz4/lz4/blob/0774d05537f9762f838f7ab541b7765f1a729cb5/lib/lz4frame.h#L486), while the code seems to assume it contains number of bytes remaining. So if you have 75 B large buffer, it decompresses it fully so srcSize = 75 both before and after, then `sourcePointer += (compressedData.size() - srcSize);` becomes `sourcePointer += (75 - 75);` not advancing the sourcePointer at all and `while (srcSize > 0)` resolving to true always.

The fix advances the sourcePointer by the number of bytes read, and [terminates the loop when the return value is 0 as the documentation suggests](https://github.com/lz4/lz4/blob/0774d05537f9762f838f7ab541b7765f1a729cb5/lib/lz4frame.h#L472).


### Screenshots
<img width="2248" height="910" alt="image" src="https://github.com/user-attachments/assets/dea2fab7-1486-439d-a8e3-51b414a4dbf3" />


### Additional things
Loving ImHex, keep it up!