### PR TITLE
add IMHEX_ENABLE_TELEMETRY (default ON) and fix telemetry config defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(IMHEX_ENABLE_CPPCHECK            "Enable cppcheck static analysis"       
 option(IMHEX_BUNDLE_PLUGIN_SDK          "Enable bundling of Plugin SDK into install package"                                            ON )
 set   (IMHEX_RENDERING_BACKEND          "GLFW" CACHE STRING "Set the rendering backend ImHex should use (GLFW or SDL)"                     )
 option(IMHEX_ENABLE_UPDATER             "Enable automatic updater"                                                                      ON )
+option(IMHEX_ENABLE_TELEMETRY           "Build with telemetry support"                                                                  ON )
 ## Testing
 option(IMHEX_ENABLE_UNIT_TESTS          "Enable building unit tests"                                                                    OFF)
 option(IMHEX_ENABLE_IMGUI_TEST_ENGINE   "Enable the ImGui Test Engine"                                                                  OFF)

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -139,6 +139,10 @@ macro(addDefines)
     if (IMHEX_ENABLE_UPDATER)
         add_compile_definitions(IMHEX_ENABLE_UPDATER)
     endif()
+
+    if (IMHEX_ENABLE_TELEMETRY)
+        add_compile_definitions(IMHEX_ENABLE_TELEMETRY)
+    endif()
 endmacro()
 
 function(addDefineToSource SOURCE DEFINE)

--- a/lib/libimhex/source/api/imhex_api.cpp
+++ b/lib/libimhex/source/api/imhex_api.cpp
@@ -1134,7 +1134,10 @@ namespace hex {
         }
 
         bool anonymousTrackingAllowed() {
-            #if defined(OS_WEB)
+            #if !defined(IMHEX_ENABLE_TELEMETRY)
+                // Telemetry has been disabled for this build
+                return false;
+            #elif defined(OS_WEB)
                 // To avoid potentially flooding our database with lots of dead users
                 // from people just visiting the website, don't send telemetry data from
                 // the web version

--- a/plugins/builtin/source/content/init_tasks.cpp
+++ b/plugins/builtin/source/content/init_tasks.cpp
@@ -27,7 +27,7 @@ namespace hex::plugin::builtin {
 
         #if defined(IMHEX_ENABLE_UPDATER)
             bool checkForUpdatesSync() {
-                int checkForUpdates = ContentRegistry::Settings::read<int>("hex.builtin.setting.general", "hex.builtin.setting.general.server_contact", 2);
+                int checkForUpdates = ContentRegistry::Settings::read<int>("hex.builtin.setting.general", "hex.builtin.setting.general.server_contact", 0);
                 if (checkForUpdates != 1)
                     return true;
 

--- a/plugins/builtin/source/content/settings_entries.cpp
+++ b/plugins/builtin/source/content/settings_entries.cpp
@@ -43,9 +43,9 @@ namespace hex::plugin::builtin {
 
         /*
             Values of this setting:
-            0 - do not check for updates on startup
+            0 - default - do not check for updates on startup, this will get overridden if the user chooses so on first startup
             1 - check for updates on startup
-            2 - default value - ask the user if he wants to check for updates. This value should only be encountered on the first startup.
+            2 - legacy, assume as 0
         */
         class ServerContactWidget : public ContentRegistry::Settings::Widgets::Widget {
         public:
@@ -70,7 +70,7 @@ namespace hex::plugin::builtin {
             }
 
         private:
-            u32 m_value = 2;
+            u32 m_value = 0;
         };
 
         class FPSWidget : public ContentRegistry::Settings::Widgets::Widget {
@@ -779,7 +779,7 @@ for (const auto &path : m_paths) {
                 const auto trackingAllowed = ImHexApi::System::anonymousTrackingAllowed();
                 ContentRegistry::Settings::add<ServerContactWidget>("hex.builtin.setting.general", "hex.builtin.setting.general.network", "hex.builtin.setting.general.server_contact")
                     .setEnabledCallback([trackingAllowed]() { return trackingAllowed; });
-                ContentRegistry::Settings::add<Widgets::Checkbox>("hex.builtin.setting.general", "hex.builtin.setting.general.network", "hex.builtin.setting.general.upload_crash_logs", true)
+                ContentRegistry::Settings::add<Widgets::Checkbox>("hex.builtin.setting.general", "hex.builtin.setting.general.network", "hex.builtin.setting.general.upload_crash_logs", false)
                     .setEnabledCallback([trackingAllowed]() { return trackingAllowed; });
             #endif
 

--- a/plugins/builtin/source/content/welcome_screen.cpp
+++ b/plugins/builtin/source/content/welcome_screen.cpp
@@ -69,7 +69,7 @@ namespace hex::plugin::builtin {
                     m_restoreCallback(restoreCallback),
                     m_deleteCallback(deleteCallback) {
 
-                m_reportError = ContentRegistry::Settings::read<bool>("hex.builtin.setting.general", "hex.builtin.setting.general.upload_crash_logs", true);
+                m_reportError = ContentRegistry::Settings::read<bool>("hex.builtin.setting.general", "hex.builtin.setting.general.upload_crash_logs", false);
             }
 
             void drawContent() override {


### PR DESCRIPTION
### Problem
Some Linux distros (for example Gentoo) have stricter rules about telemetry being in software and prefers giving users the option of opting out at compile-time (https://wiki.gentoo.org/wiki/Software_Telemetry).

### Implementation
Added IMHEX_ENABLE_TELEMETRY as an option (default ON) and fixed a couple of telemetry config defaults being left enabled because the first-time popup asking for telemetry never appeared.