### PR TITLE
feat: Toggle comments on the selected lines with Ctrl+/

### DIFF
--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -1126,6 +1126,7 @@
     "hex.builtin.view.pattern_editor.menu.edit.paste": "Paste",
     "hex.builtin.view.pattern_editor.menu.edit.undo": "Undo",
     "hex.builtin.view.pattern_editor.menu.edit.redo": "Redo",
+    "hex.builtin.view.pattern_editor.shortcut.toggle_comment": "Comment or uncomment the selected lines",
     "hex.builtin.view.pattern_editor.shortcut.toggle_insert": "Toggle Write Over",
     "hex.builtin.view.pattern_editor.shortcut.delete": "Delete One Character at the Cursor Position",
     "hex.builtin.view.pattern_editor.shortcut.backspace": "Delete One Character to the Left of Cursor",

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -2663,6 +2663,11 @@ namespace hex::plugin::builtin {
                 m_textEditor.get(ImHexApi::Provider::get()).backspace();
         });
 
+        ShortcutManager::addShortcut(this, CTRLCMD + Keys::Slash + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.toggle_comment"_unlocalized, [this] {
+            if (m_focusedSubWindowName.contains(TextEditorView))
+                m_textEditor.get(ImHexApi::Provider::get()).toggleLineComment();
+        });
+
         ShortcutManager::addShortcut(this, Keys::Insert + AllowWhileTyping, "hex.builtin.view.pattern_editor.shortcut.toggle_insert"_unlocalized, [this] {
             if (m_focusedSubWindowName.contains(TextEditorView))
                 m_textEditor.get(ImHexApi::Provider::get()).setOverwrite(!m_textEditor.get(ImHexApi::Provider::get()).isOverwrite());

--- a/plugins/ui/include/ui/line_comment.hpp
+++ b/plugins/ui/include/ui/line_comment.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <hex.hpp>
+
+#include <algorithm>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace hex::ui {
+
+    namespace impl {
+
+        // Where a line's own text starts. Equal to the line's length for a line
+        // that is only spaces and tabs.
+        inline size_t indentOf(std::string_view line) {
+            const auto firstCharacter = line.find_first_not_of(" \t");
+            return firstCharacter == std::string_view::npos ? line.size() : firstCharacter;
+        }
+
+        inline bool isBlank(std::string_view line) {
+            return line.find_first_not_of(" \t") == std::string_view::npos;
+        }
+
+        inline bool startsWithComment(std::string_view line, std::string_view commentToken) {
+            return line.substr(indentOf(line)).starts_with(commentToken);
+        }
+
+    }
+
+    // Comments or uncomments a run of whole lines, the way Ctrl+/ does.
+    //
+    // Uncomments only when every line with text on it is already commented.
+    // A run that is partly commented becomes wholly commented, rather than
+    // having each line inverted on its own. One more keypress then clears it.
+    //
+    // A blank line gets no comment token, and does not decide the direction
+    // either: a blank line between two commented lines must not make the run
+    // comment a second time.
+    //
+    // The token goes at the shallowest indent in the run, not at column 0, so
+    // a commented block keeps the shape it had.
+    //
+    // Returns `lines` unchanged when there is no token to apply, or when every
+    // line is blank.
+    inline std::vector<std::string> toggleLineComments(std::span<const std::string> lines, std::string_view commentToken) {
+        std::vector<std::string> result(lines.begin(), lines.end());
+        if (commentToken.empty())
+            return result;
+
+        bool anyText      = false;
+        bool allCommented = true;
+        size_t column     = std::string::npos;
+
+        for (const auto &line : lines) {
+            if (impl::isBlank(line))
+                continue;
+
+            anyText      = true;
+            allCommented = allCommented && impl::startsWithComment(line, commentToken);
+            column       = std::min(column, impl::indentOf(line));
+        }
+
+        if (!anyText)
+            return result;
+
+        for (auto &line : result) {
+            if (impl::isBlank(line))
+                continue;
+
+            if (allCommented) {
+                const auto tokenStart = impl::indentOf(line);
+                auto text = line.substr(tokenStart + commentToken.size());
+
+                // Takes back the one space the comment step adds, and no more.
+                // Anything deeper is the line's own indentation.
+                if (text.starts_with(' '))
+                    text.erase(0, 1);
+
+                line = line.substr(0, tokenStart) + text;
+            } else {
+                line.insert(column, std::string(commentToken) + " ");
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/plugins/ui/include/ui/text_editor.hpp
+++ b/plugins/ui/include/ui/text_editor.hpp
@@ -944,6 +944,11 @@ namespace hex::ui {
         void cut();
         void paste();
         void doPaste(const char *clipText);
+
+        // Comments or uncomments every line the selection touches, or the
+        // cursor's own line when nothing is selected. Does nothing for a
+        // language with no single line comment token.
+        void toggleLineComment();
         void deleteChar();
         void setReadOnly(bool value) { m_lines.setReadOnly(value); };
         void appendLine(const std::string &value);

--- a/plugins/ui/source/ui/text_editor/editor.cpp
+++ b/plugins/ui/source/ui/text_editor/editor.cpp
@@ -1,4 +1,5 @@
 #include <ui/text_editor.hpp>
+#include <ui/line_comment.hpp>
 #include <algorithm>
 #include <ranges>
 #include <string>
@@ -849,6 +850,59 @@ namespace hex::ui {
             v.push_back(u);
             m_lines.addUndo(v);
         }
+        m_lines.refreshSearchResults();
+    }
+
+    void TextEditor::toggleLineComment() {
+        if (m_lines.m_readOnly)
+            return;
+
+        const auto &commentToken = m_lines.getLanguageDefinition().m_singleLineComment;
+        if (commentToken.empty())
+            return;
+
+        // Whole lines, in line coordinates. Reading and writing a run of whole
+        // lines keeps this clear of the column arithmetic a partial line needs,
+        // and of whether any of those lines is currently folded.
+        const auto selection = m_lines.lineCoordinates(m_lines.m_state.m_selection);
+        const auto selectedLines = Range(selection).getSelectedLines();
+        const i32 firstLine = selectedLines.getLine();
+        const i32 lastLine  = selectedLines.getColumn();
+
+        StringVector oldLines;
+        oldLines.reserve(lastLine - firstLine + 1);
+        for (i32 line = firstLine; line <= lastLine; line += 1)
+            oldLines.emplace_back(this->getLineText(line));
+
+        const auto newLines = ui::toggleLineComments(oldLines, commentToken);
+        if (newLines == oldLines)
+            return;
+
+        const Range wholeLines(Coordinates(firstLine, 0), m_lines.lineCoordinates(lastLine, -1));
+
+        // One undo record for the whole run, the same shape doPaste() builds, so
+        // that a single Ctrl+Z takes the comment back off every line at once.
+        UndoRecord u;
+        u.m_before = m_lines.m_state;
+
+        this->setSelection(wholeLines);
+        u.m_removed = m_lines.getSelectedText();
+        u.m_removedRange = m_lines.m_state.m_selection;
+        m_lines.deleteSelection();
+
+        u.m_added = wolv::util::combineStrings(newLines, "\n");
+        u.m_addedRange.m_start = m_lines.lineCoordinates(m_lines.m_state.m_cursorPosition);
+        m_lines.insertText(u.m_added);
+        u.m_addedRange.m_end = m_lines.lineCoordinates(m_lines.m_state.m_cursorPosition);
+
+        // Leaves the run selected, so that pressing the shortcut again undoes
+        // what it just did instead of acting on one line.
+        this->setSelection(u.m_addedRange);
+        u.m_after = m_lines.m_state;
+
+        UndoRecords records;
+        records.push_back(u);
+        m_lines.addUndo(records);
         m_lines.refreshSearchResults();
     }
 

--- a/tests/helpers/CMakeLists.txt
+++ b/tests/helpers/CMakeLists.txt
@@ -16,6 +16,13 @@ set(AVAILABLE_TESTS
         FileAccess
         FileBackedProviderData
 
+    # Pattern editor
+        ToggleLineCommentsAddsAndRemoves
+        ToggleLineCommentsUsesTheShallowestIndent
+        ToggleLineCommentsTreatsARunAsAWhole
+        ToggleLineCommentsLeavesBlankLinesAlone
+        ToggleLineCommentsNeedsAToken
+
     # Utils
         ExtractBits
 )
@@ -34,6 +41,7 @@ add_executable(${PROJECT_NAME}
         source/common.cpp
         source/encoding_line_cache.cpp
         source/file.cpp
+        source/line_comment.cpp
         source/net.cpp
         source/utils.cpp
 )
@@ -41,7 +49,9 @@ add_executable(${PROJECT_NAME}
 
 # ---- No need to change anything from here downwards unless you know what you're doing ---- #
 
-target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_include_directories(${PROJECT_NAME} PRIVATE
+        include
+        ${CMAKE_SOURCE_DIR}/plugins/ui/include)
 target_link_libraries(${PROJECT_NAME} PRIVATE libimhex tests_common ${FMT_LIBRARIES})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${IMHEX_MAIN_OUTPUT_DIRECTORY})

--- a/tests/helpers/source/line_comment.cpp
+++ b/tests/helpers/source/line_comment.cpp
@@ -1,0 +1,87 @@
+#include <hex/test/tests.hpp>
+
+#include <ui/line_comment.hpp>
+
+#include <string>
+#include <vector>
+
+using hex::ui::toggleLineComments;
+
+namespace {
+
+    using Lines = std::vector<std::string>;
+
+    Lines toggle(const Lines &lines, std::string_view commentToken = "//") {
+        return toggleLineComments(lines, commentToken);
+    }
+
+}
+
+TEST_SEQUENCE("ToggleLineCommentsAddsAndRemoves") {
+    TEST_ASSERT(toggle({ "u8 a;" }) == Lines{ "// u8 a;" });
+    TEST_ASSERT(toggle({ "// u8 a;" }) == Lines{ "u8 a;" });
+
+    // A round trip leaves the line as it was.
+    TEST_ASSERT(toggle(toggle({ "u8 a;" })) == Lines{ "u8 a;" });
+
+    // A token with no space after it still uncomments.
+    TEST_ASSERT(toggle({ "//u8 a;" }) == Lines{ "u8 a;" });
+
+    // Only the one space the comment step adds comes back off. The rest of the
+    // indentation belongs to the line.
+    TEST_ASSERT(toggle({ "//    u8 a;" }) == Lines{ "   u8 a;" });
+
+    TEST_SUCCESS();
+};
+
+TEST_SEQUENCE("ToggleLineCommentsUsesTheShallowestIndent") {
+    const Lines nested = { "    u8 a;", "        u8 b;", "    u8 c;" };
+    const Lines commented = { "    // u8 a;", "    //     u8 b;", "    // u8 c;" };
+
+    // The token lands at the shallowest indent in the run, so the block keeps
+    // its shape instead of every line moving to column 0.
+    TEST_ASSERT(toggle(nested) == commented);
+    TEST_ASSERT(toggle(commented) == nested);
+
+    TEST_SUCCESS();
+};
+
+TEST_SEQUENCE("ToggleLineCommentsTreatsARunAsAWhole") {
+    // A partly commented run comments the whole way, rather than inverting each
+    // line on its own. One more press then clears it.
+    const Lines mixed = { "u8 a;", "// u8 b;" };
+    const Lines allCommented = { "// u8 a;", "// // u8 b;" };
+
+    TEST_ASSERT(toggle(mixed) == allCommented);
+    TEST_ASSERT(toggle(allCommented) == mixed);
+
+    // Every line commented means uncomment.
+    TEST_ASSERT(toggle({ "// u8 a;", "// u8 b;" }) == (Lines{ "u8 a;", "u8 b;" }));
+
+    TEST_SUCCESS();
+};
+
+TEST_SEQUENCE("ToggleLineCommentsLeavesBlankLinesAlone") {
+    // A blank line takes no token, and does not make the run comment a second
+    // time when the lines around it are already commented.
+    TEST_ASSERT(toggle({ "// u8 a;", "", "// u8 b;" }) == (Lines{ "u8 a;", "", "u8 b;" }));
+    TEST_ASSERT(toggle({ "u8 a;", "   ", "u8 b;" }) == (Lines{ "// u8 a;", "   ", "// u8 b;" }));
+
+    // Nothing to comment at all.
+    TEST_ASSERT(toggle({ "", "  " }) == (Lines{ "", "  " }));
+    TEST_ASSERT(toggle({}) == Lines{});
+
+    TEST_SUCCESS();
+};
+
+TEST_SEQUENCE("ToggleLineCommentsNeedsAToken") {
+    // A language with no single line comment token leaves the lines untouched
+    // rather than inserting a bare space.
+    TEST_ASSERT(toggle({ "u8 a;" }, "") == Lines{ "u8 a;" });
+
+    // The token is the language's own, not a hard coded "//".
+    TEST_ASSERT(toggle({ "print 1" }, "--") == Lines{ "-- print 1" });
+    TEST_ASSERT(toggle({ "-- print 1" }, "--") == Lines{ "print 1" });
+
+    TEST_SUCCESS();
+};


### PR DESCRIPTION
### Problem description
Comments or uncomments every line the selection touches, or the cursor's own line when nothing is selected.

### Implementation description
Uncomments only when every line with text on it is already commented. A partly commented run becomes wholly commented, which one more press then clears. A blank line takes no token and does not decide the direction. The token goes at the shallowest indent in the run, so the block keeps its shape.

### Additional things
The token comes from the language definition, not from a hard coded "//", so the shortcut does nothing in a language that declares none.

Put the text rule in a new header, ui/line_comment.hpp, so it can be tested on its own. TextEditor::toggleLineComment() only reads the lines, calls it, and writes the result back as one undo record, the same shape doPaste() builds. A single Ctrl+Z therefore takes the comment back off every line at once.
