### PR TITLE
feat: Escape pattern values for display

### DIFF
--- a/plugins/builtin/romfs/lang/en_US.json
+++ b/plugins/builtin/romfs/lang/en_US.json
@@ -99,6 +99,7 @@
     "hex.builtin.inspector.i48": "int48_t",
     "hex.builtin.inspector.i64": "int64_t",
     "hex.builtin.inspector.i8": "int8_t",
+    "hex.builtin.inspector.invalid": "Invalid",
     "hex.builtin.inspector.jump_to_address": "Jump to address",
     "hex.builtin.inspector.long_double": "long double",
     "hex.builtin.inspector.rgb565": "RGB565 Color",

--- a/plugins/builtin/source/content/views/view_data_inspector.cpp
+++ b/plugins/builtin/source/content/views/view_data_inspector.cpp
@@ -13,6 +13,8 @@
 #include <ui/visualizer_drawer.hpp>
 
 #include <hex/ui/imgui_imhex_extensions.h>
+#include <hex/helpers/encoding_file.hpp>
+#include <hex/helpers/unicode.hpp>
 #include <imgui_internal.h>
 
 #include <pl/pattern_language.hpp>
@@ -252,8 +254,17 @@ namespace hex::plugin::builtin {
                     if (const auto &inlineVisualizeArgs = pattern->getAttributeArguments("hex::inline_visualize"); !inlineVisualizeArgs.empty()) {
                         drawer.drawVisualizer(ContentRegistry::PatternLanguage::impl::getInlineVisualizers(), inlineVisualizeArgs, *pattern, true);
                     } else {
-                        ImGui::TextUnformatted(value.c_str());
+                        const auto escapedValue = escapeControlCharacters(value);
+                        const bool displayValid = pattern->hasValidFormattedValue() && escapedValue.has_value();
+
+                        if (!displayValid)
+                            ImGui::PushStyleColor(ImGuiCol_Text, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_LoggerError));
+                        ImGui::TextUnformatted(escapedValue.value_or("hex.builtin.inspector.invalid"_lang.get()).c_str());
+                        if (!displayValid)
+                            ImGui::PopStyleColor();
                     }
+
+                    // The copy value stays unescaped. Escaping is only for display.
                     return value;
                 };
 

--- a/plugins/builtin/source/content/views/view_pattern_editor.cpp
+++ b/plugins/builtin/source/content/views/view_pattern_editor.cpp
@@ -51,6 +51,7 @@
 #include <hex/helpers/menu_items.hpp>
 #include <hex/helpers/logger.hpp>
 #include <hex/helpers/formatting.hpp>
+#include <hex/helpers/unicode.hpp>
 #include <content/text_highlighting/pattern_language.hpp>
 
 #include <fmt/chrono.h>
@@ -1665,12 +1666,14 @@ namespace hex::plugin::builtin {
                 ImGui::SetCursorPos(ImVec2(x, ImGui::GetCursorPosY() + ImGui::GetStyle().FramePadding.y));
                 m_visualizerDrawer->drawVisualizer(ContentRegistry::PatternLanguage::impl::getInlineVisualizers(), inlineVisualizeArgs, *pattern, true);
             } else {
-                const auto value = pattern->getFormattedValue();
+                const auto escapedValue = escapeControlCharacters(pattern->getFormattedValue());
+                const auto value = escapedValue.value_or("hex.builtin.inspector.invalid"_lang.get());
+                const bool valueValid = pattern->hasValidFormattedValue() && escapedValue.has_value();
 
-                if (!pattern->hasValidFormattedValue())
+                if (!valueValid)
                     ImGui::PushStyleColor(ImGuiCol_Text, ImGuiExt::GetCustomColorU32(ImGuiCustomCol_LoggerError));
                 ImGuiExt::TextFormatted("{: <{}} ", hex::limitStringLength(value, 64), shiftHeld ? 40 : 0);
-                if (!pattern->hasValidFormattedValue())
+                if (!valueValid)
                     ImGui::PopStyleColor();
             }
 

--- a/plugins/ui/romfs/lang/en_US.json
+++ b/plugins/ui/romfs/lang/en_US.json
@@ -98,6 +98,7 @@
     "hex.ui.pattern_drawer.end": "End",
     "hex.ui.pattern_drawer.export": "Export Patterns as...",
     "hex.ui.pattern_drawer.favorites": "Favorites",
+    "hex.ui.pattern_drawer.invalid_value": "Invalid",
     "hex.ui.pattern_drawer.local": "Local",
     "hex.ui.pattern_drawer.size": "Size",
     "hex.ui.pattern_drawer.spec_name": "Display specification names",

--- a/plugins/ui/source/ui/pattern_drawer.cpp
+++ b/plugins/ui/source/ui/pattern_drawer.cpp
@@ -26,6 +26,7 @@
 #include <hex/api/achievement_manager.hpp>
 #include <hex/api/localization_manager.hpp>
 
+#include <hex/helpers/encoding_file.hpp>
 #include <hex/helpers/scaling.hpp>
 #include <wolv/math_eval/math_evaluator.hpp>
 #include <ui/text_editor.hpp>
@@ -34,6 +35,7 @@
 #include <hex/ui/imgui_imhex_extensions.h>
 #include <fonts/vscode_icons.hpp>
 #include <hex/api/tutorial_manager.hpp>
+#include <hex/helpers/unicode.hpp>
 #include <pl/core/ast/ast_node_mathematical_expression.hpp>
 
 #include <wolv/io/file.hpp>
@@ -439,8 +441,9 @@ namespace hex::ui {
     void PatternDrawer::drawValueColumn(pl::ptrn::Pattern& pattern) {
         ImGui::TableNextColumn();
 
-        const auto value = pattern.getFormattedValue();
-        const bool valueValid = pattern.hasValidFormattedValue();
+        const auto escapedValue = escapeControlCharacters(pattern.getFormattedValue());
+        const auto value = escapedValue.value_or("hex.ui.pattern_drawer.invalid_value"_lang.get());
+        const bool valueValid = pattern.hasValidFormattedValue() && escapedValue.has_value();
         const auto width = ImGui::GetColumnWidth();
 
         if (const auto &visualizeArgs = pattern.getAttributeArguments("hex::visualize"); !visualizeArgs.empty()) {


### PR DESCRIPTION
### Problem description

A string pattern's value can hold a control character or a codepoint with no glyph. Printed as-is it breaks the single line both the pattern tree and the editor's inline preview draw it on.

### Implementation description

Run both through `escapeControlCharacters()`. A value whose bytes do not decode has no escape to show, so it reads "Invalid" in the same red the tree already uses for a value that failed to format.

### Dependencies

- https://github.com/WerWolv/PatternLanguage/pull/246
- #2883 
- #2889