### PR TITLE
fix: set ImGui GetMouseDragDelta lock threshold to 0

### DIFF
--- a/plugins/builtin/source/content/views/view_achievements.cpp
+++ b/plugins/builtin/source/content/views/view_achievements.cpp
@@ -375,7 +375,7 @@ for (const auto &[categoryName, achievements] : startNodes) {
 
                     // Handle dragging the achievement tree around
                     if (ImGui::IsMouseHoveringRect(innerWindowPos, innerWindowPos + innerWindowSize)) {
-                        auto dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
+                        auto dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left, 0);
                         m_offset += dragDelta;
                         ImGui::ResetMouseDragDelta(ImGuiMouseButton_Left);
                     }

--- a/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
+++ b/plugins/visualizers/source/content/pl_visualizers/3d_model.cpp
@@ -303,7 +303,7 @@ namespace hex::plugin::visualizers {
                 ImGui::IsKeyDown(ImGuiKey_RightShift))
                 accel = 10.0F;
 
-            auto dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Middle);
+            auto dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Middle, 0);
             if (dragDelta.x != 0) {
                 rotation[1] += dragDelta.x * 0.0075F * accel;
             }
@@ -314,7 +314,7 @@ namespace hex::plugin::visualizers {
 
             ImGui::ResetMouseDragDelta(ImGuiMouseButton_Middle);
 
-            dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Right);
+            dragDelta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Right, 0);
             translation[0] += dragDelta.x * 0.0075F * accel;
             translation[1] -= dragDelta.y * 0.0075F * accel;
             ImGui::ResetMouseDragDelta(ImGuiMouseButton_Right);


### PR DESCRIPTION
Fixes drag on HiDPI in certain setups.

### Problem description
In certain HiDPI setups (i.e. mine) the default imgui mouse threshold can be excessively long causing extended drags with no change.

### Implementation description
Passes 0 as the lock_threshold value which replicates the behavior used here:

https://github.com/WerWolv/ImHex/blob/fb9358b6a5cb7e5cee84f7d064090712d5f9cc4a/plugins/diffing/source/content/views/view_diff.cpp#L309

### Additional things

Probably should set MouseDragThreshold to 0 in ImGuiIO