### PR TITLE
Fix toolbar create and open icons disappearing

### DIFF
--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -679,9 +679,9 @@ for (const auto &path : m_paths) {
                     return;
 
                 for (auto &[priority, menuItem] : ContentRegistry::UserInterface::impl::getMenuItemsMutable()) {
-		    if (menuItem.icon.glyph.empty()) {
-			    continue;
-		    }
+                    if (menuItem.icon.glyph.empty()) {
+                        continue;
+                    }
                     for (const auto &[index, value] : toolbarItems) {
                         const auto &[name, color] = value;
                         if (menuItem.unlocalizedNames.back().get() == name) {

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -679,6 +679,9 @@ for (const auto &path : m_paths) {
                     return;
 
                 for (auto &[priority, menuItem] : ContentRegistry::UserInterface::impl::getMenuItemsMutable()) {
+		    if (menuItem.icon.glyph.empty()) {
+			    continue;
+		    }
                     for (const auto &[index, value] : toolbarItems) {
                         const auto &[name, color] = value;
                         if (menuItem.unlocalizedNames.back().get() == name) {


### PR DESCRIPTION
Fixes #2803

### Problem description

When customizing the toolbar (e.g. adding the Theme Manager or Settings icons), the **Create new File** and **Open File** icons disappear from the toolbar. Removing and re-adding them makes the icons vanish.

These two are the only default toolbar items that are also registered via `addTaskBarMenuItem`. That call inserts a *second* entry into `s_menuItems` with the same leaf name as the real menu item, but with an empty glyph.



### Implementation description

The toolbar setting's `load()` matched menu items by leaf name only (`unlocalizedNames.back()`). Because `s_menuItems` is iterated in priority order, the lower-priority empty-glyph taskbar duplicate matched first and received the `toolbarIndex`. The toolbar draw loop then culls any item whose `icon.glyph` is empty (resetting its `toolbarIndex` to `-1`), so the icon disappeared.

The fix skips glyph-less menu items when restoring the toolbar in `load()`, so the real icon-carrying item gets the toolbar slot instead of its taskbar duplicate. An item with no glyph can never be a valid toolbar button, so this is consistent with the existing invariant already enforced in the draw loop.


### Screenshots
Before:
<img width="980" height="611" alt="image" src="https://github.com/user-attachments/assets/36cd303e-8362-458c-b4c1-30418f1532bd" />

After:
<img width="989" height="626" alt="image" src="https://github.com/user-attachments/assets/6e77133c-6bc6-43f4-a7cd-60c2eb456ce5" />

