### PR TITLE
Fixes: various fixes due to changes in pattern editor view size. 

### DIFF
--- a/lib/libimhex/include/hex/helpers/file_attached_data.hpp
+++ b/lib/libimhex/include/hex/helpers/file_attached_data.hpp
@@ -17,7 +17,7 @@ namespace hex {
             [[nodiscard]] operator Type() {
                 try {
                     return (*m_json)[getPathKey()].template get<Type>();
-                } catch (const nlohmann::json::exception &e) {
+                } catch (const nlohmann::json::exception &) {
                     // If value can't be loaded, default construct it
                     (*m_json)[getPathKey()] = Type();
                     return Type();

--- a/lib/libimhex/include/hex/helpers/file_attached_data.hpp
+++ b/lib/libimhex/include/hex/helpers/file_attached_data.hpp
@@ -2,7 +2,7 @@
 
 #include "default_paths.hpp"
 #include "hex/api/project_manager.hpp"
-
+#include <hex/api/content_registry/settings.hpp>
 #include <wolv/types/static_string.hpp>
 
 namespace hex {
@@ -29,6 +29,11 @@ namespace hex {
                 save();
 
                 return *this;
+            }
+
+            void erase() {
+                m_json->erase(getPathKey());
+                save();
             }
 
         private:
@@ -70,6 +75,11 @@ namespace hex {
         Data get(const std::fs::path &path) {
             loadDataIfNeeded();
             return Data(path, &m_data);
+        }
+
+        void erase(const std::fs::path &path) {
+            loadDataIfNeeded();
+            Data(path, &m_data).erase();
         }
 
     private:

--- a/lib/libimhex/include/hex/providers/file_backed_provider_data.hpp
+++ b/lib/libimhex/include/hex/providers/file_backed_provider_data.hpp
@@ -111,7 +111,7 @@ namespace hex {
             std::function<SerializedData(const T &)> encode;
             std::function<std::optional<T>(std::span<const u8>)> decode;
             std::function<T()> createDefault = [] { return T(); };
-            std::chrono::seconds debounce = std::chrono::seconds(10ll);
+            std::chrono::milliseconds debounce = std::chrono::milliseconds(10000ll);
         };
 
         explicit FileBackedProviderData(Descriptor descriptor)

--- a/lib/libimhex/include/hex/providers/file_backed_provider_data.hpp
+++ b/lib/libimhex/include/hex/providers/file_backed_provider_data.hpp
@@ -111,7 +111,7 @@ namespace hex {
             std::function<SerializedData(const T &)> encode;
             std::function<std::optional<T>(std::span<const u8>)> decode;
             std::function<T()> createDefault = [] { return T(); };
-            std::chrono::milliseconds debounce = std::chrono::milliseconds(500);
+            std::chrono::seconds debounce = std::chrono::seconds(10ll);
         };
 
         explicit FileBackedProviderData(Descriptor descriptor)
@@ -426,7 +426,7 @@ namespace hex {
             this->finishSynchronization();
             bool result = true;
             for (auto &[provider, entryPtr] : m_entries) {
-                if (!entryPtr->path.has_value() || (entryPtr->missing && !entryPtr->touched))
+                if (!entryPtr->path.has_value() || entryPtr->missing || !entryPtr->touched)
                     continue;
                 result = this->flush(provider) && result;
             }
@@ -438,7 +438,7 @@ namespace hex {
             this->finishSynchronization();
             const auto it = m_entries.find(provider);
             if (it == m_entries.end() || !it->second->path.has_value() ||
-                (it->second->missing && !it->second->touched))
+                it->second->missing || !it->second->touched)
                 return false;
 
             auto &entry = *it->second;

--- a/plugins/builtin/include/content/project.hpp
+++ b/plugins/builtin/include/content/project.hpp
@@ -48,5 +48,5 @@ namespace hex::plugin::builtin::project {
     ImportResult importProviders(std::vector<ImportedProvider> providers, std::vector<ImportedProjectFile> projectFiles = {});
     prv::Provider *openProviderForPath(const std::filesystem::path &path, const prv::Provider *excludedProvider = nullptr);
     bool prepareForShutdown(bool persist = true);
-
+    std::string removeHiddenLinesFromPattern(std::string &sourceCode);
 }

--- a/plugins/builtin/source/content/project/import.cpp
+++ b/plugins/builtin/source/content/project/import.cpp
@@ -10,6 +10,7 @@
 #include <hex/api/project_manager.hpp>
 #include <hex/helpers/fmt.hpp>
 #include <hex/helpers/logger.hpp>
+#include <hex/helpers/file_attached_data.hpp>
 #include <hex/providers/file_backed_provider_data.hpp>
 #include <hex/providers/provider.hpp>
 
@@ -18,6 +19,17 @@
 #include <nlohmann/json.hpp>
 
 namespace hex::plugin::builtin::project {
+    std::string removeHiddenLinesFromPattern(std::string &sourceCode) {
+        auto stringVector = wolv::util::splitString(sourceCode, "\n");
+        std::string result;
+        if (stringVector[0].starts_with("//+-#:")) {
+            result = stringVector[0].substr(6);
+            stringVector.erase(stringVector.begin());
+        }
+        sourceCode = wolv::util::combineStrings(stringVector, "\n");
+        return result;
+    }
+
 
     ImportResult importProviders(std::vector<ImportedProvider> providers, std::vector<ImportedProjectFile> projectFiles) {
         ImportResult result;
@@ -274,6 +286,22 @@ namespace hex::plugin::builtin::project {
                     !FileBackedProviderDataRegistry::bind(provider, file.typeId, root / file.relativePath)) {
                     log::warn("Failed to bind imported project file '{}' to provider {}", file.relativePath.string(), id);
                 }
+                if (file.typeId == "hex.builtin.pattern-source") {
+                    wolv::io::File patternFile(root / file.relativePath, wolv::io::File::Mode::Write);
+                    if (!patternFile.isValid())
+                        continue;
+
+                    auto code = patternFile.readString();
+                    auto states = removeHiddenLinesFromPattern(code);
+                    if (!states.empty()) {
+                        hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+                        closedFoldData.get(root / file.relativePath) = std::move(states);
+                    }
+                    patternFile.setSize(0);
+                    if (!patternFile.writeString(code))
+                        continue;
+                }
+
             }
 
             if (provider != nullptr && provider->isWritable() && !importedProvider.patches.empty()) {

--- a/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
+++ b/plugins/builtin/source/content/text_highlighting/pattern_language.cpp
@@ -1212,22 +1212,22 @@ namespace hex::plugin::builtin {
                     m_requiredInputs.usedNamespaces.push_back(nameSpace);
             }
         }
+        m_curr = curr;
+        i32 tokenIndex = getTokenId();
+        if (tokenIndex > 3)
+            next(-3);
+        else
+            return;
+        if (peek(tkn::Separator::RightBrace,0)) {
 
-        u32 line = m_curr->location.line;
-        i32 tokenIndex;
-
-        while (!peek(tkn::Separator::Semicolon, -1)) {
-
-            if (line = previousLine(line); line > m_firstTokenIdOfLine.size()-1)
-                return;
-
-            if (tokenIndex = m_firstTokenIdOfLine.at(line); !isTokenIdValid(tokenIndex))
-                return;
-
-            m_curr = m_startToken;
-            next(tokenIndex);
-            while (peek(tkn::Literal::Comment, -1) || peek(tkn::Literal::DocComment, -1))
+            while (!peek(tkn::Separator::Semicolon, -1) && tokenIndex > 0) {
+                while (peek(tkn::Literal::Comment, -1) || peek(tkn::Literal::DocComment, -1))
+                    next(-1);
                 next(-1);
+                tokenIndex = getTokenId();
+            }
+        } else{
+            tokenIndex = m_firstTokenIdOfLine.at(m_curr->location.line - 1);
         }
 
         while (peek(tkn::Literal::Comment) || peek(tkn::Literal::DocComment))

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -27,6 +27,7 @@
 #include <hex/helpers/magic.hpp>
 #include <hex/helpers/binary_pattern.hpp>
 #include <hex/helpers/default_paths.hpp>
+#include <hex/helpers/file_attached_data.hpp>
 
 #include <hex/providers/memory_provider.hpp>
 
@@ -374,11 +375,13 @@ namespace hex::plugin::builtin {
         m_sourceCode.setChangedCallback([this](prv::Provider *provider) {
             auto sourceCode = m_sourceCode.get(provider);
             auto &editor = m_textEditor.get(provider);
-            if (editor.getText(true) == sourceCode)
+            if (m_sourceCode.getBinding(provider).has_value()) {
+                auto path = m_sourceCode.getBinding(provider)->string();
+                editor.setPath(path);
+            }
+            if (editor.getText() == sourceCode)
                 return;
-
-            editor.setText(std::move(sourceCode));
-            editor.removeHiddenLinesFromPattern();
+            editor.setText(sourceCode);
             editor.setTextChanged(false);
             m_hasUnparsedChanges.get(provider) = true;
         });
@@ -547,7 +550,7 @@ namespace hex::plugin::builtin {
             fonts::CodeEditor().pop();
 
             m_consoleHoverBox = ImGui::GetCurrentWindow()->Rect();
-            m_consoleHoverBox.Min.y = m_textEditorHoverBox.Max.y + ImGui::GetTextLineHeightWithSpacing() * 1.5F;
+            m_consoleHoverBox.Min.y = m_textEditorHoverBox.Max.y;
 
             if (m_textEditor.get(provider).raiseContextMenu())  {
                 RequestOpenPopup::post("hex.builtin.menu.edit");
@@ -718,7 +721,6 @@ namespace hex::plugin::builtin {
     }
 
     void ViewPatternEditor::drawTextEditorFindReplacePopup(ui::TextEditor *textEditor) {
-        auto provider = ImHexApi::Provider::get();
         ImGuiWindowFlags popupFlags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
         if (ImGui::BeginPopup("##text_editor_view_find_replace_popup", popupFlags)) {
             static std::string findWord;
@@ -1045,34 +1047,31 @@ namespace hex::plugin::builtin {
             // Escape key to close the popup
             if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
                 m_popupWindowHeight = 0;
-                m_textEditor.get(provider).setTopMarginChanged(0);
+                textEditor->setTopMarginChanged(0);
                 ImGui::CloseCurrentPopup();
             }
 
             ImGui::EndChild();
-            if (m_focusedSubWindowName.contains(TextEditorView)) {
-                if (auto window = ImGui::GetCurrentWindow(); window != nullptr) {
-                    auto height = window->Size.y;
-                    auto heightChange = height - m_popupWindowHeight;
-                    auto heightChangeChange = heightChange - m_popupWindowHeightChange;
-                    if (std::fabs(heightChange) < 0.5 && std::fabs(heightChangeChange) > 1.0) {
-                        m_textEditor.get(provider).setTopMarginChanged(height);
-                    }
-                    m_popupWindowHeightChange = heightChange;
-                    m_popupWindowHeight = height;
-                }
+            if (auto window = ImGui::GetCurrentWindow(); window != nullptr) {
+                auto height = window->Size.y;
+                auto heightChange = height - m_popupWindowHeight;
+                auto heightChangeChange = heightChange - m_popupWindowHeightChange;
+                if (std::fabs(heightChange) < 0.5 && std::fabs(heightChangeChange) > 1.0)
+                    textEditor->setTopMarginChanged(height);
+
+                m_popupWindowHeightChange = heightChange;
+                m_popupWindowHeight = height;
             }
             ImGui::EndPopup();
             m_findReplacePopupIsClosed = false;
         } else if (!m_findReplacePopupIsClosed) {
             m_findReplacePopupIsClosed = true;
             m_popupWindowHeight = 0;
-            m_textEditor.get(provider).setTopMarginChanged(0);
+            textEditor->setTopMarginChanged(0);
         }
     }
 
     void ViewPatternEditor::drawTextEditorGotoLinePopup(ui::TextEditor *textEditor) {
-        auto provider = ImHexApi::Provider::get();
         ImGuiWindowFlags popupFlags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
         if (ImGui::BeginPopup("##text_editor_view_goto_line_popup", popupFlags)) {
             std::string childName;
@@ -1105,29 +1104,27 @@ namespace hex::plugin::builtin {
             }
             if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
                 m_popupWindowHeight = 0;
-                m_textEditor.get(provider).setTopMarginChanged(0);
+                textEditor->setTopMarginChanged(0);
                 ImGui::CloseCurrentPopup();
             }
 
             ImGui::EndChild();
-            if (m_focusedSubWindowName.contains(TextEditorView)) {
-                if (auto window = ImGui::GetCurrentWindow(); window != nullptr) {
-                    auto height = window->Size.y;
-                    auto heightChange = height - m_popupWindowHeight;
-                    auto heightChangeChange = heightChange - m_popupWindowHeightChange;
-                    if (std::fabs(heightChange) < 0.5 && std::fabs(heightChangeChange) > 1.0) {
-                        m_textEditor.get(provider).setTopMarginChanged(height);
-                    }
-                    m_popupWindowHeightChange = heightChange;
-                    m_popupWindowHeight = height;
-                }
+            if (auto window = ImGui::GetCurrentWindow(); window != nullptr) {
+                auto height = window->Size.y;
+                auto heightChange = height - m_popupWindowHeight;
+                auto heightChangeChange = heightChange - m_popupWindowHeightChange;
+                if (std::fabs(heightChange) < 0.5 && std::fabs(heightChangeChange) > 1.0)
+                    textEditor->setTopMarginChanged(height);
+
+                m_popupWindowHeightChange = heightChange;
+                m_popupWindowHeight = height;
             }
             ImGui::EndPopup();
             m_gotoPopupIsClosed = false;
         } else if (!m_gotoPopupIsClosed) {
             m_gotoPopupIsClosed = true;
             m_popupWindowHeight = 0;
-            m_textEditor.get(provider).setTopMarginChanged(0);
+            textEditor->setTopMarginChanged(0);
         }
     }
 
@@ -1156,9 +1153,14 @@ namespace hex::plugin::builtin {
             m_consoleNeedsUpdate = false;
         }
 
-        fonts::CodeEditor().push();
-        m_consoleEditor.get(provider).render("##console", size, true);
-        fonts::CodeEditor().pop();
+        if (ImGui::BeginChild("##console_border", size, ImGuiChildFlags_Borders)) {
+            fonts::CodeEditor().push();
+            m_consoleEditor.get(provider).render("##console", ImGui::GetContentRegionAvail(), false);
+            fonts::CodeEditor().pop();
+        }
+
+        ImGui::EndChild();
+
 
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImGui::GetStyle().FramePadding.y + 1_scaled);
     }
@@ -1542,7 +1544,7 @@ namespace hex::plugin::builtin {
 
             if (m_textEditor.get(provider).isTextChanged()) {
                 m_textEditor.get(provider).setTextChanged(false);
-                m_sourceCode.set(provider, m_textEditor.get(provider).getText(true));
+                m_sourceCode.set(provider, m_textEditor.get(provider).getText());
                 m_hasUnparsedChanges.get(provider) = true;
                 m_lastEditorChangeTime = std::chrono::steady_clock::now();
             }
@@ -1592,8 +1594,9 @@ namespace hex::plugin::builtin {
                 TaskManager::createBackgroundTask("hex.builtin.task.highlighting_pattern", [this,provider](auto &) { m_identifierHighlighter.get(provider).highlightSourceCode(); });
             } else if (m_changesWereColored && !m_allStepsCompleted) {
                 m_identifierHighlighter.get(provider).setRequestedIdentifierColors(m_colorizeIdentifiers);
-                m_textEditor.get(provider).getLines().setAllCodeFolds();
-                m_textEditor.get(provider).getLines().applyCodeFoldStates();
+                if (m_sourceCode.getBinding(provider).has_value()) {
+                    m_textEditor.get(provider).getLines().setAllCodeFolds(m_sourceCode.getBinding(provider)->string());
+                }
                 m_allStepsCompleted = true;
             }
 
@@ -1753,22 +1756,29 @@ namespace hex::plugin::builtin {
 
 
     void ViewPatternEditor::loadPatternFile(const std::fs::path &path, prv::Provider *provider, bool trackFile) {
-        std::string code;
+        wolv::io::File file(path, wolv::io::File::Mode::Write);
+        if (!file.isValid())
+            return;
+        auto code = wolv::util::preprocessText(file.readString());
+        file.writeString(code);
+        file.flush();
+
         if (trackFile) {
             if (!m_sourceCode.bind(provider, path))
                 return;
             code = m_sourceCode.get(provider);
         } else {
-            wolv::io::File file(path, wolv::io::File::Mode::Read);
-            if (!file.isValid())
-                return;
             code = wolv::util::preprocessText(file.readString());
             m_sourceCode.set(provider, code);
         }
 
         this->evaluatePattern(code, provider);
         m_textEditor.get(provider).setText(code, true);
-        m_textEditor.get(provider).removeHiddenLinesFromPattern();
+        if (m_sourceCode.getBinding(provider).has_value()) {
+            hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+            auto states = closedFoldData.get(path);
+            m_textEditor.get(provider).getLines().applyCodeFoldStates(m_sourceCode.getBinding(provider)->string());
+        }
         ContentRegistry::PatternLanguage::addPragma("base_address", [](pl::PatternLanguage &runtime, const std::string &value) {
             std::ignore = runtime;
             auto baseAddress = wolv::util::from_chars<u64>(value);
@@ -1983,8 +1993,13 @@ namespace hex::plugin::builtin {
                 return;
 
             m_textEditor.get(provider).setText(wolv::util::preprocessText(code));
-            m_textEditor.get(provider).removeHiddenLinesFromPattern();
-            m_sourceCode.set(provider, m_textEditor.get(provider).getText(true));
+            m_sourceCode.set(provider, m_textEditor.get(provider).getText());
+            if (m_sourceCode.getBinding(provider).has_value()) {
+                auto path = m_sourceCode.getBinding(provider)->string();
+                hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+                auto states = closedFoldData.get(path);
+                m_textEditor.get(provider).getLines().applyCodeFoldStates(path);
+            }
             m_hasUnparsedChanges.get(provider) = true;
         });
 
@@ -2031,9 +2046,12 @@ namespace hex::plugin::builtin {
             m_textEditor.get(provider).setShowWhitespaces(m_showWhiteSpaces);
             m_textEditor.get(provider).setDisableCodeFolds(m_codeFoldsDisabled);
             m_textEditor.get(provider).setAutoIndent(m_autoIndent);
-            //if (getLastFocusedView() == this) {
-            //    m_textEditor.get(provider).setFocus(true);
-            //}
+            if (m_sourceCode.getBinding(provider).has_value()) {
+                auto path = m_sourceCode.getBinding(provider)->string();
+                hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+                auto states = closedFoldData.get(path);
+                m_textEditor.get(provider).getLines().applyCodeFoldStates(path);
+            }
 
 
             m_consoleEditor.get(provider).setLanguageDefinition(ConsoleLog());
@@ -2071,6 +2089,12 @@ namespace hex::plugin::builtin {
                 m_textEditor.get(newProvider).setDisableCodeFolds(m_codeFoldsDisabled);
                 m_textEditor.get(newProvider).setAutoIndent(m_autoIndent);
                 m_hasUnparsedChanges.get(newProvider) = true;
+                if (m_sourceCode.getBinding(newProvider).has_value()) {
+                    auto path = m_sourceCode.getBinding(newProvider)->string();
+                    hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+                    auto states = closedFoldData.get(path);
+                    m_textEditor.get(newProvider).getLines().applyCodeFoldStates(path);
+                }
                 m_consoleEditor.get(newProvider).setText(wolv::util::combineStrings(m_console.get(newProvider), "\n"));
                 m_consoleEditor.get(newProvider).getLines().setScroll(m_consoleScroll.get(newProvider));
             }
@@ -2174,7 +2198,7 @@ namespace hex::plugin::builtin {
             }
         }, [this] {
             if (auto editor = getEditorFromFocusedWindow(); editor != nullptr) {
-                return ImHexApi::Provider::isValid() && !editor->getFindReplaceHandler()->getFindWord().empty();
+                return ImHexApi::Provider::isValid() && !m_textEditor.get(ImHexApi::Provider::get()).getFindReplaceHandler()->getFindWord().empty();
             } else {
                 return false;
             }
@@ -2901,7 +2925,7 @@ namespace hex::plugin::builtin {
                 if (!file.isValid())
                     return;
 
-                file.writeString(m_textEditor.get(provider).getText(true));
+                file.writeString(m_textEditor.get(provider).getText());
                 file.flush();
                 if (trackFile)
                     std::ignore = m_sourceCode.bind(provider, path);

--- a/plugins/ui/include/ui/text_editor.hpp
+++ b/plugins/ui/include/ui/text_editor.hpp
@@ -285,11 +285,11 @@ namespace hex::ui {
             void close();
             void moveFold(float lineCount, float lineHeight);
         private:
-            Lines *lines = nullptr;
-            Range key;
-            CursorChangeBox codeFoldStartCursorBox;
-            ActionableBox codeFoldEndActionBox;
-            CursorChangeBox codeFoldEndCursorBox;
+            Lines *m_lines = nullptr;
+            Range m_key;
+            CursorChangeBox m_codeFoldStartCursorBox;
+            ActionableBox m_codeFoldEndActionBox;
+            CursorChangeBox m_codeFoldEndCursorBox;
         };
 
         class CodeFoldTooltip : public ActionableBox {
@@ -550,9 +550,6 @@ namespace hex::ui {
             static const LanguageDefinition &Lua();
         };
 
-        TextEditor();
-        ~TextEditor();
-
         class UndoRecord {
         public:
             friend class TextEditor;
@@ -587,16 +584,6 @@ namespace hex::ui {
             UndoRecords m_records;
         };
 
-        class HiddenLine {
-        public:
-            friend class Lines;
-            HiddenLine() = default;
-            HiddenLine(i32 lineIndex, std::string lineContent) : m_lineIndex(lineIndex), m_line(std::move(lineContent)) {}
-        private:
-            i32 m_lineIndex{};
-            std::string m_line;
-        };
-
         enum class FoldSymbol : u8 { Line, Up, Down, Square };
 
         using CodeFolds             = std::map<Range, CodeFold>;
@@ -605,7 +592,6 @@ namespace hex::ui {
         using UndoBuffer            = std::vector<UndoAction>;
         using FoldedLines           = std::map<i32, FoldedLine>;
         using UnfoldedLines         = std::vector<Line>;
-        using HiddenLines           = std::vector<HiddenLine>;
         using FoldSymbols           = std::map<i32, FoldSymbol>;
         using StringVector          = std::vector<std::string>;
         using RangeFromCoordinates  = std::pair<Coordinates, Coordinates>;
@@ -615,7 +601,7 @@ namespace hex::ui {
         class Lines {
         public:
             friend class TextEditor;
-            Lines() : m_unfoldedLines({}), m_foldedLines({}), m_hiddenLines({}), m_defines({}) {}
+            Lines() : m_unfoldedLines({}), m_foldedLines({}), m_defines({}) {}
 
             Line &at(i32 index);
             Line &operator[](i32 index);
@@ -638,12 +624,12 @@ namespace hex::ui {
             void clearCodeFolds();
             void addClickableText(std::string text) { m_clickableText.push_back(text); }
             Breakpoints &getBreakpoints() { return m_breakpoints; }
-            void saveCodeFoldStates();
-            void applyCodeFoldStates();
+            void saveCodeFoldStates(std::string path);
+            void applyCodeFoldStates(std::string path);
             float lineIndexToRow(i32 lineNumber);
             float rowToLineIndex(i32 row);
             void getRowSegments();
-            void initializeCodeFolds();
+            void initializeCodeFolds(std::string path);
             bool updateCodeFolds();
             ImRect getBoxForRow(u32 lineNumber);
             void setFirstRow();
@@ -669,8 +655,6 @@ namespace hex::ui {
             friend bool Range::Coordinates::isValid(Lines &lines);
             friend TextEditor::Coordinates Range::Coordinates::sanitize(Lines &lines);
             void appendLine(const std::string &value);
-            void removeHiddenLinesFromPattern();
-            void addHiddenLinesToPattern();
             void setSelection(const Range &selection);
             Range getSelection() const;
             ImVec2 getLineStartScreenPos(float leftMargin, float lineNumber);
@@ -727,7 +711,7 @@ namespace hex::ui {
             void removeLines(i32 start, i32 end);
             void removeLine(i32 index);
             float textDistanceToLineStart(const Coordinates &from);
-            std::string getText(bool addHiddenLines = false);
+            std::string getText();
             void setCursorPosition();
             void setEditorState(const Coordinates &coordinates, bool setInteractiveStart = true);
             void ensureSelectionNotFolded();
@@ -751,9 +735,7 @@ namespace hex::ui {
             i32 getTokenId();
             void loadFirstTokenIdOfLine();
             i32 nextLineIndex(i32 lineIndex);
-            void setAllCodeFolds();
-            void setCodeFoldState(CodeFoldState states);
-            CodeFoldState getCodeFoldState() const;
+            void setAllCodeFolds(std::string path);
             void advanceToNextLine(i32 &lineIndex, i32 &currentTokenId, Location &location);
             void incrementTokenId(i32 &lineIndex, i32 &currentTokenId, Location &location);
             void moveToStringIndex(i32 stringIndex, i32 &currentTokenId, Location &location);
@@ -764,6 +746,7 @@ namespace hex::ui {
             void setScroll(ImVec2 scroll);
             ImVec2 getScroll() const {return m_scroll;}
             void swapSelectionEnds();
+            void setCdeFoldMaps();
 
             constexpr static u32 Normal = 0;
             constexpr static u32 Not    = 1;
@@ -793,9 +776,8 @@ namespace hex::ui {
         private:
             UnfoldedLines m_unfoldedLines;
             FoldedLines m_foldedLines;
-            HiddenLines m_hiddenLines;
             FoldSymbols m_rowToFoldSymbol;
-            MatchedDelimiter m_matchedDelimiter{};
+            MatchedDelimiter m_matchedDelimiter;
             bool m_colorizerEnabled = true;
             StringVector m_defines;
             FindReplaceHandler m_findReplaceHandler;
@@ -831,6 +813,7 @@ namespace hex::ui {
             StringVector m_clickableText;
             float m_topRow = 0.0F;
             bool m_setTopRow = false;
+            float m_topRowToSet = 0.0F;
             bool m_restoreSavedFolds = true;
             ImVec2 m_charAdvance;
             float m_leftMargin = 0.0F;
@@ -873,6 +856,10 @@ namespace hex::ui {
             bool m_hasVertScroll = false;
         };
 
+        TextEditor();
+        ~TextEditor();
+        void setPath(std::string path) { m_path = std::move(path); }
+
     private:
 // Rendering
         ImVec2 underWavesAt(ImVec2 pos, i32 nChars, ImColor color = ImGui::GetStyleColorVec4(ImGuiCol_Text), const ImVec2 &size_arg = ImVec2(0, 0));
@@ -906,10 +893,6 @@ namespace hex::ui {
         float lineIndexToRow(i32 lineNumber);
         void clearErrorMarkers();
         void clearActionables() { m_lines.clearActionables();}
-        void saveCodeFoldStates();
-        void applyCodeFoldStates();
-        void removeHiddenLinesFromPattern() { m_lines.removeHiddenLinesFromPattern(); }
-        void addHiddenLinesToPattern() { m_lines.addHiddenLinesToPattern(); }
         void setDisableCodeFolds(bool disable) { m_lines.m_codeFoldsDisabled = disable; }
 // Highlighting
     private:
@@ -933,7 +916,7 @@ namespace hex::ui {
         i64 drawColoredText(i32 lineIndex, const ImVec2 &textEditorSize);
         void drawBlockIndicators(ImDrawList *drawList);
         void drawMatchedDelimiter();
-        void postRender(float lineNumber, std::string textWindowName);
+        void postRender(float row, std::string textWindowName);
         ImVec2 calculateCharAdvance() const;
         void openCodeFoldAt(Coordinates line);
     public:
@@ -971,7 +954,7 @@ namespace hex::ui {
         void setLanguageDefinition(const LanguageDefinition &aLanguageDef) { m_lines.setLanguageDefinition(aLanguageDef); }
         std::string getLineText(i32 line);
         void setTextChanged(bool value) { m_lines.setTextChanged(value); }
-        std::string getText(bool addHiddenLines = false) { return m_lines.getText(addHiddenLines); }
+        std::string getText() { return m_lines.getText(); }
         void addUndo(UndoRecords value) { m_lines.addUndo(value); }
         bool isTextChanged() { return m_lines.isTextChanged(); }
         void setHandleMouseInputs(bool value) { m_handleMouseInputs = value; }
@@ -1051,6 +1034,7 @@ namespace hex::ui {
         static i32 stringCharacterCount(const std::string &str);
         Coordinates lineCoordsToIndexCoords(const Coordinates &coordinates);
     private:
+        std::string m_path;
         float m_lineSpacing = 1.0F;
         Lines m_lines;
         float m_newTopMargin = 0.0F;

--- a/plugins/ui/source/ui/text_editor/code_folder.cpp
+++ b/plugins/ui/source/ui/text_editor/code_folder.cpp
@@ -3,6 +3,7 @@
 #include <pl/core/token.hpp>
 #include <wolv/utils/string.hpp>
 #include <hex/helpers/logger.hpp>
+#include <hex/helpers/file_attached_data.hpp>
 #include <hex/api/content_registry/pattern_language.hpp>
 #include <pl/core/preprocessor.hpp>
 #include <pl/api.hpp>
@@ -318,7 +319,7 @@ namespace hex::ui {
         i32 lineIndex = location.line - 1;
         std::string delimiters, openDelimiter, closeDelimiter;
         i32 currentTokenId = from;
-        auto line = operator[](lineIndex);
+        auto line = m_unfoldedLines[lineIndex];
         if (isOpenFound) {
             delimiters = s_openDelimiters + s_closeDelimiters;
             if (auto columnIndex = line.m_chars.find_first_of(s_delimiters, location.column - 1); columnIndex != std::string::npos) {
@@ -340,7 +341,7 @@ namespace hex::ui {
                 if (currentTokenId < 0) {
                     return result;
                 }
-                line = operator[](m_curr->location.line - 1);
+                line = m_unfoldedLines[m_curr->location.line - 1];
                 size_t stringIndex = line.columnIndex(m_curr->location.column);
                 std::string currentChar = std::string(1, line[static_cast<u64>(stringIndex - 1)]);
                 location = m_curr->location;
@@ -403,13 +404,14 @@ namespace hex::ui {
         return result;
     }
 
-    void TextEditor::saveCodeFoldStates() {
-        m_lines.saveCodeFoldStates();
-    }
-
-    void Lines::saveCodeFoldStates() {
+    void Lines::saveCodeFoldStates(std::string path) {
+        if (m_codeFoldKeys.empty()) {
+            m_saveCodeFoldStateRequested = true;
+            return;
+        }
         i32 codeFoldIndex = 0;
         Indices closedFoldIncrements;
+        std::string result;
         for (auto key: m_codeFoldKeys) {
             if (m_codeFoldState.contains(key) && !m_codeFoldState[key]) {
                 closedFoldIncrements.push_back(codeFoldIndex);
@@ -417,31 +419,18 @@ namespace hex::ui {
             } else
                 codeFoldIndex++;
         }
-        if (!m_hiddenLines.empty())
-            m_hiddenLines.clear();
         if (!closedFoldIncrements.empty()) {
-            std::string result = "//+-#:";
             for (u32 i = 0; i < closedFoldIncrements.size(); ++i) {
                 result += std::to_string(closedFoldIncrements[i]);
                 if (i < closedFoldIncrements.size() - 1)
                     result += ",";
             }
-            auto lineIndex = 0;
-            m_hiddenLines.emplace_back(lineIndex, result);
         }
-    }
-
-    void TextEditor::applyCodeFoldStates() {
-        m_lines.applyCodeFoldStates();
-    }
-
-    void Lines::setCodeFoldState(CodeFoldState state) {
-        m_codeFoldState = state;
-        saveCodeFoldStates();
-    }
-
-    CodeFoldState Lines::getCodeFoldState() const {
-        return m_codeFoldState;
+        hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
+        if (result.empty())
+            closedFoldData.erase(path);
+        else
+           closedFoldData.get(path) = result;
     }
 
     void Lines::resetCodeFoldStates() {
@@ -450,20 +439,11 @@ namespace hex::ui {
             m_codeFoldState[key] = true;
     }
 
-    void Lines::applyCodeFoldStates() {
+    void Lines::applyCodeFoldStates(std::string path) {
+        hex::FileAttachedData<"closed_folds", std::string> closedFoldData;
 
-        std::string commentLine;
-        for (const auto& line: m_hiddenLines) {
-            if (line.m_line.starts_with("//+-#:")) {
-                commentLine = line.m_line;
-                break;
-            }
-        }
-        if (commentLine.size() < 6 || !commentLine.starts_with("//+-#:")) {
-            resetCodeFoldStates();
-            return;
-        }
-        auto states = commentLine.substr(6);
+        std::string states = closedFoldData.get(path);
+
         i32 count;
         StringVector stringVector;
         if (states.empty())
@@ -471,6 +451,10 @@ namespace hex::ui {
         else {
             stringVector = wolv::util::splitString(states, ",", true);
             count = stringVector.size();
+            if (m_codeFoldKeys.empty()) {
+                m_useSavedFoldStatesRequested = true;
+                return;
+            }
         }
         if (count == 1 && stringVector[0].empty())
             return;
@@ -615,9 +599,9 @@ namespace hex::ui {
         if (userTriggered) {
             auto topLine = lineCoordinates( rowToLineIndex(topRow), 0);
             if (key.contains(topLine))
-                m_topRow = lineIndexToRow(key.m_start.m_line);
+                m_topRowToSet = lineIndexToRow(key.m_start.m_line);
             else
-                m_topRow = topRow;
+                m_topRowToSet = topRow;
             m_setTopRow = true;
             m_saveCodeFoldStateRequested = true;
             m_globalRowMaxChanged = true;
@@ -812,19 +796,14 @@ namespace hex::ui {
         }
     }
 
-    void Lines::setAllCodeFolds() {
-        initializeCodeFolds();
+    void Lines::setAllCodeFolds(std::string path) {
+        initializeCodeFolds(path);
         tokensFromSource();
         m_foldPoints.clear();
         findFoldDelimiters(0, false);
         setIndentBlocks();
         nonDelimitedFolds();
         m_codeFoldKeys.clear();
-        m_codeFolds.clear();
-        m_codeFoldKeyMap.clear();
-        m_codeFoldValueMap.clear();
-        m_codeFoldKeyLineMap.clear();
-        m_codeFoldValueLineMap.clear();
         m_codeFoldDelimiters.clear();
         m_indentBlocks.clear();
         m_indentBlocks.insert(Range(lineCoordinates(0, 0), lineCoordinates(size() - 1, m_unfoldedLines.back().size())));
@@ -846,6 +825,16 @@ namespace hex::ui {
                 foldDelimiters.first = foldDelimiters.second - 2 + (foldDelimiters.second == ')');
             m_codeFoldKeys.insert(foldInterval);
             m_codeFoldDelimiters[foldInterval] = foldDelimiters;
+        }
+        initializeCodeFolds(path);
+    }
+
+    void Lines::setCdeFoldMaps() {
+        m_codeFoldKeyMap.clear();
+        m_codeFoldKeyLineMap.clear();
+        m_codeFoldValueMap.clear();
+        m_codeFoldValueLineMap.clear();
+        for (auto foldInterval: m_codeFoldKeys) {
             if (!m_codeFoldKeyMap.contains(foldInterval.m_start))
                 m_codeFoldKeyMap[foldInterval.m_start] = foldInterval.m_end;
             if (!m_codeFoldValueMap.contains(foldInterval.m_end))

--- a/plugins/ui/source/ui/text_editor/editor.cpp
+++ b/plugins/ui/source/ui/text_editor/editor.cpp
@@ -893,7 +893,7 @@ namespace hex::ui {
         m_lines.refreshSearchResults();
     }
 
-    std::string Lines::getText(bool includeHiddenLines) {
+    std::string Lines::getText() {
         auto start = lineCoordinates(0, 0);
         auto size = m_unfoldedLines.size();
         auto line = m_unfoldedLines[size - 1];
@@ -901,11 +901,6 @@ namespace hex::ui {
         if (start == Invalid || end == Invalid)
             return "";
         std::string result;
-        if (includeHiddenLines) {
-            for (const auto &hiddenLine: m_hiddenLines) {
-                result += hiddenLine.m_line + "\n";
-            }
-        }
         result += getRange(Range(start, end));
         return result;
     }

--- a/plugins/ui/source/ui/text_editor/navigate.cpp
+++ b/plugins/ui/source/ui/text_editor/navigate.cpp
@@ -143,6 +143,7 @@ namespace hex::ui {
             setScrollY();
             return;
         }
+        auto pageSize = std::floor(m_numberOfLinesDisplayed);
         auto row = lineIndexToRow(m_state.m_cursorPosition.m_line);
         if (isMultiLineRow(row)) {
             auto position = unfoldedToFoldedCoords(m_state.m_cursorPosition);
@@ -151,8 +152,16 @@ namespace hex::ui {
         if (row < amount) {
             row = 0;
             m_state.m_cursorPosition.m_column = 0;
-        } else
+        } else {
             row -= amount;
+            if (amount >= pageSize) {
+                auto numberOfPagesToScroll = std::floor(amount / pageSize);
+                auto numberOfAvailablePages = std::floor(m_topRow / pageSize);
+                auto numberOfPages = std::min(numberOfPagesToScroll, numberOfAvailablePages);
+                m_topRowToSet = m_topRow - numberOfPages * pageSize;
+                setFirstRow();
+            }
+        }
         if (isMultiLineRow(row)) {
             auto position = foldedToUnfoldedCoords(Coordinates( rowToLineIndex(row), m_state.m_cursorPosition.m_column));
             m_state.m_cursorPosition = position;
@@ -180,28 +189,39 @@ namespace hex::ui {
             setScrollY();
             return;
         }
+        auto pageSize = std::floor(m_numberOfLinesDisplayed);
+        auto row = lineIndexToRow(oldPos.m_line);
+        auto column = oldPos.m_column;
 
-        if (isLastLine(oldPos.m_line) && m_state.m_cursorPosition.m_column == lineMaxColumn(oldPos.m_line)) {
-            if (m_topRow < getGlobalRowMax()) {
-                m_topRow += amount;
-                m_topRow = std::clamp(m_topRow, 0.0F, getGlobalRowMax());
-                setFirstRow();
-                ensureCursorVisible();
-            }
+        if (row + amount > getGlobalRowMax() && column >= lineMaxColumn(rowToLineIndex(getGlobalRowMax()))) {
+            row += amount;
+            row = std::clamp(row, 0.0F, getGlobalRowMax());
+            m_state.m_cursorPosition.m_line = rowToLineIndex(row);
+            m_topRowToSet = m_topRow + amount;
+            m_topRowToSet = std::clamp(m_topRowToSet, 0.0F, getGlobalRowMax());
+            setFirstRow();
+            ensureCursorVisible();
             return;
         }
 
-        auto row = lineIndexToRow(m_state.m_cursorPosition.m_line);
         if (isMultiLineRow(row)) {
-            auto position = unfoldedToFoldedCoords(m_state.m_cursorPosition);
+            auto position = unfoldedToFoldedCoords(oldPos);
             m_state.m_cursorPosition.m_column = position.m_column;
         }
         if (row + amount > getGlobalRowMax()) {
             row = getGlobalRowMax();
             m_state.m_cursorPosition.m_column = lineMaxColumn(rowToLineIndex(row));
-        } else
+        } else {
             row += amount;
-
+            if (amount >= pageSize) {
+                auto numberOfPagesToScroll = std::floor(amount / pageSize);
+                auto numberOfAvailablePages = std::floor((getGlobalRowMax() - m_topRow) / pageSize);
+                auto numberOfPages = std::min(numberOfPagesToScroll, numberOfAvailablePages);
+                m_topRowToSet = m_topRow + numberOfPages * pageSize;
+                setFirstRow();
+            } else
+                ensureCursorVisible();
+        }
         if (isMultiLineRow(row)) {
             auto position = foldedToUnfoldedCoords(Coordinates( rowToLineIndex(row), m_state.m_cursorPosition.m_column));
             m_state.m_cursorPosition = position;
@@ -415,7 +435,8 @@ namespace hex::ui {
         } else {
             m_setScrollY = false;
             auto scrollY = ImGui::GetScrollY();
-            ImGui::SetScrollY(std::clamp(scrollY + m_scrollYIncrement, 0.0f, ImGui::GetScrollMaxY()));
+            m_scroll.y = std::clamp(scrollY + m_scrollYIncrement, 0.0f, ImGui::GetScrollMaxY());
+            ImGui::SetScrollY(m_scroll.y);
         }
     }
 
@@ -426,7 +447,8 @@ namespace hex::ui {
         } else {
             m_setScrollX = false;
             auto scrollX = ImGui::GetScrollX();
-            ImGui::SetScrollX(std::clamp(scrollX + m_scrollXIncrement, 0.0f, ImGui::GetScrollMaxX()));
+            m_scroll.x = std::clamp(scrollX + m_scrollXIncrement, 0.0f, ImGui::GetScrollMaxX());
+            ImGui::SetScrollX(m_scroll.x);
         }
     }
 
@@ -494,10 +516,10 @@ namespace hex::ui {
             m_line = std::clamp(m_line, 0, lineCount - 1);
 
 
-        auto maxColumn = lines.lineMaxColumn(m_line) + 1;
+        auto maxColumn = lines.lineMaxColumn(m_line);
         if (m_column < 0) {
-            m_column = std::clamp(m_column, -maxColumn, -1);
-            m_column = maxColumn + m_column;
+            m_column = std::clamp(m_column, -maxColumn - 1, -1);
+            m_column = maxColumn + m_column + 1;
         } else
             m_column = std::clamp(m_column, 0, maxColumn);
 

--- a/plugins/ui/source/ui/text_editor/render.cpp
+++ b/plugins/ui/source/ui/text_editor/render.cpp
@@ -219,7 +219,7 @@ namespace hex::ui {
             return;
         } else {
             m_setTopRow = false;
-            ImGui::SetScrollY(m_topRow * m_charAdvance.y);
+            ImGui::SetScrollY(m_topRowToSet * m_charAdvance.y);
         }
     }
 
@@ -331,8 +331,8 @@ namespace hex::ui {
         ImVec2 textEditorSize = size;
         textEditorSize.x -= m_lines.m_lineNumberFieldWidth;
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::ColorConvertU32ToFloat4(m_palette[(i32) PaletteIndex::Background]));
-        m_scrollX = m_longestDrawnLineLength * m_lines.m_charAdvance.x >= textEditorSize.x;
         m_scrollY = m_lines.size() > 1;
+        m_scrollX = m_longestDrawnLineLength * m_lines.m_charAdvance.x >= textEditorSize.x - (m_scrollY ? ImGui::GetStyle().ScrollbarSize : 0.0f);
         m_lines.m_hasHorizScroll = m_scrollX;
         m_lines.m_hasVertScroll = m_scrollY;
         ImGui::SetCursorScreenPos(ImVec2(m_lines.m_lineNumbersStartPos.x + m_lines.m_lineNumberFieldWidth, m_lines.m_lineNumbersStartPos.y));
@@ -386,16 +386,20 @@ namespace hex::ui {
         auto foldedSelectionEnd = unfoldedToFoldedCoords(selectionEnd);
         for (auto &foldedLine: m_foldedLines) {
             auto keyCount = foldedLine.second.m_keys.size();
+            Keys toOpen;
             for (u32 i = 0; i < keyCount; i++) {
                 auto ellipsisIndex = foldedLine.second.m_ellipsisIndices[i];
                 Range ellipsisRange = Range(
                     Coordinates(rowToLineIndex(foldedLine.first), ellipsisIndex),
                     Coordinates(rowToLineIndex(foldedLine.first), ellipsisIndex + 3)
                 );
-                if (Range(foldedSelectionStart,foldedSelectionEnd).overlaps(ellipsisRange)) {
-                    openCodeFold(foldedLine.second.m_keys[i]);
-                }
+                if (Range(foldedSelectionStart,foldedSelectionEnd).overlaps(ellipsisRange))
+                    toOpen.push_back(foldedLine.second.m_keys[i]);
+
             }
+            for (auto &key: toOpen)
+                openCodeFold(key);
+
         }
     }
 
@@ -425,15 +429,25 @@ namespace hex::ui {
         float scrollX = ImGui::GetScrollX();
         float scrollY = ImGui::GetScrollY();
 
+        ImGuiContext &g = *GImGui;
+        if ( g.CurrentWindow->ScrollTarget.y != FLT_MAX && g.CurrentWindow->ScrollTarget.y != scrollY) {
+            ImGui::SetScrollY(g.CurrentWindow->ScrollTarget.y);
+            m_scrollToCursor = true;
+            return;
+        }
+
         float height = ImGui::GetWindowHeight() - m_topMargin  - (m_hasHorizScroll ? ImGui::GetStyle().ScrollbarSize : 0.0f);
-        float width = ImGui::GetWindowWidth()   - m_leftMargin - (m_hasVertScroll ? ImGui::GetStyle().ScrollbarSize : 0.0f);
+        float width  = ImGui::GetWindowWidth() - m_leftMargin - (m_hasVertScroll ? ImGui::GetStyle().ScrollbarSize : 0.0f);
 
         float top = m_topMargin > scrollY ? m_topMargin - scrollY : scrollY;
+        float bottom = top + height - m_charAdvance.y;
         float topRow = top / m_charAdvance.y;
-        float bottomRow = ((top + height) / m_charAdvance.y) - 1;
+        float bottomRow = bottom / m_charAdvance.y;
 
-        float leftColumnIndex = scrollX / m_charAdvance.x;
-        float rightColumnIndex = ((scrollX + width) / m_charAdvance.x) - 1;
+        float left = scrollX;
+        float right = left + width - m_charAdvance.x;
+        float leftColumnIndex = left / m_charAdvance.x;
+        float rightColumnIndex = right / m_charAdvance.x;
 
         pos = lineCoordinates(unfoldedToFoldedCoords(m_state.m_cursorPosition));
 
@@ -442,11 +456,11 @@ namespace hex::ui {
         bool scrollToCursorX = true;
         bool scrollToCursorY = true;
 
-        if ((posRow > topRow && posRow <= bottomRow) ||
+        if ((posRow == 0 && topRow == 0 ) || (posRow >= topRow + 1 && posRow <= bottomRow - 1) ||
             (posRow == topRow && topRow == getGlobalRowMax()  && scrollY == ImGui::GetScrollMaxY()))
             scrollToCursorY = false;
 
-        if ((posColumnIndex >= leftColumnIndex) && (posColumnIndex < rightColumnIndex))
+        if ((posColumnIndex == 0 && leftColumnIndex == 0) || ((posColumnIndex >= leftColumnIndex + 1) && (posColumnIndex <= rightColumnIndex - 1)))
             scrollToCursorX = false;
 
         if ((!scrollToCursorX && !scrollToCursorY && m_oldTopMargin == m_topMargin) || pos.m_line < 0) {
@@ -454,31 +468,37 @@ namespace hex::ui {
             return;
         }
 
+        bool scrollToCursor = false;
+
         if (scrollToCursorY) {
-            if (posRow <= topRow) {
-                if (posRow <= 0) {
-                    ImGui::SetScrollY(0.0f);
-                    m_scrollToCursor = false;
-                    return;
-                }
-                ImGui::SetScrollY(posRow * m_charAdvance.y);
-                m_scrollToCursor = true;
+            if (posRow < topRow + 1) {
+                ImGui::SetScrollY((posRow - 1) * m_charAdvance.y);
+                scrollToCursor = true;
             }
-            if (posRow >= bottomRow) {
-                ImGui::SetScrollY((posRow + 1) * m_charAdvance.y - height);
-                m_scrollToCursor = true;
+
+           if (posRow > bottomRow - 1 && posRow <= bottomRow) {
+                ImGui::SetScrollY(scrollY + (m_charAdvance.y - ((i64) bottom % (i64) m_charAdvance.y)));
+                scrollToCursor = true;
+            } else if (posRow > bottomRow - 1) {
+                ImGui::SetScrollY(std::max(0.0f, posRow * m_charAdvance.y));
+                scrollToCursor = true;
             }
         }
         if (scrollToCursorX) {
-            if (posColumnIndex < leftColumnIndex) {
-                ImGui::SetScrollX(std::max(0.0f, posColumnIndex * m_charAdvance.x));
-                m_scrollToCursor = true;
+            if (posColumnIndex < leftColumnIndex + 1) {
+                ImGui::SetScrollX(std::max(0.0f, (posColumnIndex - 1) * m_charAdvance.x));
+                scrollToCursor = true;
             }
-            if (posColumnIndex > rightColumnIndex) {
-                ImGui::SetScrollX(std::max(0.0f, posColumnIndex * m_charAdvance.x - width));
-                m_scrollToCursor = true;
+
+            if (posColumnIndex > rightColumnIndex - 1 && posColumnIndex <= rightColumnIndex) {
+                ImGui::SetScrollX(scrollX + (m_charAdvance.x - ((i64) right % (i64) m_charAdvance.x)));
+                scrollToCursor = true;
+            } else if (posColumnIndex > rightColumnIndex - 1) {
+                ImGui::SetScrollX(std::max(0.0f, posColumnIndex * m_charAdvance.x));
+                scrollToCursor = true;
             }
         }
+        m_scrollToCursor = scrollToCursor;
         m_oldTopMargin = m_topMargin;
     }
 
@@ -517,27 +537,27 @@ namespace hex::ui {
     }
 
     bool TextEditor::CodeFold::trigger() {
-        lines->m_codeFoldHighlighted = NoCodeFoldSelected;
+        m_lines->m_codeFoldHighlighted = NoCodeFoldSelected;
        if (!isOpen() && startHovered()) {
-            lines->m_codeFoldHighlighted = key;
-            codeFoldStartCursorBox.callback();
+           m_lines->m_codeFoldHighlighted = m_key;
+           m_codeFoldStartCursorBox.callback();
        } else {
-           auto &rowFoldSymbols = lines->m_rowToFoldSymbol;
-           auto row = lines->lineIndexToRow(key.m_end.m_line);
+           auto &rowFoldSymbols = m_lines->m_rowToFoldSymbol;
+           auto row = m_lines->lineIndexToRow(m_key.m_end.m_line);
            if (isOpen() && endHovered()  && rowFoldSymbols.contains(row) && rowFoldSymbols[row] != FoldSymbol::Square) {
-               lines->m_codeFoldHighlighted = key;
-               codeFoldEndCursorBox.callback();
+               m_lines->m_codeFoldHighlighted = m_key;
+               m_codeFoldEndCursorBox.callback();
            }
-           row = lines->lineIndexToRow(key.m_start.m_line);
+           row = m_lines->lineIndexToRow(m_key.m_start.m_line);
            if (startHovered() && rowFoldSymbols.contains(row) && rowFoldSymbols[row] != FoldSymbol::Square) {
-               lines->m_codeFoldHighlighted = key;
-               codeFoldStartCursorBox.callback();
+               m_lines->m_codeFoldHighlighted = m_key;
+               m_codeFoldStartCursorBox.callback();
            }
        }
 
         bool result = TextEditor::ActionableBox::trigger();
         if (isOpen())
-            result = result || codeFoldEndActionBox.trigger();
+            result = result || m_codeFoldEndActionBox.trigger();
         bool clicked = ImGui::IsMouseClicked(0);
         result = result && clicked;
         return result;
@@ -564,12 +584,9 @@ namespace hex::ui {
         }
     }
 
-    void TextEditor::Lines::initializeCodeFolds() {
+    void TextEditor::Lines::initializeCodeFolds(std::string path) {
 
-        m_codeFoldKeyMap.clear();
-        m_codeFoldKeyLineMap.clear();
-        m_codeFoldValueMap.clear();
-        m_codeFoldValueLineMap.clear();
+
         m_codeFolds.clear();
         m_rowToFoldSymbol.clear();
 
@@ -598,15 +615,9 @@ namespace hex::ui {
             auto index = m_codeFoldKeys.find(key);
             if (index->m_start != key.m_start || index->m_end != key.m_end)
                 m_codeFoldState[key] = true;
-
-            if (!m_codeFoldKeyMap.contains(key.m_start))
-                m_codeFoldKeyMap[key.m_start] = key.m_end;
-
-            if (!m_codeFoldValueMap.contains(key.m_end))
-                m_codeFoldValueMap[key.m_end] = key.m_start;
-            m_codeFoldKeyLineMap.insert(std::make_pair(key.m_start.m_line, key.m_start));
-            m_codeFoldValueLineMap.insert(std::make_pair(key.m_end.m_line, key.m_end));
         }
+
+        setCdeFoldMaps();
 
         for (auto &[row, foldedLine]: m_foldedLines) {
             for (auto key = foldedLine.m_keys.begin(); key != foldedLine.m_keys.end(); key++) {
@@ -618,12 +629,14 @@ namespace hex::ui {
 
         updateLinesSize();
 
-        if (m_useSavedFoldStatesRequested) {
-            applyCodeFoldStates();
-            m_useSavedFoldStatesRequested = false;
-        } else if (m_saveCodeFoldStateRequested) {
-            saveCodeFoldStates();
-            m_saveCodeFoldStateRequested = false;
+        if (!m_codeFoldKeys.empty()) {
+            if (m_useSavedFoldStatesRequested) {
+                m_useSavedFoldStatesRequested = false;
+                applyCodeFoldStates(path);
+            } else if (m_saveCodeFoldStateRequested) {
+                m_saveCodeFoldStateRequested = false;
+                saveCodeFoldStates(path);
+            }
         }
 
         m_foldedLines.clear();
@@ -1163,28 +1176,25 @@ namespace hex::ui {
         m_lines.m_cursorScreenPosition = ImGui::GetCursorScreenPos();
 
         m_topLineNumber = getTopLineNumber();
-        float lineIndex = m_topLineNumber;
+        float lineIndex;
 
-        float scrollX;
-        if (m_lines.m_setScrollX)
-            m_lines.setScrollX();
-        else
-            scrollX = ImGui::GetScrollX();
-
-        float scrollY;
-        if (m_lines.m_setScrollY)
-            m_lines.setScrollY();
-        else
-            scrollY = ImGui::GetScrollY();
-
+        float scrollY = 0.0F;
         if (m_lines.m_setScroll) {
             m_lines.setScroll(m_lines.m_scroll);
             scrollY = m_lines.m_scroll.y;
-            scrollX = m_lines.m_scroll.x;
         } else {
-            scrollY = ImGui::GetScrollY();
-            scrollX = ImGui::GetScrollX();
-            m_lines.m_scroll = ImVec2(scrollX, scrollY);
+
+            if (m_lines.m_setScrollX)
+                m_lines.setScrollX();
+            else
+                m_lines.m_scroll.x = ImGui::GetScrollX();
+
+            if (m_lines.m_setScrollY)
+                m_lines.setScrollY();
+            else
+                m_lines.m_scroll.y = ImGui::GetScrollY();
+
+            scrollY = m_lines.m_scroll.y;
         }
 
         if (m_lines.m_setTopRow)
@@ -1193,12 +1203,10 @@ namespace hex::ui {
             m_lines.m_topRow = std::max<float>(0.0F, (scrollY - m_lines.m_topMargin) / m_lines.m_charAdvance.y);
 
         float row = m_lines.m_topRow;
-        float maxDisplayedRow = m_lines.getMaxDisplayedRow();
-
         m_longestDrawnLineLength = m_longestLineLength;
         if (!m_lines.isEmpty()) {
             if (!m_lines.m_codeFoldsDisabled) {
-                m_lines.initializeCodeFolds();
+                m_lines.initializeCodeFolds(m_path);
                 if (m_lines.updateCodeFolds()) {
                     m_lines.setFocusAtCoords(m_lines.m_state.m_cursorPosition, false);
                 }
@@ -1207,7 +1215,7 @@ namespace hex::ui {
             }
 
             bool focused = ImGui::IsWindowFocused();
-            while (std::floor(row) <= std::floor(maxDisplayedRow)) {
+            for (u32 i=0; i < std::floor(m_lines.m_numberOfLinesDisplayed + 0.025f); i++) {
                 if (!focused && m_lines.m_updateFocus) {
                     m_lines.m_state.m_cursorPosition = m_lines.m_focusAtCoords;
                     m_lines.resetCursorBlinkTime();
@@ -1272,7 +1280,7 @@ namespace hex::ui {
             ImGui::Dummy(m_lines.m_charAdvance);
         }
 
-        postRender(lineIndex, "##lineNumbers");
+        postRender(row, "##lineNumbers");
         if (m_lines.m_scrollToCursor)
             m_lines.ensureCursorVisible();
         m_lines.m_withinRender = false;
@@ -1356,7 +1364,7 @@ namespace hex::ui {
             color.w *= ImGui::GetStyle().Alpha;
             m_palette[i] = ImGui::ColorConvertFloat4ToU32(color);
         }
-        auto windowHeight = ImGui::GetWindowHeight();
+        auto windowHeight = ImGui::GetWindowHeight() - m_lines.m_topMargin;
         if (m_scrollX)
             windowHeight -= ImGui::GetStyle().ScrollbarSize;
         m_lines.m_numberOfLinesDisplayed = windowHeight / m_lines.m_charAdvance.y;
@@ -1364,7 +1372,7 @@ namespace hex::ui {
 
     void TextEditor::drawSelection(float lineIndex, ImDrawList *drawList) {
         auto row = m_lines.lineIndexToRow(lineIndex);
-        auto lineStartScreenPos = m_lines.getLineStartScreenPos(0,row);
+        auto lineStartScreenPos = m_lines.getLineStartScreenPos(0, row);
         Range lineCoords;
         if (m_lines.isMultiLineRow(row)) {
             lineCoords.m_start = m_lines.lineCoordinates(m_lines.m_foldedLines.at(row).m_full.m_start.m_line, 0);
@@ -1396,7 +1404,7 @@ namespace hex::ui {
             ImGui::BeginChild(title.c_str());
         auto row = m_lines.lineIndexToRow(lineIndex);
         auto lineStartScreenPos = m_lines.getLineStartScreenPos(0, row);
-        ImVec2 lineNumberStartScreenPos = ImVec2(m_lines.m_lineNumbersStartPos.x, lineStartScreenPos.y);
+        ImVec2 lineNumberStartScreenPos = ImVec2(m_lines.m_lineNumbersStartPos.x + 2, lineStartScreenPos.y);
         auto start = lineStartScreenPos;
         ImVec2 end = lineStartScreenPos + ImVec2(m_lines.m_lineNumberFieldWidth + contentSize.x, m_lines.m_charAdvance.y);
         auto center = lineNumberStartScreenPos + ImVec2(m_lines.m_lineNumberFieldWidth - 2 * m_lines.m_charAdvance.x + 1_scaled, 0);
@@ -1463,10 +1471,10 @@ namespace hex::ui {
             }
         }
 
-        if (ImGui::IsItemHovered() && (ImGui::IsKeyDown(ImGuiKey_RightShift) || ImGui::IsKeyDown(ImGuiKey_LeftShift)) && m_lines.m_state.m_cursorPosition.isValid(m_lines)) {
+        if (ImGui::IsItemHovered() && (ImGui::IsKeyDown(ImGuiKey_RightShift) || ImGui::IsKeyDown(ImGuiKey_LeftShift))) {
             if (ImGui::BeginTooltip()) {
                 auto lineCursor = m_lines.m_state.m_cursorPosition.m_line + 1;
-                auto columnCursor = m_lines.m_state.m_cursorPosition.m_column + 1;
+                auto columnCursor = std::min(m_lines.m_state.m_cursorPosition.m_column + 1, m_lines.lineMaxColumn(m_lines.m_state.m_cursorPosition.m_line) + 1);
                 ImGui::Text("(%d/%d)", lineCursor, columnCursor);
             }
             ImGui::EndTooltip();
@@ -1477,8 +1485,8 @@ namespace hex::ui {
 
     void TextEditor::drawLineNumbers(float lineIndex) {
         auto row = m_lines.lineIndexToRow(lineIndex);
-        auto lineStartScreenPos = m_lines.getLineStartScreenPos(0,row);
-        ImVec2 lineNumberStartScreenPos = ImVec2(m_lines.m_lineNumbersStartPos.x, lineStartScreenPos.y);
+        auto lineStartScreenPos = m_lines.getLineStartScreenPos(0, row);
+        ImVec2 lineNumberStartScreenPos = ImVec2(m_lines.m_lineNumbersStartPos.x + 3, lineStartScreenPos.y);
         auto lineNumber = lineIndex + 1;
         if (lineNumber <= 0)
             return;
@@ -1495,7 +1503,7 @@ namespace hex::ui {
         i32 padding = std::floor(std::log10(m_lines.size())) - std::floor(std::log10((float)lineNumberToDraw));
         std::string lineNumberStr = std::string(padding, ' ') + std::to_string(lineNumberToDraw);
 
-        TextUnformattedColoredAt(ImVec2(lineNumberStartScreenPos.x, lineStartScreenPos.y), color, lineNumberStr.c_str());
+        TextUnformattedColoredAt(lineNumberStartScreenPos, color, lineNumberStr.c_str());
     }
 
     void TextEditor::drawCursor(float lineIndex, const ImVec2 &contentSize, bool focused, ImDrawList *drawList) {
@@ -1550,7 +1558,7 @@ namespace hex::ui {
 
     void TextEditor::drawButtons(float lineIndex) {
         auto row = m_lines.lineIndexToRow(lineIndex);
-         auto lineStartScreenPos = m_lines.getLineStartScreenPos(0,row);
+         auto lineStartScreenPos = m_lines.getLineStartScreenPos(0, row);
         auto lineText = m_lines.m_unfoldedLines[lineIndex].m_chars;
         Coordinates gotoKey = lineCoordinates( lineIndex + 1, 1);
         if (gotoKey != Invalid) {
@@ -1611,7 +1619,7 @@ namespace hex::ui {
 
     void TextEditor::drawText(Coordinates &lineStart, u32 tokenLength, unsigned char color) {
         auto row = m_lines.lineIndexToRow(lineStart.m_line);
-        auto begin = m_lines.getLineStartScreenPos(0,row);
+        auto begin = m_lines.getLineStartScreenPos(0, row);
         i32 renderColor = color;
         Line line = m_lines[lineStart.m_line];
         auto i = line.columnIndex(lineStart.m_column);
@@ -1642,8 +1650,10 @@ namespace hex::ui {
            fonts::CodeEditor().pop();
 
         ErrorMarkers::iterator errorIt;
-        auto errorHoverBoxKey = lineStart + lineCoordinates( 1, 1);
-        if (errorIt = m_lines.m_errorMarkers.find(errorHoverBoxKey); errorIt != m_lines.m_errorMarkers.end()) {
+        auto errorHoverBoxKey = lineStart + Coordinates(1, 1);
+        if (errorIt = std::find_if(m_lines.m_errorMarkers.begin(), m_lines.m_errorMarkers.end(), [&](const auto &item) {
+                return item.first >= errorHoverBoxKey && item.first <= errorHoverBoxKey + Coordinates(0, tokenLength);
+            }); errorIt != m_lines.m_errorMarkers.end()) {
             auto errorMessage = errorIt->second.second;
             auto errorLength = errorIt->second.first;
             if (errorLength == 0 && line.size() > (u32) i + 1)
@@ -1665,7 +1675,7 @@ namespace hex::ui {
     }
 
     TextEditor::CodeFold::CodeFold(Lines *lines,  TextEditor::Range key, const ImRect &startBox, const ImRect &endBox) :
-            ActionableBox(startBox), lines(lines), key(key), codeFoldStartCursorBox(startBox), codeFoldEndActionBox(endBox), codeFoldEndCursorBox(endBox)
+            ActionableBox(startBox), m_lines(lines), m_key(key), m_codeFoldStartCursorBox(startBox), m_codeFoldEndActionBox(endBox), m_codeFoldEndCursorBox(endBox)
             {
     if (lines->m_codeFolds.empty())
         return;
@@ -1679,15 +1689,12 @@ namespace hex::ui {
         lines->m_codeFoldState[key] = true;
 }
 
-    void TextEditor::postRender(float lineIndex, std::string title) {
-        lineIndex--;
-        float row = m_lines.lineIndexToRow(lineIndex);
+    void TextEditor::postRender(float row, std::string title) {
+        row--;
         auto lineStartScreenPos = m_lines.getLineStartScreenPos(0, row);
 
         float globalRowMax = m_lines.getGlobalRowMax();
-        auto rowMax = 0;
-        if (globalRowMax > 0)
-            rowMax = std::clamp(row + m_lines.m_numberOfLinesDisplayed, 0.0F, globalRowMax - 1.0F);
+        auto rowMax = m_lines.getMaxDisplayedRow();
         float xPadding = (m_longestDrawnLineLength + 1) * m_lines.m_charAdvance.x;
         float yPadding = (globalRowMax - rowMax) * m_lines.m_charAdvance.y + ImGui::GetWindowHeight();
         if (!m_lines.m_ignoreImGuiChild) {
@@ -1709,20 +1716,9 @@ namespace hex::ui {
             auto window = ImGui::GetCurrentWindow();
             auto maxScroll = window->ScrollMax.y;
             if (maxScroll > 0) {
-                float pixelCount;
-                if (m_newTopMargin > m_lines.m_topMargin) {
-                    pixelCount = m_newTopMargin - m_lines.m_topMargin;
-                } else if (m_newTopMargin > 0) {
-                    pixelCount = m_lines.m_topMargin - m_newTopMargin;
-                } else {
-                    pixelCount = m_lines.m_topMargin;
-                }
                 auto oldScrollY = ImGui::GetScrollY();
+                m_shiftedScrollY = oldScrollY + m_newTopMargin - m_lines.m_topMargin;
 
-                if (m_newTopMargin > m_lines.m_topMargin)
-                    m_shiftedScrollY = oldScrollY + pixelCount;
-                else
-                    m_shiftedScrollY = oldScrollY - pixelCount;
                 ImGui::SetScrollY(m_shiftedScrollY);
                 m_lines.m_topMargin = m_newTopMargin;
 
@@ -1816,6 +1812,8 @@ namespace hex::ui {
 
     void TextEditor::drawBlockIndicators(ImDrawList *drawList) {
         for (auto &range: m_lines.m_indentBlocks) {
+            if (range.m_start == Coordinates(0,0) && range.m_end == lineCoordinates(-1,-1))
+                continue;
             if (range.contains(m_lines.m_state.m_cursorPosition)) {
                 auto blockStartScreenPos = m_lines.getLineStartScreenPos(0, lineIndexToRow(range.m_start.m_line));
                 auto maxRow = std::min(m_lines.getMaxDisplayedRow(), lineIndexToRow(range.m_end.m_line));

--- a/plugins/ui/source/ui/text_editor/support.cpp
+++ b/plugins/ui/source/ui/text_editor/support.cpp
@@ -3,6 +3,7 @@
 #include <wolv/utils/string.hpp>
 #include <pl/api.hpp>
 #include <pl/core/preprocessor.hpp>
+#include <hex/helpers/file_attached_data.hpp>
 
 #include <algorithm>
 
@@ -554,7 +555,7 @@ namespace hex::ui {
     }
 
     bool CodeFold::isDetected() {
-        return lines->m_codeFoldHighlighted == key;
+        return m_lines->m_codeFoldHighlighted == m_key;
     }
 
     TextEditor *TextEditor::getSourceCodeEditor() {
@@ -719,22 +720,29 @@ namespace hex::ui {
         auto ctrl = io.ConfigMacOSXBehaviors ? io.KeyAlt : io.KeyCtrl;
         auto alt = io.ConfigMacOSXBehaviors ? io.KeyCtrl : io.KeyAlt;
 
-        if (ImGui::IsWindowHovered()) {
-            if (!alt) {
-                auto click = ImGui::IsMouseClicked(0);
-                auto doubleClick = ImGui::IsMouseDoubleClicked(0);
-                auto rightClick = ImGui::IsMouseClicked(1);
-                auto t = ImGui::GetTime();
-                auto tripleClick = click && !doubleClick && (m_lastClick != -1.0f && (t - m_lastClick) < io.MouseDoubleClickTime);
-                bool resetBlinking = false;
-                /*
-                Left mouse button triple click
-                */
+        if (!alt) {
+            auto click = ImGui::IsMouseClicked(0);
+            auto doubleClick = ImGui::IsMouseDoubleClicked(0);
+            auto rightClick = ImGui::IsMouseClicked(1);
+            auto t = ImGui::GetTime();
+            auto tripleClick = click && !doubleClick && (m_lastClick != -1.0f && (t - m_lastClick) < io.MouseDoubleClickTime);
+            bool resetBlinking = false;
+
+            auto window = ImGui::GetCurrentWindow();
+            auto barSize = ImGui::GetStyle().ScrollbarSize;
+            auto rectMin = window->Pos;
+            auto rectMax = rectMin + window->Size - ImVec2(m_scrollY ? barSize : 0, m_scrollX ? barSize : 0);
+            rectMin.y -= m_lines.m_charAdvance.y;
+
+            if (ImGui::IsMouseHoveringRect(rectMin, rectMax, false)) {
 
                 auto coordinates = screenPosCoordinates(ImGui::GetMousePos());
                 if (coordinates == Invalid)
                     return;
 
+                /*
+                Left mouse button triple click
+                */
                 if (tripleClick) {
                     if (!ctrl) {
                         m_lines.m_state.m_cursorPosition = coordinates;
@@ -776,7 +784,7 @@ namespace hex::ui {
                 } else if (rightClick) {
                     auto cursorPosition = coordinates;
 
-                    if (!m_lines.hasSelection() || !m_lines.m_state.m_selection.contains(cursorPosition,Range::EndsInclusive::Both))
+                    if (!m_lines.hasSelection() || !m_lines.m_state.m_selection.contains(cursorPosition, Range::EndsInclusive::Both))
                         m_lines.setEditorState(cursorPosition);
 
                     resetBlinking = true;
@@ -785,6 +793,11 @@ namespace hex::ui {
                 }
                 // Mouse left button dragging (=> update selection)
                 else if (ImGui::IsMouseDragging(0) && ImGui::IsMouseDown(0)) {
+                    auto active_id = ImGui::GetActiveID();
+
+                    if (active_id != 0 && (active_id == ImGui::GetWindowScrollbarID(window, ImGuiAxis_X) || active_id == ImGui::GetWindowScrollbarID(window, ImGuiAxis_Y)))
+                        return;
+
                     io.WantCaptureMouse = true;
                     m_lines.setEditorState(coordinates, false);
                     m_lines.ensureCursorVisible();
@@ -1198,7 +1211,7 @@ namespace hex::ui {
 
     ImRect Lines::getBoxForRow(u32 row) {
         auto boxSize = m_charAdvance.x + (((u32) m_charAdvance.x % 2) ? 2.0f : 1.0f);
-        auto lineStartScreenPos = getLineStartScreenPos(0,row);
+        auto lineStartScreenPos = getLineStartScreenPos(0, row);
         ImVec2 lineNumberStartScreenPos = ImVec2(m_lineNumbersStartPos.x + m_lineNumberFieldWidth, lineStartScreenPos.y);
         ImRect result;
         result.Min = ImVec2(lineNumberStartScreenPos.x - (boxSize - 1) / 2, lineNumberStartScreenPos.y);
@@ -1214,32 +1227,34 @@ namespace hex::ui {
     }
 
     bool CodeFold::startHovered() {
-        return codeFoldStartCursorBox.trigger();
+        return m_codeFoldStartCursorBox.trigger();
     }
 
     bool CodeFold::endHovered() {
         if (isOpen())
-            return codeFoldEndCursorBox.trigger();
+            return m_codeFoldEndCursorBox.trigger();
         return false;
     }
 
     bool CodeFold::isOpen() const {
-        return lines->m_codeFoldState[key];
+        if (m_lines->m_codeFoldState.contains(m_key))
+            return m_lines->m_codeFoldState[m_key];
+        return true;
     }
 
     void CodeFold::open() {
 
-        lines->openCodeFold(key);
+        m_lines->openCodeFold(m_key);
     }
 
     void CodeFold::close() {
-        lines->closeCodeFold(key, true);
+        m_lines->closeCodeFold(m_key, true);
     }
 
     void CodeFold::moveFold(float lineCount, float lineHeight) {
-        codeFoldStartCursorBox.shiftBoxVertically(lineCount, lineHeight);
-        codeFoldEndActionBox.shiftBoxVertically(lineCount, lineHeight);
-        codeFoldEndCursorBox.shiftBoxVertically(lineCount, lineHeight);
+        m_codeFoldStartCursorBox.shiftBoxVertically(lineCount, lineHeight);
+        m_codeFoldEndActionBox.shiftBoxVertically(lineCount, lineHeight);
+        m_codeFoldEndCursorBox.shiftBoxVertically(lineCount, lineHeight);
         shiftBoxVertically(lineCount, lineHeight);
     }
 
@@ -1292,40 +1307,6 @@ namespace hex::ui {
 
       i32 TextEditor::getTotalLines() const {
         return m_lines.size();
-    }
-
-    void Lines::removeHiddenLinesFromPattern() {
-        i32 lineIndex = 0;
-        const auto totalLines = (i32)m_unfoldedLines.size();
-        while (lineIndex < totalLines && m_unfoldedLines[lineIndex].m_chars.starts_with("//+-"))
-            lineIndex++;
-        if (lineIndex > 0) {
-            m_hiddenLines.clear();
-            setSelection(Range(lineCoordinates(0, 0), lineCoordinates(lineIndex, 0)));
-            for (i32 i = 0; i < lineIndex; i++) {
-                HiddenLine hiddenLine(i, m_unfoldedLines[i].m_chars);
-                m_hiddenLines.emplace_back(std::move(hiddenLine));
-                m_useSavedFoldStatesRequested = true;
-            }
-            deleteSelection();
-            setTextChanged(false);
-        }
-    }
-
-    void Lines::addHiddenLinesToPattern() {
-        if (m_hiddenLines.empty())
-            return;
-        for (const auto &hiddenLine : m_hiddenLines) {
-            i32 lineIndex;
-            if (hiddenLine.m_lineIndex < 0)
-                lineIndex = size() + hiddenLine.m_lineIndex;
-            else
-                lineIndex = hiddenLine.m_lineIndex;
-            if (m_unfoldedLines[lineIndex].m_chars.starts_with("//+-"))
-                m_unfoldedLines.erase(m_unfoldedLines.begin() + lineIndex);
-            insertLine(lineIndex, hiddenLine.m_line);
-            setTextChanged(false);
-        }
     }
 
     i32 TextEditor::getCodeFoldLevel(i32 line) const {

--- a/plugins/ui/source/ui/text_editor/utf8.cpp
+++ b/plugins/ui/source/ui/text_editor/utf8.cpp
@@ -182,26 +182,35 @@ namespace hex::ui {
     Coordinates TextEditor::screenPosCoordinates(const ImVec2 &position) {
         auto boxSize = m_lines.m_charAdvance.x + (((u32)m_lines.m_charAdvance.x % 2) ? 2.0f : 1.0f);
         if (m_lines.isEmpty())
-            return m_lines.lineCoordinates( 0, 0);
+            return lineCoordinates(0, 0);
         auto lineSize = m_lines.size();
         if (position.y > m_lines.getLineStartScreenPos(0, lineIndexToRow(lineSize - 1)).y + m_lines.m_charAdvance.y)
-            return m_lines.lineCoordinates( -1, -1);
+            return lineCoordinates(-1, -1);
 
         auto local = position - m_lines.m_cursorScreenPosition;
         auto row = screenPosToRow(position);
-
-        Coordinates result = lineCoordinates(0,0);
+        auto scrollX = ImGui::GetScrollX();
+        auto scrollY = ImGui::GetScrollY();
+        Coordinates result = Coordinates(0, 0);
         i32 lineIndex= rowToLineIndex((i32) std::floor(row));
-        if (lineIndex < 0 || lineIndex >= m_lines.size())
+
+        if ((local.y > ImGui::GetWindowHeight() + scrollY - (m_scrollX ? ImGui::GetStyle().ScrollbarSize : 0))) {
             return Invalid;
+        }
+        if (local.y < 0)
+            return result;
+
+        if (lineIndex < 0 ||  lineIndex >= m_lines.size())
+                return Invalid;
+
+
         result.m_line = lineIndex;
         if (m_lines.m_codeFoldKeyLineMap.contains(lineIndex) || m_lines.m_codeFoldValueLineMap.contains(lineIndex)) {
             if (local.x < (boxSize - 1)/2)
-                return Invalid;
-        }
-        else if (local.x < 0 || m_lines[result.m_line].empty())
-            return m_lines.lineCoordinates( result.m_line, 0);
+                return {lineIndex, 0};
 
+        } else if (local.x < 0 || m_lines[lineIndex].empty())
+            return {lineIndex, 0};
 
         auto &line = m_lines[result.m_line].m_chars;
         i32 count = 0;
@@ -217,7 +226,12 @@ namespace hex::ui {
         result = m_lines.lineIndexCoords(lineIndex + 1, count - increase);
         result = m_lines.foldedToUnfoldedCoords(result);
         if (result == Invalid)
-            return {0, 0};
+            return Invalid;
+
+        auto maxX = ImGui::GetWindowWidth() + scrollX - (m_scrollY ? ImGui::GetStyle().ScrollbarSize : 0);
+        if (local.x > maxX)
+            return Invalid;
+
         return result;
     }
 


### PR DESCRIPTION
fixes from adding margin to pattern editor and making scrollbars opaque.

* Console needs to have window padding.
* Find/replace and go to popped in wrong locations and the margins didn't move correctly.
* Scrolling down didn't use available space for lines appearing.
* Resizing editor window hid text lines behind horizontal scrollbar.
* holding down arrow key made scroll switch between two states when last line reached the top.
* Scrolling caused clipping problems.
* Arrow keys navigation could move cursor off screen.
* Clicking on vertical scrollbar column changed cursor position.
* Horizontal scrollbar was created only after longest line was past the vertical scrollbar column.
* Line numbers were a bit too close to the margin.
* Scrolling while selecting no longer worked.

Problems found while fixing the ones above

* global scope indicator cluttered the display.
* block comments left some lines colored as comment when closed before the lines.
* Adding folds before existing ones changed their states.
* Moved fold state saving to file attached data.
* opening a legacy project showed hidden line. Now it gets deleted while the fold information is retained.
* undoing pastes left an extra character when the cursor had a bigger column value than the max column on the pasted line.
* Closing some specific blocks could prevent blocks being created below them after editions.
* Implemented proper page up/down leaving the relative cursor unchanged.
* Cursor placement in higher dpi screens could jump to end of line unexpectedly.
* member variables missing m_
* Column number popup showed wrong or no value.
* attribute functions not linking to type when last ';' of the struct was moved to last line where attributes are.
* text editor failed to detect errors depending on their location.
