### PR TITLE
fix: only exit on startup if an error happened

### DIFF
--- a/lib/libimhex/source/subcommands/subcommands.cpp
+++ b/lib/libimhex/source/subcommands/subcommands.cpp
@@ -114,8 +114,9 @@ namespace hex::subcommands {
         int exitCode = 0;
         for (const auto &[subcommand, subCommandArgs] : subCommands) {
             exitCode = subcommand.callback(subCommandArgs);
-            if (exitCode != 0)
+            if (exitCode != EXIT_CONTINUE) {
                 break;
+            }
         }
 
         if (pluginsInitialized) {
@@ -129,7 +130,9 @@ namespace hex::subcommands {
             std::exit(0);
         }
 
-        std::exit(exitCode);
+        if (exitCode != EXIT_CONTINUE) {
+            std::exit(exitCode);
+        }
     }
 
     void forwardSubCommand(const std::string &cmdName, const std::vector<std::string> &args) {


### PR DESCRIPTION
### Problem description

At the moment running `imhex path/to/file` without a main instance will just exit the program rather than showing the main interface. 

This is caused by this commit: https://github.com/WerWolv/ImHex/commit/ced975989b052cb6937716615d7f41e76a29bf50

also EXIT_CONTINUE was introduced, which changes the exit code behavior.

### Implementation description
this changes the subcommand processing loop to check for EXIT_CONTINUE, and only exits the full program if the final exit code is not EXIT_CONTINUE