### PR TITLE
fix: multiple pattern related bugs

### DIFF
--- a/lib/libimhex/include/hex/helpers/file_attached_data.hpp
+++ b/lib/libimhex/include/hex/helpers/file_attached_data.hpp
@@ -32,6 +32,9 @@ namespace hex {
             }
 
             void erase() {
+                if (m_json->type() == nlohmann::json::value_t::null) {
+                    return;
+                }
                 m_json->erase(getPathKey());
                 save();
             }

--- a/lib/libimhex/include/hex/helpers/magic.hpp
+++ b/lib/libimhex/include/hex/helpers/magic.hpp
@@ -40,7 +40,7 @@ namespace hex::magic {
         bool remote;
 
         bool operator<(const FoundPattern &other) const {
-            return patternFilePath.filename() < other.patternFilePath.filename();
+            return patternFilePath < other.patternFilePath;
         }
     };
 

--- a/lib/libimhex/source/helpers/logger.cpp
+++ b/lib/libimhex/source/helpers/logger.cpp
@@ -25,7 +25,11 @@ namespace hex::log {
         bool s_colorOutputEnabled = false;
         std::recursive_mutex s_loggerMutex;
         bool s_loggingSuspended = false;
+#if defined(DEBUG)
+        bool s_debugLoggingEnabled = true;
+#else
         bool s_debugLoggingEnabled = false;
+#endif
 
     }
 
@@ -57,11 +61,7 @@ namespace hex::log {
         }
 
         bool isDebugLoggingEnabled() {
-            #if defined(DEBUG)
-                return true;
-            #else
-                return s_debugLoggingEnabled;
-            #endif
+            return s_debugLoggingEnabled;
         }
 
         FILE *getDestination() {

--- a/plugins/builtin/source/content/project/import.cpp
+++ b/plugins/builtin/source/content/project/import.cpp
@@ -298,6 +298,7 @@ namespace hex::plugin::builtin::project {
                         closedFoldData.get(root / file.relativePath) = std::move(states);
                     }
                     patternFile.setSize(0);
+                    patternFile.seek(0);
                     if (!patternFile.writeString(code))
                         continue;
                 }

--- a/plugins/builtin/source/content/recent.cpp
+++ b/plugins/builtin/source/content/recent.cpp
@@ -160,6 +160,10 @@ namespace hex::plugin::builtin::recent {
                         .data           = jsonData
                     };
 
+                    if (entry.displayName.empty()) {
+                        entry.displayName = recentFile.getPath().filename().string();
+                    }
+
                     // Do not add entry twice
                     if (!alreadyAddedProviders.insert(entry).second)
                         continue;
@@ -333,6 +337,11 @@ namespace hex::plugin::builtin::recent {
                 // Copy to avoid changing list while iteration
                 auto recentEntries = s_recentEntries;
                 for (auto &recentEntry : recentEntries) {
+                    if (recentEntry.displayName.empty()) {
+                        // recent entry is invalid, happens when items are removed externally or from the projects view
+                        continue;
+                    }
+
                     if (menu::menuItemEx(recentEntry.displayName.c_str(), getProviderIcon(UntranslatedString(recentEntry.type)))) {
                         loadRecentEntry(recentEntry);
                     }

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -1776,20 +1776,17 @@ namespace hex::plugin::builtin {
         ImGui::PopID();
     }
 
-
     void ViewPatternEditor::loadPatternFile(const std::fs::path &path, prv::Provider *provider, bool trackFile) {
-        wolv::io::File file(path, wolv::io::File::Mode::Write);
-        if (!file.isValid())
-            return;
-        auto code = wolv::util::preprocessText(file.readString());
-        file.writeString(code);
-        file.flush();
-
+        std::string code;
         if (trackFile) {
             if (!m_sourceCode.bind(provider, path))
                 return;
             code = m_sourceCode.get(provider);
         } else {
+            wolv::io::File file(path, wolv::io::File::Mode::Read);
+            if (!file.isValid())
+                return;
+
             code = wolv::util::preprocessText(file.readString());
             m_sourceCode.set(provider, code);
         }

--- a/plugins/ui/source/ui/text_editor/code_folder.cpp
+++ b/plugins/ui/source/ui/text_editor/code_folder.cpp
@@ -341,7 +341,11 @@ namespace hex::ui {
                 if (currentTokenId < 0) {
                     return result;
                 }
-                line = m_unfoldedLines[m_curr->location.line - 1];
+                const auto unfoldedLineLocation = m_curr->location.line - 1;
+                if (unfoldedLineLocation >= m_unfoldedLines.size()) {
+                    return result;
+                }
+                line = m_unfoldedLines[unfoldedLineLocation];
                 size_t stringIndex = line.columnIndex(m_curr->location.column);
                 std::string currentChar = std::string(1, line[static_cast<u64>(stringIndex - 1)]);
                 location = m_curr->location;


### PR DESCRIPTION
1. Fixes a `-Werror` violation in debug builds for Clang 23.1.0, where clang's analyzer finds that `s_debugLoggingEnabled` is only written to, not read and throws an error.
2. Fixes viable patterns silently being dropped if the filename matches, even if they are in sub-directories and are different patterns.
3. Fixes `#pragma once` silently dropping the next `#pragma` if it's not followed by a blank newline (WerWolv/PatternLanguage#249) (this commit has been dropped in this PR because it would make merging more complicated, but the fix is still valid on the PatternLanguage PR)
4. Fixes an ImHex empty ID assertion that is hit when temporary project files are removed from the project view while in a new project. This somehow clears the displayName field of the recent entry, which crashes on the assertion. 
5. Fixes an out of bounds access when a malformed pattern is pasted ontop of another malformed pattern
6. Fixes a json exception when saving the pattern
7. Fixes a regression causing ImHex to append the pattern to the current pattern file.