### PR TITLE
Allow renaming in-memory provider tabs

### DIFF
--- a/lib/libimhex/include/hex/providers/memory_provider.hpp
+++ b/lib/libimhex/include/hex/providers/memory_provider.hpp
@@ -38,6 +38,8 @@ namespace hex::prv {
 
         [[nodiscard]] std::string getName() const override { return m_name; }
 
+        void setName(std::string name) { m_name = std::move(name); }
+
         [[nodiscard]] UnlocalizedString getTypeName() const override { return "MemoryProvider"; }
 
         [[nodiscard]] const char* getIcon() const override {

--- a/plugins/builtin/source/content/ui_items.cpp
+++ b/plugins/builtin/source/content/ui_items.cpp
@@ -16,6 +16,7 @@
 #include <hex/helpers/fmt.hpp>
 #include <hex/helpers/logger.hpp>
 #include <hex/helpers/debugging.hpp>
+#include <hex/providers/memory_provider.hpp>
 #include <hex/providers/provider.hpp>
 
 #include <fonts/vscode_icons.hpp>
@@ -27,6 +28,7 @@
 
 #include <toasts/toast_notification.hpp>
 #include <popups/popup_question.hpp>
+#include <popups/popup_text_input.hpp>
 
 #include <csignal>
 #include <fonts/tabler_icons.hpp>
@@ -423,6 +425,15 @@ namespace hex::plugin::builtin {
     }
 
     static void drawProviderContextMenu(prv::Provider *provider) {
+        if (auto *memoryProvider = dynamic_cast<prv::MemoryProvider*>(provider); memoryProvider != nullptr) {
+            if (ImGui::MenuItemEx(Lang("hex.builtin.provider.rename").get(), ICON_VS_TAG)) {
+                ui::PopupTextInput::open("hex.builtin.provider.rename", "hex.builtin.provider.rename.desc", [memoryProvider](const std::string &name) {
+                    memoryProvider->setName(name);
+                    RequestUpdateWindowTitle::post();
+                });
+            }
+        }
+
         if (auto *menuItemProvider = dynamic_cast<prv::IProviderMenuItems*>(provider); menuItemProvider != nullptr) {
             for (const auto &menuEntry : menuItemProvider->getMenuEntries()) {
                 if (ImGui::MenuItemEx(menuEntry.name.c_str(), menuEntry.icon)) {
@@ -500,12 +511,12 @@ namespace hex::plugin::builtin {
 
         EventFrameBegin::subscribe([] {
             if (rightClickedProvider != nullptr) {
-                if (auto *menuItemProvider = dynamic_cast<prv::IProviderMenuItems*>(rightClickedProvider); menuItemProvider != nullptr) {
-                    if (!menuItemProvider->getMenuEntries().empty()) {
-                        if (ImGui::BeginPopup("ProviderMenu")) {
-                            drawProviderContextMenu(rightClickedProvider);
-                            ImGui::EndPopup();
-                        }
+                auto *menuItemProvider = dynamic_cast<prv::IProviderMenuItems*>(rightClickedProvider);
+                auto *memoryProvider = dynamic_cast<prv::MemoryProvider*>(rightClickedProvider);
+                if ((menuItemProvider != nullptr && !menuItemProvider->getMenuEntries().empty()) || memoryProvider != nullptr) {
+                    if (ImGui::BeginPopup("ProviderMenu")) {
+                        drawProviderContextMenu(rightClickedProvider);
+                        ImGui::EndPopup();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- add the existing rename action to in-memory provider context menus
- allow raw section views to be renamed like other provider tabs
- refresh the window title after a provider is renamed

Fixes #2669

## Validation

- `git diff --check`
- CMake Debug configure with GCC 15.2 and Ninja
- `ninja -C build/codex plugins/builtin/CMakeFiles/builtin.dir/source/content/ui_items.cpp.o -j2`
- `ninja -C build/codex lib/libimhex/CMakeFiles/libimhex.dir/source/providers/memory_provider.cpp.o -j2`
