### PR TITLE
fix: Stop the background services before the cleanup

### DIFF
--- a/lib/libimhex/source/subcommands/subcommands.cpp
+++ b/lib/libimhex/source/subcommands/subcommands.cpp
@@ -12,6 +12,7 @@
 #include <hex/helpers/fmt.hpp>
 #include <hex/helpers/logger.hpp>
 
+#include "hex/api/content_registry/background_services.hpp"
 #include "hex/api/content_registry/settings.hpp"
 
 namespace hex::subcommands {
@@ -126,6 +127,10 @@ namespace hex::subcommands {
 
         if (pluginsInitialized) {
             TaskManager::exit();
+
+            // A service thread must not reach an AutoReset object that cleanup() already reset.
+            ContentRegistry::BackgroundServices::impl::stopServices();
+
             ImHexApi::System::impl::cleanup();
             EventManager::clear();
             PluginManager::unload();

--- a/main/gui/source/init/tasks.cpp
+++ b/main/gui/source/init/tasks.cpp
@@ -9,6 +9,7 @@
 #include <hex/helpers/logger.hpp>
 #include <hex/helpers/default_paths.hpp>
 
+#include <hex/api/content_registry/background_services.hpp>
 #include <hex/api/content_registry/settings.hpp>
 #include <hex/api/plugin_manager.hpp>
 #include <hex/api/achievement_manager.hpp>
@@ -110,6 +111,9 @@ namespace hex::init {
             log::fatal("Please report this issue on the ImHex GitHub page!");
             log::fatal("To the person fixing this, read the comment above this message for more information.");
         });
+
+        // A service thread must not reach an AutoReset object that cleanup() already reset.
+        ContentRegistry::BackgroundServices::impl::stopServices();
 
         ImHexApi::System::impl::cleanup();
 


### PR DESCRIPTION
A background service names its own thread. That builds a `Lang`, which writes the name into a global map. The map is an AutoReset object, and so is the list that holds the service threads.

`cleanup()` resets every AutoReset object in the order of their addresses. Nothing stopped the services first, so a thread could write its name into a map that `cleanup()` already reset. Nothing frees that entry again. LeakSanitizer reports it, but only when the addresses fall that way, so the failure moves from run to run.

`stopServices()` already does this work and had no caller. Call it in both paths that shut ImHex down, ahead of `cleanup()`.