### PR TITLE
impr: don't draw an empty settings box for disassemblers

### DIFF
--- a/lib/libimhex/include/hex/api/content_registry/disassemblers.hpp
+++ b/lib/libimhex/include/hex/api/content_registry/disassemblers.hpp
@@ -47,6 +47,7 @@ EXPORT_MODULE namespace hex {
 
             virtual std::optional<Instruction> disassemble(u64 imageBaseAddress, u64 instructionLoadAddress, u64 instructionDataAddress, std::span<const u8> code) = 0;
             virtual void drawSettings() = 0;
+            virtual bool hasSettings() { return false; }
 
             [[nodiscard]] const std::string& getName() const { return m_name; }
 

--- a/plugins/disassembler/source/content/disassemblers/capstone_architectures.cpp
+++ b/plugins/disassembler/source/content/disassemblers/capstone_architectures.cpp
@@ -192,6 +192,10 @@ namespace hex::plugin::disasm {
             ImGui::Separator();
         }
 
+        bool hasSettings() override {
+            return true;
+        }
+
         std::optional<ContentRegistry::Disassemblers::Instruction> disassemble(u64 imageBaseAddress, u64 instructionLoadAddress, u64 instructionDataAddress, std::span<const u8> code) override {
             auto ptr = code.data();
             auto size = code.size_bytes();

--- a/plugins/disassembler/source/content/disassemblers/custom_architectures.cpp
+++ b/plugins/disassembler/source/content/disassemblers/custom_architectures.cpp
@@ -96,6 +96,10 @@ namespace hex::plugin::disasm {
             }
         }
 
+        bool hasSettings() override {
+            return !m_spec.getSettings().empty();
+        }
+
         std::optional<ContentRegistry::Disassemblers::Instruction> disassemble(u64 imageBaseAddress, u64 instructionLoadAddress, u64 instructionDataAddress, std::span<const u8> code) override {
             std::ignore = imageBaseAddress;
             std::ignore = instructionDataAddress;

--- a/plugins/disassembler/source/content/views/view_disassembler.cpp
+++ b/plugins/disassembler/source/content/views/view_disassembler.cpp
@@ -348,10 +348,12 @@ namespace hex::plugin::disasm {
                             }
 
                             // Draw sub-settings for each architecture
-                            if (ImGuiExt::BeginBox()) {
-                                currArchitecture->drawSettings();
+                            if (currArchitecture->hasSettings()) {
+                                if (ImGuiExt::BeginBox()) {
+                                    currArchitecture->drawSettings();
+                                }
+                                ImGuiExt::EndBox();
                             }
-                            ImGuiExt::EndBox();
                         }
                     }
                 }


### PR DESCRIPTION
### Problem description
If a disassembler provider has no settings, ImHex draws an empty box. This is a very minor opinionated aesthetics thing.

### Implementation description
Add a hasSettings method that returns true if settings should be drawn, this is a breaking change.

### Screenshots
Left: Before
Right: After

<img width="1490" height="355" alt="image" src="https://github.com/user-attachments/assets/d4927d0f-81d3-48bd-8441-ddee0b7ffa20" />