### PR TITLE
refactor: Store one Codepoint per byte in a Codepage

### DIFF
--- a/lib/libimhex/include/hex/helpers/codepage.hpp
+++ b/lib/libimhex/include/hex/helpers/codepage.hpp
@@ -5,11 +5,19 @@
 #include <array>
 #include <optional>
 #include <string>
-#include <string_view>
 
 namespace hex {
 
     class EncodingFile;
+
+    /**
+     * @brief A Unicode code point
+     *
+     * Invalid stands for no code point. Unicode stops at U+10FFFF, so -1 is never a character.
+     */
+    enum class Codepoint : char32_t {
+        Invalid = char32_t(-1)
+    };
 
     /**
      * @brief A single-byte character set
@@ -30,17 +38,17 @@ namespace hex {
          * @brief Builds a codepage from a single-byte encoding
          * @param encoding The encoding to convert
          * @return The codepage, or std::nullopt when `encoding` is not one: at least one of its
-         * characters takes more than one byte
+         * characters takes more than one byte, or is more than one code point
          */
         static std::optional<Codepage> fromEncoding(const EncodingFile &encoding);
 
         /**
-         * @brief Looks up the character a byte draws as
+         * @brief Looks up the character a byte stands for
          * @param byte The byte to look up
-         * @return Its character, or an empty view when the codepage gives it none of its own.
-         * That covers both a control code and an unmapped byte.
+         * @return Its code point, which can be a control code, or Codepoint::Invalid when the
+         * codepage maps the byte to no character at all
          */
-        [[nodiscard]] std::string_view operator[](u8 byte) const { return m_characters[byte]; }
+        [[nodiscard]] Codepoint operator[](u8 byte) const { return m_characters[byte]; }
 
         /**
          * @brief Gets the codepage's name
@@ -49,9 +57,9 @@ namespace hex {
         [[nodiscard]] const std::string& getName() const { return m_name; }
 
     private:
-        Codepage() = default;
+        Codepage() { m_characters.fill(Codepoint::Invalid); }
 
-        std::array<std::string, 256> m_characters;
+        std::array<Codepoint, 256> m_characters;
         std::string m_name;
     };
 

--- a/lib/libimhex/include/hex/helpers/unicode.hpp
+++ b/lib/libimhex/include/hex/helpers/unicode.hpp
@@ -21,11 +21,19 @@ namespace hex {
     bool isSingleCharacter(std::string_view text);
 
     /**
-     * @brief Checks whether `byte` is a standard-ASCII control code
-     * @param byte The byte to check
-     * @return Whether the byte is a control code, which has no glyph
+     * @brief Reads `text` as exactly one whole, valid UTF-8 code point
+     * @param text The text to read
+     * @return Its code point, or std::nullopt when isSingleCharacter() is false for it
      */
-    bool isControlCode(u8 byte);
+    std::optional<char32_t> decodeSingleCodepoint(std::string_view text);
+
+    /**
+     * @brief Checks whether `codepoint` is a C0 control or DELETE
+     * @param codepoint The code point to check
+     * @return Whether it is a control code, which has no glyph. C1, U+0080 to U+009F, is not
+     * one, since Unicode has a picture character for only C0 and DELETE.
+     */
+    bool isControlCode(char32_t codepoint);
 
     /**
      * @brief Escapes one decoded code point for display

--- a/lib/libimhex/source/helpers/codepage.cpp
+++ b/lib/libimhex/source/helpers/codepage.cpp
@@ -11,9 +11,8 @@ namespace hex {
         static const Codepage asciiCodepage = [] {
             Codepage result;
 
-            // A control code has no character to draw, so its entry stays empty.
-            for (size_t byte = 0x20; byte < 0x7F; byte += 1)
-                result.m_characters[byte] = std::string(1, char(byte));
+            for (size_t byte = 0; byte <= 0x7F; byte += 1)
+                result.m_characters[byte] = Codepoint(byte);
 
             return result;
         }();
@@ -30,15 +29,16 @@ namespace hex {
 
         for (size_t byte = 0; byte <= 0xFF; byte += 1) {
             const auto key = u8(byte);
-            if (isControlCode(key))
-                continue;
-
             const auto entry = encoding.lookup(std::span(&key, 1));
             if (!entry.has_value())
                 continue;
 
-            if (const auto text = entry->first; isSingleCharacter(text))
-                result.m_characters[byte] = text;
+            // A byte that draws as more than one code point does not fit in a cell.
+            const auto codepoint = decodeSingleCodepoint(entry->first);
+            if (!codepoint.has_value())
+                return std::nullopt;
+
+            result.m_characters[byte] = Codepoint(*codepoint);
         }
 
         return result;

--- a/lib/libimhex/source/helpers/unicode.cpp
+++ b/lib/libimhex/source/helpers/unicode.cpp
@@ -80,6 +80,13 @@ namespace hex {
         return info.status == Utf8CodepointStatus::Complete && info.length == text.size();
     }
 
+    std::optional<char32_t> decodeSingleCodepoint(std::string_view text) {
+        if (!isSingleCharacter(text))
+            return std::nullopt;
+
+        return readUtf8Codepoint(text).codepoint;
+    }
+
     bool isValidUtf8(std::string_view text) {
         while (!text.empty()) {
             const auto info = readUtf8Codepoint(text);
@@ -92,8 +99,8 @@ namespace hex {
         return true;
     }
 
-    bool isControlCode(u8 byte) {
-        return byte <= 0x1F || byte == 0x7F;
+    bool isControlCode(char32_t codepoint) {
+        return codepoint <= 0x1F || codepoint == 0x7F;
     }
 
     pl::core::DecodeResult decodeUtf8Bounded(std::span<const u8> bytes, std::optional<size_t> maxCodepoints) {

--- a/plugins/ui/source/ui/hex_editor.cpp
+++ b/plugins/ui/source/ui/hex_editor.cpp
@@ -36,16 +36,20 @@ namespace hex::ui {
             if (size == 1) {
                 const auto c = static_cast<unsigned char>(data[0]);
 
-                // A byte with no character falls through to the tables below.
-                if (m_codepage != nullptr) {
-                    if (const auto text = (*m_codepage)[c]; !text.empty()) {
-                        ImGui::TextUnformatted(text.data(), text.data() + text.size());
-                        return;
-                    }
+                // The codepage decides the cell. It gives an unmapped byte no character at all.
+                const auto codepoint = m_codepage != nullptr ? (*m_codepage)[c] : Codepage::ascii()[c];
+                const auto character = char32_t(codepoint);
+                const bool hasCharacter = codepoint != Codepoint::Invalid;
+
+                if (hasCharacter && !isControlCode(character)) {
+                    std::array<char, 5> text = {};
+                    const auto length = ImTextCharToUtf8(text.data(), character);
+                    ImGui::TextUnformatted(text.data(), text.data() + length);
+                    return;
                 }
 
                 // A control code's picture is correct under any encoding.
-                if (m_extendedAscii && isControlCode(c)) {
+                if (hasCharacter && m_extendedAscii) {
                     constexpr static std::array ControlCharacters = {
                         "\u2400", "\u2401", "\u2402", "\u2403", "\u2404", "\u2405", "\u2406", "\u2407",
                         "\u2408", "\u2409", "\u240A", "\u240B", "\u240C", "\u240D", "\u240E", "\u240F",
@@ -53,17 +57,12 @@ namespace hex::ui {
                         "\u2418", "\u2419", "\u241A", "\u241B", "\u241C", "\u241D", "\u241E", "\u241F",
                     };
 
-                    ImGuiExt::TextFormattedDisabled(c == 0x7F ? "\u2421" : ControlCharacters[c]);
+                    ImGuiExt::TextFormattedDisabled(character == 0x7F ? "\u2421" : ControlCharacters[character]);
                     return;
                 }
 
                 // CP1252 fills undefined high bytes, but never over a declared table.
-                const bool allowExtendedAscii = m_extendedAscii && !m_codepageDeclared;
-
-                if (std::isprint(c) != 0) {
-                    const std::array<char, 2> string = { char(c), 0x00 };
-                    ImGui::TextUnformatted(string.data());
-                } else if (allowExtendedAscii) {
+                if (!hasCharacter && m_extendedAscii && !m_codepageDeclared) {
                     constexpr static std::array ExtendedAsciiCharacters = {
                         "\u20AC", "\u0081", "\u201A", "\u0192", "\u201E", "\u2026", "\u2020", "\u2021",
                         "\u02C6", "\u2030", "\u0160", "\u2039", "\u0152", "\u008D", "\u017D", "\u008F",
@@ -84,9 +83,10 @@ namespace hex::ui {
                     };
 
                     ImGui::TextUnformatted(ExtendedAsciiCharacters[c - 0x80]);
-                } else {
-                    ImGuiExt::TextFormattedDisabled(".");
+                    return;
                 }
+
+                ImGuiExt::TextFormattedDisabled(".");
             } else {
                 ImGuiExt::TextFormattedDisabled(".");
             }

--- a/tests/helpers/source/encoding.cpp
+++ b/tests/helpers/source/encoding.cpp
@@ -241,6 +241,13 @@ TEST_SEQUENCE("SingleCharacterAndControlCodes") {
     TEST_ASSERT(!hex::isControlCode(0x41));
     TEST_ASSERT(!hex::isControlCode(0x80));
 
+    // A code point above ASCII is not one, whatever its low byte says.
+    TEST_ASSERT(!hex::isControlCode(U'\u2022'));
+    TEST_ASSERT(!hex::isControlCode(char32_t(0x0100)));
+
+    // C1 has no picture character of its own, so it is not one either.
+    TEST_ASSERT(!hex::isControlCode(char32_t(0x0085)));
+
     TEST_SUCCESS();
 };
 
@@ -257,24 +264,51 @@ TEST_SEQUENCE("EncodingLookupRejectsPathTraversal") {
 TEST_SEQUENCE("CodepageFromEncoding") {
     const auto &ascii = hex::Codepage::ascii();
     TEST_ASSERT(ascii.getName().empty());
-    TEST_ASSERT(ascii['A'] == "A");
-    TEST_ASSERT(ascii[' '] == " ");
-    TEST_ASSERT(ascii[0x00].empty());
-    TEST_ASSERT(ascii[0x7F].empty());
-    TEST_ASSERT(ascii[0x80].empty());
+    TEST_ASSERT(ascii['A'] == hex::Codepoint(U'A'));
+    TEST_ASSERT(ascii[' '] == hex::Codepoint(U' '));
+    TEST_ASSERT(ascii[0x00] == hex::Codepoint(U'\0'));
+    TEST_ASSERT(ascii[0x7F] == hex::Codepoint(0x7F));
+    TEST_ASSERT(ascii[0x80] == hex::Codepoint::Invalid);
     const hex::EncodingFile singleByte(hex::EncodingFile::Type::Thingy, std::string(
         "80=\xCE\xB1\n"
         "81=\xCE\xB2\n"));
     const auto codepage = hex::Codepage::fromEncoding(singleByte);
     TEST_ASSERT(codepage.has_value());
-    TEST_ASSERT((*codepage)[0x80] == "\xCE\xB1");
-    TEST_ASSERT((*codepage)[0x81] == "\xCE\xB2");
-    TEST_ASSERT((*codepage)[0x82].empty());
+    TEST_ASSERT((*codepage)[0x80] == hex::Codepoint(U'\u03B1'));
+    TEST_ASSERT((*codepage)[0x81] == hex::Codepoint(U'\u03B2'));
+    TEST_ASSERT((*codepage)[0x82] == hex::Codepoint::Invalid);
 
     // A table with a multi byte sequence cannot give every byte its own cell.
     const hex::EncodingFile multiByte(hex::EncodingFile::Type::Thingy, std::string(
         "8140=\xE3\x81\x82\n"));
     TEST_ASSERT(!hex::Codepage::fromEncoding(multiByte).has_value());
+
+    // A byte that draws as more than one code point cannot either.
+    const hex::EncodingFile multiCharacter(hex::EncodingFile::Type::Thingy, std::string(
+        "80=ab\n"));
+    TEST_ASSERT(!hex::Codepage::fromEncoding(multiCharacter).has_value());
+
+    // A control code's name is text, not a character, so this table is not a codepage.
+    const hex::EncodingFile namedControlCode(hex::EncodingFile::Type::Thingy, std::string(
+        "00=NUL\n"
+        "80=\xCE\xB1\n"));
+    TEST_ASSERT(!hex::Codepage::fromEncoding(namedControlCode).has_value());
+
+    // A table names a control code with its escape instead.
+    const hex::EncodingFile escapedControlCode(hex::EncodingFile::Type::Thingy, std::string(
+        "00=\\u0000\n"
+        "07=\\u2022\n"
+        "25=\\u000A\n"
+        "80=\xCE\xB1\n"));
+    const auto withControlCodes = hex::Codepage::fromEncoding(escapedControlCode);
+    TEST_ASSERT(withControlCodes.has_value());
+    TEST_ASSERT((*withControlCodes)[0x00] == hex::Codepoint(U'\0'));
+    TEST_ASSERT((*withControlCodes)[0x80] == hex::Codepoint(U'\u03B1'));
+
+    // The character decides what the byte stands for, not the byte itself.
+    TEST_ASSERT((*withControlCodes)[0x25] == hex::Codepoint(U'\u000A'));
+    TEST_ASSERT((*withControlCodes)[0x07] == hex::Codepoint(U'\u2022'));
+    TEST_ASSERT((*withControlCodes)[0x0A] == hex::Codepoint::Invalid);
 
     TEST_SUCCESS();
 };


### PR DESCRIPTION
A Codepage gives one byte one cell. A `std::string` entry could hold more than one Codepoint, which does not fit. Store a `char32_t`, where -1 means the byte has no character.

`Codepage::fromEncoding()` now rejects a table with a byte that draws as more than one Codepoint. Before, it dropped only that byte. This covers a control code named as text, such as `"00=NUL"`. A table writes the escape `"00=\u0000"` instead. The table stays valid for the custom encoding column, which decodes with the `EncodingFile` itself.
