### PR TITLE
fix: segfault with error markers at obscenely high framerates

### DIFF
--- a/plugins/ui/source/ui/text_editor/render.cpp
+++ b/plugins/ui/source/ui/text_editor/render.cpp
@@ -1682,9 +1682,10 @@ namespace hex::ui {
 
         ErrorMarkers::iterator errorIt;
         auto errorHoverBoxKey = lineStart + Coordinates(1, 1);
-        if (errorIt = std::find_if(m_lines.m_errorMarkers.begin(), m_lines.m_errorMarkers.end(), [&](const auto &item) {
+        auto errorMarkers = m_lines.m_errorMarkers; // copy so lines can't be deleted mid flight
+        if (errorIt = std::find_if(errorMarkers.begin(), errorMarkers.end(), [&](const auto &item) {
                 return item.first >= errorHoverBoxKey && item.first <= errorHoverBoxKey + Coordinates(0, tokenLength);
-            }); errorIt != m_lines.m_errorMarkers.end()) {
+            }); errorIt != errorMarkers.end()) {
             auto errorMessage = errorIt->second.second;
             auto errorLength = errorIt->second.first;
             if (errorLength == 0 && line.size() > (u32) i + 1)


### PR DESCRIPTION
line gets deleted mid render, apparently making the iterator increment to an invalid out of bounds value.

this is just a hotfix, it should be pinned down where the error lines get mutated during a render.