### PR TITLE
fix: Set cursor position explicitly before jumping to the selection in paste from source feature

### DIFF
--- a/plugins/builtin/include/content/views/view_hex_editor.hpp
+++ b/plugins/builtin/include/content/views/view_hex_editor.hpp
@@ -38,6 +38,10 @@ namespace hex::plugin::builtin {
             m_hexEditor.setSelection(start, end);
         }
 
+        void setCursorPosition(u64 cursorPosition) {
+            m_hexEditor.setCursorPosition(cursorPosition);
+        }
+
         void jumpToSelection() {
             m_hexEditor.jumpToSelection();
         }

--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -877,7 +877,7 @@
     "hex.builtin.view.hex_editor.menu.edit.paste_all": "Paste all",
     "hex.builtin.view.hex_editor.menu.edit.paste_all_string": "Paste all as string",
     "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.title": "Paste from Source...",
-    "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.description": "ImHex provides multiple methods for pasting data from another source. Select the desired paste mode after choosing the source and destination providers.\nNote: You can turn off the paste mode recommendation in the settings below.",
+    "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.description": "ImHex provides multiple methods for pasting data from another source. Select the desired paste mode after choosing the source and destination.\nNote: You can turn off the paste mode suggestion in the settings below.",
     "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.warning": "This operation does not support undo or redo.\nWould you like to proceed?",
     "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.provider.source.title": "Source",
     "hex.builtin.view.hex_editor.menu.edit.paste_from_source.popup.provider.dest.title": "Destination",

--- a/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_paste_from_source.cpp
+++ b/plugins/builtin/source/content/popups/hex_editor/popup_hex_editor_paste_from_source.cpp
@@ -512,6 +512,7 @@ namespace hex::plugin::builtin {
                                                                                                               : (std::min(source.providerSelection.getSize(), dest.providerSelection.getSize())));
                         ImHexApi::Provider::setCurrentProvider(dest.providerSelection.provider);
                         editor->setSelection(dest.providerSelection.getEndAddress(), dest.providerSelection.getStartAddress());
+                        editor->setCursorPosition(dest.providerSelection.getEndAddress());
                         editor->jumpToSelection();
                         // Clear paste mode
                         m_pasteMode = PasteModeType::ModeNotSelected;
@@ -672,6 +673,7 @@ namespace hex::plugin::builtin {
                     ImHexApi::Provider::setCurrentProvider(providerSelection.provider);
                     if (!isProviderEmpty) {
                         editor->setSelection(providerSelection.getStartAddress(), providerSelection.getEndAddress());
+                        editor->setCursorPosition(providerSelection.getStartAddress());
                         editor->jumpToSelection();
                     }
                 }
@@ -772,6 +774,7 @@ namespace hex::plugin::builtin {
                     // Jump to the selection in hex editor
                     if (!isProviderEmpty) {
                         editor->setSelection(m_setSelectionStart, m_setSelectionEnd);
+                        editor->setCursorPosition(m_setSelectionStart);
                         editor->jumpToSelection();
                     }
                 }
@@ -854,6 +857,7 @@ namespace hex::plugin::builtin {
                 if (providerValidity && (ImHexApi::Provider::getCurrentProviderIndex() == providerIndex) && providerSelectionToggle && (providerActualSize > 0) &&
                         (!(ImGui::IsMouseDragging(ImGuiMouseButton_Left)) && !(ImGui::IsKeyDown(ImGuiKey_LeftShift)) && !(ImGui::IsKeyDown(ImGuiKey_RightShift)))) {
                     editor->setSelection(providerSelection.getStartAddress(), providerSelection.getEndAddress());
+                    editor->setCursorPosition(providerSelection.getStartAddress());
                 }
 
                 ImGui::EndTabBar();
@@ -896,12 +900,26 @@ namespace hex::plugin::builtin {
     }
 
     void PopupPasteFromSource::drawPopupBorderHighlight(void) const {
-        ImDrawList* drawList = ImGui::GetWindowDrawList();
+        ImGuiWindow* window = ImGui::GetCurrentWindow();
+        if (window == nullptr) {
+            return;
+        }
 
-        // Draw border highlight
-        drawList->AddRect(ImGui::GetWindowPos(), ImGui::GetWindowPos() + ImGui::GetWindowSize(),
-                          ImGui::GetColorU32(ImGuiCol_NavWindowingHighlight), ImGui::GetStyle().WindowRounding,
-                          ImDrawFlags_None, 3_scaled);
+        ImDrawList* drawList = ImGui::GetWindowDrawList();
+        if (drawList == nullptr) {
+            return;
+        }
+
+        ImGuiViewport* viewport = window->Viewport;
+        if (viewport == nullptr) {
+            return;
+        }
+
+        ImRect rect = window->Rect();
+
+        drawList->PushClipRect(viewport->Pos, (viewport->Pos + viewport->Size));
+        drawList->AddRect(rect.Min, rect.Max, ImGui::GetColorU32(ImGuiCol_NavWindowingHighlight), window->WindowRounding, ImDrawFlags_None, 1_scaled);
+        drawList->PopClipRect();
     }
 
     void PopupPasteFromSource::setSelection(u64 start, u64 end) {


### PR DESCRIPTION
### Problem description
Due the cursor position change in hex editor setSelection function in commit af154270bf3baa92a602206138f3018d8c170fb0, jumping to begin or end using action buttons is not working as expected in the paste from source popup.

### Implementation description
- Explicitly set the cursor position before jumping to the selection.
- Also fixed the popup border highlight getting clipped